### PR TITLE
Add per-case execution mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ skills/eval-optimize/    # Skill: automated refinement loop
 
 Skills projects create an `eval.yaml` config file with:
 - `skill` — skill to evaluate
-- `arguments` — arguments string passed to the skill invocation
+- `execution` — `mode` (`case` or `batch`) and `arguments` template with `{field}` placeholders
 - `runner` — agent runner (`claude-code`, etc.), `runner_options` for runner-specific settings
 - `permissions` — `allow`/`deny` tool patterns for headless execution
 - `dataset` — `path` to test cases directory, `schema` describing case structure in natural language

--- a/README.md
+++ b/README.md
@@ -106,8 +106,12 @@ The harness uses natural language to describe evaluation datasets and skills inp
 name: my-skill-eval
 description: Evaluate the main skill pipeline
 skill: my-skill-name
-arguments: "--headless"  # Arguments passed to the skill
 runner: claude-code
+
+# Execution — how the skill processes test cases
+execution:
+  mode: case              # case (default) or batch
+  arguments: "{prompt}"   # resolved per case from input.yaml fields
 
 # Permissions — tool access during headless execution
 permissions:
@@ -228,7 +232,7 @@ thresholds:
 
 ### Key concepts
 
-- **`arguments`** — arguments string passed to the skill invocation (e.g., `"--input batch.yaml --headless"`). Stored in eval.yaml for reproducibility; can be overridden via `--skill-args` on execute.py.
+- **`execution`** — `mode` (`case` or `batch`) and `arguments` template. In `case` mode (default), the skill is invoked once per test case with `{field}` placeholders resolved from each case's input.yaml. In `batch` mode, all cases are bundled into batch.yaml for a single invocation.
 - **`schema`** — natural language description of structure. Used on `dataset` and each `outputs` entry. Agents and judges read these to understand the data.
 - **`inputs.tools`** — tool interception for headless execution. Each entry has a `match` (natural language description of what to intercept — tools, scripts, APIs) and a `prompt` (how to handle it). eval-analyze generates these from skill analysis; eval-run resolves them to concrete patterns at setup time.
 - **`outputs`** — two types: `path` for file artifacts on disk, `tool` for tool call side effects (Jira, APIs). Both have `schema` descriptions.
@@ -246,6 +250,9 @@ thresholds:
 name: rfe-creator
 skill: rfe.speedrun
 runner: claude-code
+execution:
+  mode: batch
+  arguments: "--input batch.yaml --headless --dry-run"
 mlflow_experiment: rfe-eval
 permissions:
   deny: ["mcp__atlassian__*"]  # Block Jira writes during eval

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -79,6 +79,23 @@ class InputsConfig:
 
 
 @dataclass
+class ExecutionConfig:
+    """How the skill is invoked against test cases.
+
+    Modes:
+    - case (default): one skill invocation per case, with case-specific
+      arguments resolved from input.yaml fields via {field} placeholders.
+    - batch: all cases in one invocation via batch.yaml.
+
+    Arguments template placeholders:
+    - {field} → substitutes the value of 'field' from input.yaml
+    - {field?} → substitutes if present, omitted if missing
+    """
+    mode: str = "case"
+    arguments: str = ""
+
+
+@dataclass
 class JudgeConfig:
     """Configuration for a single judge.
 
@@ -113,11 +130,13 @@ class EvalConfig:
     name: str = ""
     description: str = ""
     skill: str = ""
-    arguments: str = ""
     runner: str = "claude-code"
     runner_options: dict = field(default_factory=dict)
     permissions: dict = field(default_factory=dict)
     mlflow_experiment: str = ""
+
+    # Execution — how the skill is invoked
+    execution: ExecutionConfig = field(default_factory=ExecutionConfig)
 
     # Dataset — natural language schema + path
     dataset_path: str = ""
@@ -157,15 +176,22 @@ class EvalConfig:
         # Dataset
         dataset = raw.get("dataset", {})
 
+        # Execution config
+        exec_raw = raw.get("execution", {})
+        execution = ExecutionConfig(
+            mode=exec_raw.get("mode", "case"),
+            arguments=exec_raw.get("arguments", ""),
+        )
+
         config = cls(
             name=raw.get("name", path.stem),
             description=raw.get("description", ""),
             skill=raw.get("skill", ""),
-            arguments=raw.get("arguments", ""),
             runner=raw.get("runner", "claude-code"),
             runner_options=raw.get("runner_options", {}),
             permissions=raw.get("permissions", {}),
             mlflow_experiment=raw.get("mlflow_experiment", raw.get("name", "")),
+            execution=execution,
             dataset_path=_validate_relative_path(
                 dataset.get("path", ""), "dataset.path"),
             dataset_schema=dataset.get("schema", ""),

--- a/eval.yaml
+++ b/eval.yaml
@@ -8,8 +8,13 @@ description: Evaluate the main skill pipeline
 
 # Skill to test
 skill: my-skill-name
-arguments: "--headless"  # Arguments passed to the skill invocation
 runner: claude-code   # Agent runner: claude-code, opencode, etc.
+
+# Execution — how the skill processes test cases
+execution:
+  mode: case              # per-case (default) or batch
+  arguments: "{prompt}"       # resolved per case from input.yaml fields
+  # For batch skills: mode: batch, arguments: "--input batch.yaml --headless"
 
 # Permissions — tool access during headless execution
 permissions:

--- a/skills/eval-analyze/SKILL.md
+++ b/skills/eval-analyze/SKILL.md
@@ -113,6 +113,8 @@ If no test cases exist, note this clearly and suggest running `/eval-dataset` to
 Combine the skill analysis (Step 3) and dataset exploration (Step 4) into a complete eval.yaml. Read the full template and writing guidance at `${CLAUDE_SKILL_DIR}/references/eval-yaml-template.md`.
 
 Key points:
+- **Execution mode**: determine from the skill analysis whether it expects a single input (`mode: case`) or a batch file (`mode: batch`). Look at `$ARGUMENTS` in the SKILL.md — if it takes one value (a key, prompt, or file path), use `case`. If it takes `--input <file>` with a YAML list, or has parallelism/batch-size controls, use `batch`. When in doubt, use `case`.
+- **Arguments template**: for `case` mode, build a template with `{field}` placeholders matching the input.yaml fields you observed in Step 4 (e.g., `"{strat_key} {adr_file?}"`). For `batch` mode, use the literal arguments string (e.g., `"--input batch.yaml --headless"`).
 - The `dataset.schema` and `outputs[*].schema` fields drive the entire pipeline — be specific, reference actual file/field names you observed
 - If the skill uses AskUserQuestion, calls external services (MCP tools), or runs scripts that interact with APIs, add `inputs.tools` entries. Use `match` to describe what to intercept in natural language (e.g., "any Jira interaction via MCP or scripts"), and `prompt` for how to handle it.
 - Aim for 2-4 inline `check` judges + 1-2 LLM `prompt` judges. Start lean.

--- a/skills/eval-analyze/SKILL.md
+++ b/skills/eval-analyze/SKILL.md
@@ -89,12 +89,13 @@ First check if eval.yaml already has a `dataset.path` (from a previous run or `-
 ls <dataset_path>/ 2>/dev/null | head -20
 ```
 
-If not set or doesn't exist, search the project for test case directories:
+If not set or doesn't exist, search the project for test case directories using the Glob tool:
 
-```bash
-find . -type d \( -name "cases" -o -name "test-cases" -o -name "fixtures" -o -name "examples" \) \
-  -not -path "./.venv/*" -not -path "./.git/*" -not -path "./node_modules/*" 2>/dev/null
 ```
+Glob: **/cases/ or **/test-cases/ or **/fixtures/ or **/examples/
+```
+
+Exclude `.venv/`, `.git/`, `node_modules/` from results.
 
 If nothing found, ask the user where their test cases are (or will be).
 

--- a/skills/eval-analyze/prompts/analyze-skill.md
+++ b/skills/eval-analyze/prompts/analyze-skill.md
@@ -22,6 +22,11 @@ inputs:
     <natural language description of what the skill expects as input —
      how cases are structured, what files or fields they contain>
   invocation: "<how the skill is invoked: /skill-name args>"
+  companion_files:
+    - "<files the skill reads from disk at runtime, beyond the prompt —
+       e.g., strategy.md, adr.md, config files. These must be in the
+       test case directory so the harness can provision them into the
+       workspace. List actual filenames you observed in the SKILL.md.>"
 
 outputs:
   # File artifacts written to disk

--- a/skills/eval-analyze/prompts/analyze-skill.md
+++ b/skills/eval-analyze/prompts/analyze-skill.md
@@ -40,6 +40,22 @@ sub_skills:
     produces: "<what artifacts it writes, if any>"
   # List all sub-skills in pipeline order
 
+execution_mode:
+  mode: "<case or batch>"
+  reasoning: |
+    <why you chose this mode — what you observed in the skill>
+  # case: the skill expects a single input (one problem, one Jira key, one file)
+  #   and runs a pipeline on it. $ARGUMENTS is a single value or a few fields.
+  #   Examples: /rfe.create "problem statement", /test-plan.create RHAISTRAT-1520
+  # batch: the skill accepts a batch file (--input batch.yaml) and processes
+  #   multiple items in one invocation. It iterates over entries internally.
+  #   Strong signal: the skill has parallelism or batch-size controls
+  #   (--batch-size, --parallel, --concurrency).
+  #   Examples: /rfe.speedrun --input batch.yaml, /rfe.auto-fix --input ids.yaml
+  arguments_template: "<template with {field} placeholders from input.yaml>"
+  # For case mode: "{prompt}", "{strat_key} {adr_file?}"
+  # For batch mode: "--input batch.yaml --headless --dry-run"
+
 flags:
   supported:
     - "--flag: what it does"

--- a/skills/eval-analyze/prompts/generate-eval-md.md
+++ b/skills/eval-analyze/prompts/generate-eval-md.md
@@ -22,6 +22,7 @@ analyzed_at: <ISO 8601 timestamp>
 skill_hash: <SHA256 hash prefix of SKILL.md, 12 chars>
 
 # Discovered skill capabilities
+execution_mode: <case/batch>
 headless: <true/false>
 dry_run: <true/false>
 

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -11,11 +11,26 @@ skill: <skill-name>
 runner: claude-code
 
 # Execution — how the skill processes test cases
+#
+# How to choose the mode:
+# - case (default): the skill expects ONE input and runs a pipeline on it.
+#   Signs: $ARGUMENTS is a single value (Jira key, prompt, file path),
+#   the skill runs phases sequentially on that input, then exits.
+#   Examples: /test-plan.create RHAISTRAT-1520, /rfe.create "problem..."
+#
+# - batch: the skill accepts a BATCH FILE and processes multiple items
+#   in one invocation. Signs: the skill has --input flag that takes a
+#   YAML list, it iterates over entries internally, it has batch-size
+#   or parallelism controls (--batch-size, --parallel, --concurrency).
+#   Parallelism options are a strong signal — if the skill manages
+#   concurrency itself, it's doing batch processing.
+#   Examples: /rfe.speedrun --input batch.yaml, /rfe.auto-fix --input ids.yaml
+#
+# When in doubt, use case — it's safer (each case gets full isolation).
 execution:
-  mode: case              # per-case (default): one invocation per case
-                              # batch: all cases in one invocation via batch.yaml
+  mode: case
   arguments: <argument template with {field} placeholders from input.yaml>
-  # Per-case examples: "{prompt}", "{strat_key} {adr_file?}"
+  # Case examples: "{prompt}", "{strat_key} {adr_file?}"
   # Batch example: "--input batch.yaml --headless --dry-run"
 
 # Permissions for headless execution

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -8,8 +8,15 @@ Use this template when generating eval.yaml. Fill in every field from what you o
 name: <project-name>
 description: <one line: what is being evaluated>
 skill: <skill-name>
-arguments: <arguments passed to the skill invocation, from SKILL.md $ARGUMENTS>
 runner: claude-code
+
+# Execution — how the skill processes test cases
+execution:
+  mode: case              # per-case (default): one invocation per case
+                              # batch: all cases in one invocation via batch.yaml
+  arguments: <argument template with {field} placeholders from input.yaml>
+  # Per-case examples: "{prompt}", "{strat_key} {adr_file?}"
+  # Batch example: "--input batch.yaml --headless --dry-run"
 
 # Permissions for headless execution
 permissions:

--- a/skills/eval-analyze/scripts/validate_eval.py
+++ b/skills/eval-analyze/scripts/validate_eval.py
@@ -88,6 +88,14 @@ def validate_config(path="eval.yaml"):
             except ImportError:
                 errors.append(f"judges.{name}.module '{module}' not importable")
 
+    # --- Execution config ---
+    execution = config.get("execution", {})
+    exec_mode = execution.get("mode", "case")
+    if exec_mode not in ("case", "batch"):
+        errors.append(f"execution.mode must be 'case' or 'batch', got '{exec_mode}'")
+    if not execution.get("arguments"):
+        warnings.append("No execution.arguments — skill will be invoked with no arguments")
+
     # --- Inputs (tool interception) ---
     for t in (config.get("inputs", {}).get("tools") or []):
         if not t.get("match"):
@@ -114,6 +122,7 @@ def validate_config(path="eval.yaml"):
         status = "INCOMPLETE"
 
     print(f"{status}: {config.get('name')} (skill={config.get('skill')})")
+    print(f"  execution: mode={exec_mode}, arguments={'yes' if execution.get('arguments') else 'no'}")
     print(f"  dataset: {dataset.get('path', 'not set')}")
     print(f"  schema: {'yes' if dataset.get('schema') else 'no'}")
     print(f"  outputs: {len(outputs)} directories")

--- a/skills/eval-dataset/SKILL.md
+++ b/skills/eval-dataset/SKILL.md
@@ -19,6 +19,7 @@ You generate evaluation test cases for a skill. You read the skill analysis (eva
 
 Read eval.yaml and eval.md to understand:
 - **The skill** — what it does, what inputs it expects, what it produces
+- **The execution config** — `execution.mode` (`case` or `batch`) and `execution.arguments` (the argument template). In `case` mode, `{field}` placeholders in the arguments are resolved per case from input.yaml — every field referenced in the template (e.g., `{strat_key}`, `{prompt}`) must exist in the generated input.yaml files.
 - **The dataset schema** — `dataset.schema` describes the case structure (files, fields, formats)
 - **The dataset path** — where cases should be created
 - **The output schema** — `outputs[*].schema` describes what the skill produces (informs what reference outputs look like)
@@ -53,7 +54,9 @@ Read `dataset.schema` and extract a concrete checklist:
 4. **Field semantics** — what kind of content each field expects (e.g., "problem statement", "clarifying context", "priority level"). Use these descriptions to generate realistic content, not generic placeholders
 5. **Naming patterns** — any file naming conventions mentioned (e.g., "named NNN-slug.md")
 
-This checklist is your generation template. Every case must satisfy items 1-2. Items 3-4 guide content variety.
+6. **Argument fields** — if `execution.mode` is `case`, parse `execution.arguments` for `{field}` placeholders. Every placeholder must appear as a required field in input.yaml. Cross-check against items 1-2 above — if `{strat_key}` is in the arguments but not in the schema, add it as a required field.
+
+This checklist is your generation template. Every case must satisfy items 1-2 and 6. Items 3-4 guide content variety.
 
 ## Step 3: Assess Current State
 
@@ -129,6 +132,8 @@ case-005-ambiguous-phrasing/
 
 If unsure what questions the skill asks, leave `answers.yaml` out — the hook script auto-accepts with "yes" or the first option.
 
+**Companion files**: If eval.md lists `companion_files` (files the skill reads from disk at runtime — e.g., `strategy.md`, `adr.md`), each test case must include them. In `case` mode, the harness copies all case files into the workspace, so the skill will find them at their expected relative paths. Generate realistic content for these files appropriate to each case's scenario.
+
 **Reference outputs**: Only include gold standard reference files if you can confidently produce a correct output. It's better to leave references out (the user can generate them later with `/eval-run --gold`) than to include incorrect ones that mislead judges.
 
 ## Step 6: Validate
@@ -137,7 +142,9 @@ After generating, verify the cases:
 
 1. Read one generated case back and check it matches the schema
 2. Count files per case — do they match what `dataset.schema` describes?
-3. Check for obvious issues (empty files, placeholder text, wrong field names)
+3. If `execution.mode` is `case`, verify that input.yaml contains all fields referenced by `{field}` placeholders in `execution.arguments`
+4. If companion files are expected, verify they exist in each case directory
+5. Check for obvious issues (empty files, placeholder text, wrong field names)
 
 ```bash
 ls <dataset_path>/case-001-*/ 
@@ -151,7 +158,7 @@ Tell the user what was created:
 - **Strategy used**: bootstrap / expand / from-traces
 - **Coverage**: What scenarios are now covered (simple, complex, edge cases)
 - **What's missing**: Reference outputs (if not generated), any gaps still remaining
-- **Next steps**:
+- **Next steps** (include `--config <config>` if a non-default config was used):
   - `/eval-run --model <model>` to test the skill against these cases
   - `/eval-run --model <model> --gold` to generate gold references from the best outputs
   - `/eval-dataset --strategy expand --count 10` to add more cases later

--- a/skills/eval-mlflow/SKILL.md
+++ b/skills/eval-mlflow/SKILL.md
@@ -109,9 +109,10 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/log_results.py \
 
 This logs:
 - **Params**: skill, runner, model, run_id
-- **Metrics**: per-judge mean and pass_rate (e.g., `has_content/pass_rate`)
+- **Metrics**: per-judge mean and pass_rate, execution metrics (duration, cost, turns), per-model cost/token breakdown
 - **Artifacts**: summary.yaml
 - **Table**: per-case results with case_id, judge, value, rationale
+- **Traces**: one per case (case mode) or one for the run (batch mode), built from stdout.log
 - **Tags**: regressions_detected (yes/no)
 
 ## Step 5: Push Feedback (if `--action push-feedback` or `all`)
@@ -153,7 +154,7 @@ Print summary:
 - **Pulled**: N annotations from MLflow UI (if pull ran)
 - **MLflow UI**: `$MLFLOW_TRACKING_URI`
 
-Suggest next steps:
+Suggest next steps (include `--config <config>` if a non-default config was used):
 - `/eval-review --run-id <id>` for human review
 - `/eval-optimize --model <model>` for automated improvement
 - View results in MLflow UI at the tracking URI

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -181,21 +181,43 @@ def main():
                     columns[key] = [row[key] for row in table_rows]
                 mlflow.log_table(columns, artifact_file="per_case_results.json")
 
-    # ── Main orchestrator trace from stdout.log ──────────────────
-    stdout_path = run_dir / "stdout.log"
+    # ── Traces from stdout.log ─────────────────────────────────
     main_trace_id = None
-    if stdout_path.exists() and run_result:
-        trace_name = f"{config.skill} ({args.run_id})" if config.skill else ""
-        trace_dict = build_trace(stdout_path, run_result, args.run_id,
-                                 experiment_id, trace_name=trace_name,
-                                 subagent_model=run_result.get(
-                                     "subagent_model"))
-        if trace_dict:
-            main_trace_id = log_trace(trace_dict)
-            if main_trace_id:
-                num_spans = len(trace_dict["data"]["spans"])
-                duration_s = run_result.get("duration_s", 0)
-                print(f"TRACE: {main_trace_id} ({num_spans} spans, {duration_s:.0f}s)")
+    exec_mode = run_result.get("execution_mode", "batch")
+
+    if exec_mode == "case":
+        # Per-case mode: each case has its own stdout.log
+        cases_dir = run_dir / "cases"
+        if cases_dir.exists():
+            for case_dir in sorted(d for d in cases_dir.iterdir() if d.is_dir()):
+                case_stdout = case_dir / "stdout.log"
+                if not case_stdout.exists():
+                    continue
+                case_id = case_dir.name
+                case_result = run_result.get("per_case", {}).get(case_id, run_result)
+                trace_name = f"{config.skill} ({case_id})" if config.skill else case_id
+                trace_dict = build_trace(case_stdout, case_result, case_id,
+                                         experiment_id, trace_name=trace_name)
+                if trace_dict:
+                    tid = log_trace(trace_dict)
+                    if tid:
+                        if not main_trace_id:
+                            main_trace_id = tid
+                        num_spans = len(trace_dict["data"]["spans"])
+                        print(f"TRACE: {tid} ({num_spans} spans) — {case_id}")
+    else:
+        # Batch mode: one stdout.log for the entire run
+        stdout_path = run_dir / "stdout.log"
+        if stdout_path.exists() and run_result:
+            trace_name = f"{config.skill} ({args.run_id})" if config.skill else ""
+            trace_dict = build_trace(stdout_path, run_result, args.run_id,
+                                     experiment_id, trace_name=trace_name)
+            if trace_dict:
+                main_trace_id = log_trace(trace_dict)
+                if main_trace_id:
+                    num_spans = len(trace_dict["data"]["spans"])
+                    duration_s = run_result.get("duration_s", 0)
+                    print(f"TRACE: {main_trace_id} ({num_spans} spans, {duration_s:.0f}s)")
 
     # ── Link traces to run ───────────────────────────────────────
     trace_ids = []

--- a/skills/eval-optimize/SKILL.md
+++ b/skills/eval-optimize/SKILL.md
@@ -76,9 +76,9 @@ For each failure pattern, investigate why the skill produces bad output:
    python3 ${CLAUDE_SKILL_DIR}/../eval-analyze/scripts/find_skills.py --name <skill>
    ```
 
-2. **Read transcripts** (if available) — transcripts can be very large, so delegate to an Agent:
+2. **Read transcripts** (if available) — transcripts can be very large, so delegate to an Agent. Check `run_result.json` for `execution_mode`: in `case` mode, each case has its own transcript at `$AGENT_EVAL_RUNS_DIR/<id>/cases/<case>/stdout.log`; in `batch` mode, there's one at `$AGENT_EVAL_RUNS_DIR/<id>/stdout.log`. Focus on the failing cases.
    ```text
-   Agent tool, subagent_type="Explore": "Read $AGENT_EVAL_RUNS_DIR/<id>/stdout.log and report:
+   Agent tool, subagent_type="Explore": "Read the transcript at <path> and report:
    - Did the skill follow its own instructions? Which were unclear?
    - Did it take roundabout paths or try multiple approaches?
    - Did sub-skills behave unexpectedly?
@@ -103,6 +103,8 @@ Apply targeted fixes to the SKILL.md. For each edit:
 - **Don't overfit** — if only 1 of 20 cases fails, the fix should be general enough to help without breaking the other 19
 
 Show each edit before applying. If the change is risky (could affect passing cases), note it.
+
+**Execution mode context**: check `execution.mode` in eval.yaml. In `case` mode, each case runs in its own isolated workspace with all case files copied in — the skill receives case-specific arguments resolved from input.yaml. In `batch` mode, all cases are in one workspace via batch.yaml. Your edits must work for the configured mode.
 
 ## Step 5: Re-Run and Verify
 
@@ -148,7 +150,8 @@ If max iterations reached with failures remaining:
 - Suggest `/eval-review --run-id <final-id>` for human assessment of the remaining issues
 - Suggest `/eval-dataset --strategy expand` if failures suggest missing test coverage
 
-In all cases, suggest `/eval-mlflow --run-id <final-id>` to log the optimization results to MLflow for tracking.
+In all cases (include `--config <config>` if a non-default config was used):
+- Suggest `/eval-mlflow --run-id <final-id>` to log the optimization results to MLflow for tracking.
 
 ## Rules
 

--- a/skills/eval-review/SKILL.md
+++ b/skills/eval-review/SKILL.md
@@ -48,9 +48,11 @@ If the user says "looks fine" or gives no feedback, move on. Empty feedback mean
 
 ## Step 4: Check Transcripts (if available)
 
-If execution transcripts exist (`$AGENT_EVAL_RUNS_DIR/<id>/stdout.log`), delegate analysis to an Agent — transcripts can be very large and should not be loaded into your context directly.
+If execution transcripts exist, delegate analysis to an Agent — transcripts can be very large and should not be loaded into your context directly.
 
-Spawn an Agent to read `$AGENT_EVAL_RUNS_DIR/<id>/stdout.log` and report:
+Check `run_result.json` for `execution_mode`. In `case` mode, each case has its own transcript at `$AGENT_EVAL_RUNS_DIR/<id>/cases/<case>/stdout.log`. In `batch` mode, there's one at `$AGENT_EVAL_RUNS_DIR/<id>/stdout.log`. Analyze the transcript(s) for the cases the user reviewed.
+
+Spawn an Agent to read the relevant stdout.log and report:
 - Did the skill try multiple approaches before succeeding? (instructions may be unclear)
 - Did it use unnecessary tools or take roundabout paths? (skill could be more directive)
 - Did it encounter errors and recover? (error handling might need improvement)
@@ -61,14 +63,22 @@ Report relevant transcript findings to the user alongside their case feedback �
 
 ## Step 5: Save Feedback
 
-Persist the collected feedback so it survives beyond this conversation and can be used by `/eval-optimize`:
+Persist the collected feedback so it survives beyond this conversation and can be used by `/eval-optimize` and `/eval-mlflow`.
 
-```bash
-python3 -m agent_eval.state write-ids $AGENT_EVAL_RUNS_DIR/<id>/review.yaml \
-  reviewed_cases=<count> feedback_cases=<count_with_feedback>
+Write `$AGENT_EVAL_RUNS_DIR/<id>/review.yaml` with this structure:
+
+```yaml
+run_id: "<id>"
+reviewed_cases: <count>
+feedback_cases: <count_with_feedback>
+reviewer: "human"
+feedback:
+  case-001-name: "User's comment about this case"
+  case-002-name: "Another comment"
+  case-003-name: ""  # empty = acceptable
 ```
 
-Also write the per-case feedback to `$AGENT_EVAL_RUNS_DIR/<id>/review.yaml` as a `feedback` section with case IDs and the user's comments. This file is read by `/eval-optimize` to ground its changes in human judgment.
+Use the Write tool to create the file directly — do NOT use `agent_eval.state` commands (they produce a different format). This file is read by `/eval-optimize` to ground changes in human judgment, and by `/eval-mlflow` to push feedback to MLflow traces.
 
 ## Step 6: Analyze Patterns
 
@@ -84,7 +94,7 @@ Present your analysis: "Here's what I noticed across your feedback..."
 
 Based on the feedback patterns:
 
-1. Read the skill's SKILL.md (from eval.yaml's `skill` field, locate via `python3 skills/eval-analyze/scripts/find_skills.py --name <skill>`)
+1. Read the skill's SKILL.md (from eval.yaml's `skill` field, locate via `python3 ${CLAUDE_SKILL_DIR}/../eval-analyze/scripts/find_skills.py --name <skill>`)
 2. Identify which parts of the skill's instructions relate to the user's complaints
 3. Propose specific edits — show a before/after diff for each change
 4. Explain why each change should help, grounded in the feedback evidence
@@ -95,10 +105,11 @@ If feedback suggests new judges, propose additions to eval.yaml as well.
 
 ## Step 8: Next Steps
 
-After applying approved changes, suggest:
+After applying approved changes, suggest (include `--config <config>` if a non-default config was used):
 - `/eval-run --model <model> --baseline <run-id>` to re-run and compare
 - `/eval-optimize --model <model>` if they want automated iteration from here
 - `/eval-dataset --strategy expand` if the feedback revealed coverage gaps
+- `/eval-mlflow --run-id <run-id> --action push-feedback` to push review feedback to MLflow traces
 
 ## Rules
 

--- a/skills/eval-review/SKILL.md
+++ b/skills/eval-review/SKILL.md
@@ -27,12 +27,14 @@ Also read eval.yaml to understand the skill being tested, the dataset schema, an
 
 ## Step 2: Present Overview
 
-Show the user a high-level summary:
+If an HTML report exists at `$AGENT_EVAL_RUNS_DIR/<id>/report.html`, tell the user — they can open it in a browser for a visual overview with per-case details, diffs, and judge scores.
+
+Then show a high-level summary:
 - Overall pass rates per judge
 - How many cases passed all judges vs had failures
 - If a pairwise comparison was run, show the win/loss/tie counts
 
-Then ask: "Want to review all cases, only failures, or specific cases?"
+Ask: "Want to review all cases, only failures, or specific cases?"
 
 ## Step 3: Walk Through Cases
 

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -132,7 +132,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
 
 Pass `--agent` with the `runner` value from eval.yaml (default: `claude-code`).
 
-The `--skill-args` value is the argument string for the skill invocation (e.g., `"--input batch.yaml --headless"`). If omitted, execute.py uses the `arguments` field from eval.yaml. Override via CLI only when testing different argument combinations.
+The `--skill-args` value is the argument string for the skill invocation (e.g., `"--input batch.yaml --headless"`). If omitted, execute.py uses `execution.arguments` from eval.yaml. In `case` mode, `{field}` placeholders are resolved per case from input.yaml. Override via CLI only when testing different argument combinations.
 
 ### Monitoring Progress
 

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -75,11 +75,11 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/preflight.py \
   [--run-id <id>]
 ```
 
-The script checks all output paths from eval.yaml plus `tmp/` state files. It also checks whether `eval/runs/<id>` already has results from a previous run.
+The script checks `tmp/` state files and whether `$AGENT_EVAL_RUNS_DIR/<id>` already has results from a previous run.
 
 - **If `CLEAN`**: proceed to workspace setup.
 - **If `DIRTY`**: report the findings to the user and ask what to do:
-  - **Force clean**: run `preflight.py --clean` to delete all stale artifacts, then proceed.
+  - **Force clean**: run `preflight.py --clean --force` to delete all stale artifacts, then proceed.
   - **Change run-id**: append a version suffix (e.g., `2026-04-11-opus-v2`) and re-check. This avoids overwriting previous run results but still requires cleaning project artifacts — re-run preflight with `--clean` and the new run-id.
   - **Abort**: let the user handle cleanup manually.
 
@@ -115,7 +115,9 @@ The hook script (`tools.py`) uses these concrete checks at runtime — no LLM ne
 
 ## Step 4: Execute Skill
 
-Run the skill headlessly against all cases. The execute script handles CLI construction, streaming progress, and result capture:
+Run the skill headlessly against test cases. In `case` mode (default), execute.py runs the skill once per case with case-specific arguments and workspace — each case gets its own stdout.log and subagent transcripts. In `batch` mode, all cases run in a single invocation via batch.yaml.
+
+The execute script handles CLI construction, streaming progress, and result capture:
 
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -29,6 +29,30 @@ How data flows from dataset cases through execution, collection, and scoring.
   skills/ → symlink
 ```
 
+### Case Mode (execution.mode: case)
+
+When `execution.mode` is `case` (default), workspace.py creates a separate workspace per case:
+
+```
+/tmp/agent-eval/{run-id}/
+  case_order.yaml         # [{case_id: "case-001-name"}, ...]
+  cases/
+    case-001-name/
+      input.yaml          # Copied from dataset
+      strategy.md         # Copied from dataset (companion files)
+      answers.yaml        # Copied from dataset (if present)
+      {output_dirs}/      # Empty dirs for skill outputs
+      .claude/settings.json  # Generated (hooks + permissions)
+      subagents/           # SubagentStop hook target
+      scripts/ → symlink
+      CLAUDE.md → symlink
+      skills/ → symlink
+    case-002-name/
+      ...
+```
+
+Each case gets ALL files from the dataset case directory (not just input.yaml), plus symlinked project resources and hooks. The skill runs in the case workspace as its working directory.
+
 ## 2. Workspace → Execution
 
 **What execute.py does**:
@@ -39,11 +63,23 @@ How data flows from dataset cases through execution, collection, and scoring.
 - Parses the final `result` event for token usage and cost
 - Writes `run_result.json` with exit_code, duration_s, token_usage, cost_usd
 
-**What the skill sees**:
+**What the skill sees (batch mode)**:
 - Working directory: the workspace
 - Input: batch.yaml content (via skill prompt)
 - Output directories: created and ready
 - Hooks: if configured, AskUserQuestion gets auto-answered, external services get checked
+
+**What the skill sees (case mode)**:
+- Working directory: the case workspace (`workspace/cases/{case_id}/`)
+- Input: case-specific arguments resolved from `execution.arguments` template + all case files on disk
+- Output directories: created and ready
+- Hooks: per-case hooks with SubagentStop for transcript capture
+
+**Case mode execution**:
+- execute.py loops through `case_order.yaml`, invoking the skill once per case
+- Each case gets its own stdout.log, stderr.log, and subagent transcripts
+- Results are saved to `$AGENT_EVAL_RUNS_DIR/{id}/cases/{case_id}/stdout.log`
+- run_result.json includes `execution_mode: "case"` and `per_case` breakdown
 
 ## 3. Execution → Collection
 

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -146,7 +146,9 @@ def _collect_per_case(workspace, output_dir, config):
         case_id = case_dir.name
 
         for output_cfg in config.outputs:
-            out_path = _safe_path_component(output_cfg.path or ".", "output path")
+            if not output_cfg.path:
+                continue  # Skip tool-only outputs (no filesystem path)
+            out_path = _safe_path_component(output_cfg.path, "output path")
             src = case_dir / out_path
 
             if not src.exists():
@@ -166,6 +168,9 @@ def _collect_per_case(workspace, output_dir, config):
             case_output.mkdir(parents=True, exist_ok=True)
 
             for f in files:
+                # Reject symlinks (CWE-59)
+                if f.is_symlink():
+                    continue
                 rel = f.relative_to(src_base)
                 dest = case_output / rel
                 dest.parent.mkdir(parents=True, exist_ok=True)

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -43,6 +43,13 @@ def main():
     workspace = Path(args.workspace)
     output_dir = Path(args.output)
 
+    # Per-case mode: outputs are already in case workspaces
+    if config.execution.mode == "case":
+        _collect_per_case(workspace, output_dir, config)
+        return
+
+    # ── Batch mode (below) ───────────────────────────────────────
+
     # Load case order
     order_path = workspace / "case_order.yaml"
     if not order_path.exists():
@@ -106,6 +113,65 @@ def main():
                 shutil.copy2(src_file, dest)
 
             results.setdefault(case_id, {})[out_path] = len(matched_files)
+
+    # Save collection summary
+    with open(output_dir / "collection.json", "w") as f:
+        json.dump(results, f, indent=2)
+
+    for case_id, info in sorted(results.items()):
+        counts = ", ".join(f"{k}={v}" for k, v in info.items())
+        print(f"  {case_id}: {counts}")
+
+    if not results:
+        print("WARNING: no artifacts collected", file=sys.stderr)
+
+
+def _collect_per_case(workspace, output_dir, config):
+    """Collect artifacts from per-case workspaces.
+
+    In per-case mode, each case has its own workspace at
+    workspace/cases/{case_id}/. The skill writes outputs relative to
+    its cwd (the case workspace). We scan for output files matching
+    the configured output paths and copy them to the run output dir.
+    """
+    cases_dir = workspace / "cases"
+    if not cases_dir.exists():
+        print("ERROR: no cases/ directory in workspace", file=sys.stderr)
+        sys.exit(1)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    results = {}
+
+    for case_dir in sorted(d for d in cases_dir.iterdir() if d.is_dir()):
+        case_id = case_dir.name
+
+        for output_cfg in config.outputs:
+            out_path = _safe_path_component(output_cfg.path or ".", "output path")
+            src = case_dir / out_path
+
+            if not src.exists():
+                continue
+
+            if src.is_file():
+                files = [src]
+                src_base = src.parent
+            else:
+                files = sorted(f for f in src.rglob("*") if f.is_file())
+                src_base = src
+
+            if not files:
+                continue
+
+            case_output = output_dir / "cases" / case_id / out_path
+            case_output.mkdir(parents=True, exist_ok=True)
+
+            for f in files:
+                rel = f.relative_to(src_base)
+                dest = case_output / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(f, dest)
+
+            results.setdefault(case_id, {})[out_path] = len(files)
 
     # Save collection summary
     with open(output_dir / "collection.json", "w") as f:

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -145,17 +145,32 @@ def _resolve_arguments(template, case_data):
     """Resolve {field} and {field?} placeholders from case input data."""
     import re
 
+    missing = []
+
     def _replace(m):
         field = m.group(1)
         optional = field.endswith("?")
         if optional:
             field = field[:-1]
-        value = case_data.get(field, "")
-        if not value and optional:
+        if field not in case_data:
+            if optional:
+                return ""
+            missing.append(field)
+            return ""
+        value = case_data[field]
+        if value is None or (isinstance(value, str) and not value.strip()):
+            if optional:
+                return ""
+            missing.append(field)
             return ""
         return str(value).strip()
 
-    return re.sub(r'\{(\w+\??)\}', _replace, template).strip()
+    result = re.sub(r'\{(\w+\??)\}', _replace, template).strip()
+    if missing:
+        raise ValueError(
+            f"Missing required fields in input.yaml: {', '.join(missing)}. "
+            f"Template: {template}")
+    return result
 
 
 def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
@@ -240,9 +255,16 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
         case_results[case_id] = {
             "exit_code": result.exit_code,
             "duration_s": round(result.duration_s, 1),
+            "token_usage": result.token_usage,
             "cost_usd": result.cost_usd,
             "num_turns": result.num_turns,
         }
+
+        # Write per-case run_result.json so score.py can read
+        # execution metadata per case (not just aggregate)
+        with open(case_output / "run_result.json", "w") as f:
+            json.dump(case_results[case_id], f, indent=2)
+            f.write("\n")
         worst_exit = max(worst_exit, result.exit_code)
 
         status = "OK" if result.exit_code == 0 else f"FAIL (exit {result.exit_code})"

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -43,7 +43,7 @@ def main():
     parser.add_argument("--workspace", required=True)
     parser.add_argument("--skill", required=True)
     parser.add_argument("--skill-args", default=None,
-                        help="Skill arguments (default: from eval.yaml skill_args)")
+                        help="Skill arguments (default: from eval.yaml execution.arguments)")
     parser.add_argument("--model", required=True)
     parser.add_argument("--output", required=True)
     parser.add_argument("--config", default="eval.yaml",
@@ -64,7 +64,7 @@ def main():
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Resolve skill args: CLI override > config > empty
-    skill_args = args.skill_args if args.skill_args is not None else config.arguments
+    skill_args = args.skill_args if args.skill_args is not None else config.execution.arguments
 
     # Resolve {prompt} placeholder from batch.yaml
     if skill_args and "{prompt}" in skill_args:
@@ -94,39 +94,38 @@ def main():
         log_prefix="eval",
     )
 
-    print(f"Executing: /{args.skill} {skill_args}", file=sys.stderr)
-    print(f"Agent: {runner.name} | Model: {args.model}", file=sys.stderr)
-    print(f"Workspace: {args.workspace}", file=sys.stderr)
-
-    # Set MLflow environment in the workspace settings so /eval-mlflow
-    # can create a consolidated trace post-hoc from the stream-json log.
-    # We do NOT inject the Stop hook here — it fires for every subagent
-    # session, creating fragmented traces instead of one consolidated trace.
-    if args.mlflow_experiment:
-        from agent_eval.mlflow.experiment import inject_tracing_env
-        inject_tracing_env(args.workspace, project_root=Path.cwd(),
-                           experiment_name=args.mlflow_experiment)
-        print(f"MLflow tracing: environment configured (trace via /eval-mlflow)", file=sys.stderr)
-
-    # Use workspace settings if generated (tool interception and/or tracing hooks)
-    workspace_settings = Path(args.workspace) / ".claude" / "settings.json"
-    settings_path = workspace_settings if workspace_settings.exists() else None
-
     # Resolve timeout and budget: CLI override > runner_options > defaults
     opts = config.runner_options or {}
     timeout_s = args.timeout or opts.get("timeout", 3600)
     max_budget = args.max_budget or opts.get("max_budget_usd", 100.0)
 
     # Compose system prompt: runner_options.system_prompt (if any) + harness prompt.
-    # The harness prompt is defense-in-depth alongside hook enforcement —
-    # hooks block the tool calls, the prompt prevents the model from wasting
-    # budget on workaround attempts.
     existing_prompt = ""
     if isinstance(config.runner_options, dict):
         existing_prompt = str(config.runner_options.get("system_prompt", "")).strip()
     system_prompt = "\n\n".join(p for p in [existing_prompt, _HARNESS_SYSTEM_PROMPT] if p)
 
-    # Run via the abstraction
+    # ── Per-case execution ───────────────────────────────────────
+    if config.execution.mode == "case":
+        _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
+                          system_prompt)
+        return
+
+    # ── Batch execution (below) ──────────────────────────────────
+    print(f"Executing: /{args.skill} {skill_args}", file=sys.stderr)
+    print(f"Agent: {runner.name} | Model: {args.model}", file=sys.stderr)
+    print(f"Workspace: {args.workspace}", file=sys.stderr)
+
+    # Set MLflow environment in the workspace settings
+    if args.mlflow_experiment:
+        from agent_eval.mlflow.experiment import inject_tracing_env
+        inject_tracing_env(args.workspace, project_root=Path.cwd(),
+                           experiment_name=args.mlflow_experiment)
+
+    workspace_settings = Path(args.workspace) / ".claude" / "settings.json"
+    settings_path = workspace_settings if workspace_settings.exists() else None
+
+
     result = runner.run_skill(
         skill_name=args.skill,
         args=skill_args,
@@ -138,15 +137,154 @@ def main():
         timeout_s=timeout_s,
     )
 
-    # Save results
+    _save_result(result, args, output_dir, runner)
+    sys.exit(result.exit_code)
+
+
+def _resolve_arguments(template, case_data):
+    """Resolve {field} and {field?} placeholders from case input data."""
+    import re
+
+    def _replace(m):
+        field = m.group(1)
+        optional = field.endswith("?")
+        if optional:
+            field = field[:-1]
+        value = case_data.get(field, "")
+        if not value and optional:
+            return ""
+        return str(value).strip()
+
+    return re.sub(r'\{(\w+\??)\}', _replace, template).strip()
+
+
+def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
+                      system_prompt=""):
+    """Execute the skill once per case with case-specific arguments."""
+    import yaml as _yaml
+
+    workspace = Path(args.workspace)
+    case_order_path = workspace / "case_order.yaml"
+    if not case_order_path.exists():
+        print("ERROR: no case_order.yaml in workspace", file=sys.stderr)
+        sys.exit(1)
+
+    with open(case_order_path) as f:
+        case_order = _yaml.safe_load(f) or []
+
+    print(f"Executing: /{args.skill} (per-case, {len(case_order)} cases)",
+          file=sys.stderr)
+    print(f"Agent: {runner.name} | Model: {args.model}", file=sys.stderr)
+
+    case_results = {}
+    worst_exit = 0
+
+    for i, entry in enumerate(case_order, 1):
+        case_id = entry["case_id"] if isinstance(entry, dict) else entry
+        case_ws = workspace / "cases" / case_id
+
+        if not case_ws.exists():
+            print(f"  [{i}/{len(case_order)}] {case_id}: SKIP (workspace missing)",
+                  file=sys.stderr)
+            continue
+
+        # Resolve per-case arguments from input.yaml
+        case_args = config.execution.arguments
+        input_path = case_ws / "input.yaml"
+        if input_path.exists() and case_args:
+            case_data = _yaml.safe_load(input_path.read_text()) or {}
+            if isinstance(case_data, dict):
+                case_args = _resolve_arguments(case_args, case_data)
+
+        # Set MLflow environment per case workspace
+        if args.mlflow_experiment:
+            from agent_eval.mlflow.experiment import inject_tracing_env
+            inject_tracing_env(str(case_ws), project_root=Path.cwd(),
+                               experiment_name=args.mlflow_experiment)
+
+        case_settings = case_ws / ".claude" / "settings.json"
+        settings_path = case_settings if case_settings.exists() else None
+
+        print(f"  [{i}/{len(case_order)}] {case_id}: /{args.skill} {case_args}",
+              file=sys.stderr)
+
+        result = runner.run_skill(
+            skill_name=args.skill,
+            args=case_args,
+            workspace=case_ws,
+            model=args.model,
+            settings_path=settings_path,
+            system_prompt=system_prompt,
+            max_budget_usd=max_budget,
+            timeout_s=timeout_s,
+        )
+
+        # Save per-case outputs
+        case_output = output_dir / "cases" / case_id
+        case_output.mkdir(parents=True, exist_ok=True)
+        if result.stdout:
+            (case_output / "stdout.log").write_text(result.stdout)
+        if result.stderr:
+            (case_output / "stderr.log").write_text(result.stderr)
+
+        # Copy subagent transcripts
+        ws_subagents = case_ws / "subagents"
+        if ws_subagents.exists() and ws_subagents.is_dir():
+            import shutil
+            out_subagents = case_output / "subagents"
+            out_subagents.mkdir(exist_ok=True)
+            for f in ws_subagents.iterdir():
+                if f.is_file() and not f.is_symlink() and f.suffix == ".jsonl":
+                    shutil.copy2(f, out_subagents / f.name)
+
+        case_results[case_id] = {
+            "exit_code": result.exit_code,
+            "duration_s": round(result.duration_s, 1),
+            "cost_usd": result.cost_usd,
+            "num_turns": result.num_turns,
+        }
+        worst_exit = max(worst_exit, result.exit_code)
+
+        status = "OK" if result.exit_code == 0 else f"FAIL (exit {result.exit_code})"
+        print(f"    → {status} | {result.duration_s:.0f}s | "
+              f"${result.cost_usd or 0:.2f}", file=sys.stderr)
+
+    # Write aggregated run_result.json
+    total_duration = sum(r["duration_s"] for r in case_results.values())
+    total_cost = sum(r.get("cost_usd") or 0 for r in case_results.values())
+    run_meta = {
+        "exit_code": worst_exit,
+        "duration_s": round(total_duration, 1),
+        "cost_usd": round(total_cost, 2),
+        "num_cases": len(case_results),
+        "model": args.model,
+        "agent": runner.name,
+        "agent_version": getattr(runner, "version", ""),
+        "execution_mode": "case",
+        "per_case": case_results,
+    }
+    with open(output_dir / "run_result.json", "w") as f:
+        json.dump(run_meta, f, indent=2)
+        f.write("\n")
+
+    print(f"EXIT: {worst_exit}")
+    print(f"DURATION: {total_duration:.0f}s total")
+    print(f"COST: ${total_cost:.2f} total")
+    print(f"CASES: {len(case_results)} "
+          f"({sum(1 for r in case_results.values() if r['exit_code'] == 0)} OK, "
+          f"{sum(1 for r in case_results.values() if r['exit_code'] != 0)} FAIL)")
+
+    sys.exit(worst_exit)
+
+
+def _save_result(result, args, output_dir, runner):
+    """Save batch execution results (stdout, stderr, run_result.json)."""
     if result.stdout:
         (output_dir / "stdout.log").write_text(result.stdout)
     if result.stderr:
         (output_dir / "stderr.log").write_text(result.stderr)
 
     # Copy subagent transcripts captured by the SubagentStop hook.
-    # The hook copies .jsonl files to workspace/subagents/ while the
-    # session is still alive. We move them to the run output directory.
     # Only copy regular .jsonl files — reject symlinks (CWE-59).
     ws_subagents = Path(args.workspace) / "subagents"
     if ws_subagents.exists() and ws_subagents.is_dir():
@@ -158,7 +296,6 @@ def main():
                 shutil.copy2(f, out_subagents / f.name)
 
     full_model = result.resolved_model or args.model
-    # Subagent models: from stream events (actual), or CLI flag, or same as main
     models_used = result.models_used or []
     subagent_models = [m for m in models_used if m != full_model]
     subagent_model_str = ", ".join(subagent_models) if subagent_models else full_model
@@ -174,14 +311,15 @@ def main():
         "subagent_model": subagent_model_str,
         "agent": runner.name,
         "agent_version": getattr(runner, "version", ""),
+        "execution_mode": "batch",
     }
     run_result_path = output_dir / "run_result.json"
     with open(run_result_path, "w") as f:
         json.dump(run_meta, f, indent=2)
         f.write("\n")
 
-    # Verify the file is valid JSON — catch write failures early rather than
-    # letting report.py fail later with an opaque JSONDecodeError.
+    # Verify the file is valid JSON.
+
     with open(run_result_path) as f:
         json.load(f)
 
@@ -189,8 +327,6 @@ def main():
     print(f"DURATION: {result.duration_s:.0f}s")
     if result.cost_usd:
         print(f"COST: ${result.cost_usd:.2f}")
-
-    sys.exit(result.exit_code)
 
 
 if __name__ == "__main__":

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -111,16 +111,23 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
                 pass
 
     # --- Logs (if traces config enables them) ---
+    # In case mode, stdout/stderr are per-case at case_dir/stdout.log.
+    # In batch mode, they're at runs_dir/run_id/stdout.log.
     if run_id:
         if config.traces.stdout:
-            stdout_path = runs_dir / run_id / "stdout.log"
+            # Try case-level first (case mode), fall back to run-level (batch)
+            stdout_path = case_dir / "stdout.log"
+            if not stdout_path.exists():
+                stdout_path = runs_dir / run_id / "stdout.log"
             if stdout_path.exists():
                 try:
                     record["stdout"] = stdout_path.read_text()
                 except OSError:
                     pass
         if config.traces.stderr:
-            stderr_path = runs_dir / run_id / "stderr.log"
+            stderr_path = case_dir / "stderr.log"
+            if not stderr_path.exists():
+                stderr_path = runs_dir / run_id / "stderr.log"
             if stderr_path.exists():
                 try:
                     record["stderr"] = stderr_path.read_text()
@@ -134,7 +141,9 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
     if tool_outputs:
         stdout_text = record.get("stdout", "")
         if not stdout_text and run_id:
-            stdout_path = runs_dir / run_id / "stdout.log"
+            stdout_path = case_dir / "stdout.log"
+            if not stdout_path.exists():
+                stdout_path = runs_dir / run_id / "stdout.log"
             if stdout_path.exists():
                 try:
                     stdout_text = stdout_path.read_text()

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -68,6 +68,13 @@ def main():
         shutil.rmtree(workspace)
     workspace.mkdir(parents=True, mode=0o700)
 
+    # Branch on execution mode
+    if config.execution.mode == "case":
+        _create_per_case_workspace(workspace, case_dirs, config, args)
+        return
+
+    # ── Batch mode (below) ───────────────────────────────────────
+
     # Create output directories from config
     for output in config.outputs:
         if output.path and output.path != ".":
@@ -154,6 +161,86 @@ def main():
     print(f"WORKSPACE: {workspace}")
     print(f"CASES: {len(case_dirs)}")
     print(f"BATCH: {workspace / 'batch.yaml'}")
+
+
+def _create_per_case_workspace(workspace, case_dirs, config, args):
+    """Create a separate workspace per case for per-case execution.
+
+    Each case gets its own workspace subdirectory with:
+    - All files from the dataset case directory (input.yaml, strategy.md, etc.)
+    - Symlinked project resources (scripts, skills, .context, CLAUDE.md)
+    - Tool interception hooks and SubagentStop hook
+    - Output directories from eval.yaml
+    """
+    project_root = Path.cwd()
+    default_symlinks = ["scripts", ".claude", "CLAUDE.md", ".context", "skills"]
+    symlink_names = (
+        [s.strip() for s in args.symlinks.split(",") if s.strip()]
+        if args.symlinks else default_symlinks
+    )
+
+    case_order = []
+
+    for case_dir in case_dirs:
+        case_id = case_dir.name
+        case_ws = workspace / "cases" / case_id
+        case_ws.mkdir(parents=True, exist_ok=True)
+
+        # Copy ALL files from the dataset case directory (H-2)
+        for f in case_dir.iterdir():
+            if f.is_file():
+                shutil.copy2(f, case_ws / f.name)
+            elif f.is_dir():
+                shutil.copytree(f, case_ws / f.name, dirs_exist_ok=True)
+
+        # Create output directories
+        for output in config.outputs:
+            if output.path and output.path != ".":
+                out = case_ws / output.path
+                if out.suffix:
+                    out.parent.mkdir(parents=True, exist_ok=True)
+                else:
+                    out.mkdir(parents=True, exist_ok=True)
+
+        # Symlink project resources (skip .claude — we create our own)
+        for name in symlink_names:
+            if name == ".claude":
+                continue
+            p = Path(name)
+            if p.is_absolute() or ".." in p.parts:
+                continue
+            target = project_root / name
+            link = case_ws / name
+            if target.exists() and not link.exists():
+                link.symlink_to(target.resolve())
+
+        # Symlink .claude subdirectories (skills/, etc.)
+        claude_dir = project_root / ".claude"
+        if claude_dir.is_dir():
+            for sub in claude_dir.iterdir():
+                if sub.is_dir() and sub.name != "settings.json":
+                    link = case_ws / ".claude" / sub.name
+                    if not link.exists():
+                        link.parent.mkdir(parents=True, exist_ok=True)
+                        link.symlink_to(sub.resolve())
+
+        # Set up hooks (tool interception + SubagentStop)
+        if config.inputs.tools:
+            _setup_tool_hooks(case_ws, config)
+        else:
+            _setup_subagent_only_hook(case_ws)
+
+        case_order.append({"case_id": case_id})
+
+    # Write case order at the parent workspace level
+    with open(workspace / "case_order.yaml", "w") as f:
+        yaml.dump(case_order, f, default_flow_style=False)
+
+    print(f"WORKSPACE: {workspace}")
+    print(f"MODE: case")
+    print(f"CASES: {len(case_dirs)}")
+    for entry in case_order:
+        print(f"  {entry['case_id']}: {workspace / 'cases' / entry['case_id']}")
 
 
 def _read_input(case_dir):


### PR DESCRIPTION
## Summary

**Problem**: The harness ran the skill once with all cases bundled into `batch.yaml`. Pipeline-style skills (like `test-plan.create`) that expect a single input processed only the first case and exited.

**Solution**: New `execution` config section in eval.yaml:

```yaml
execution:
  mode: per-case              # default: one invocation per case
  arguments: "{strat_key} {adr_file?}"  # resolved per case from input.yaml
```

### What changed

- **config.py**: New `ExecutionConfig` dataclass (`mode`, `arguments`). Default mode is `case`.
- **workspace.py**: New `_create_per_case_workspace()` creates a separate workspace per case with ALL case files copied (input.yaml, strategy.md, answers.yaml, etc.).
- **execute.py**: New `_execute_per_case()` loops through cases, resolves `{field}` placeholders from each case's input.yaml, invokes the skill independently.
- **collect.py**: New `_collect_per_case()` scans per-case workspaces for outputs — simpler than batch (no positional mapping).

### Batch mode preserved

For skills like `rfe.speedrun` that handle batching internally, set `execution.mode: batch` explicitly:

```yaml
execution:
  mode: batch
  arguments: "--input batch.yaml --headless --dry-run"
```

### Gaps closed

| Gap | Description | Fix |
|-----|-------------|-----|
| H-1 | Batch execution runs skill once, not per-case | Per-case loop in execute.py |
| H-2 | Case files not provisioned into workspace | Full case directory copy in workspace.py |
| H-3 | Skill arguments not constructed from input.yaml | `{field}` template resolution per case |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added execution modes (per-case and batch) with support for dynamic argument templates using field placeholders.
  * Per-case execution now processes test cases individually with case-specific configurations.

* **Configuration Changes**
  * Replaced root-level `arguments` field with `execution` block defining execution mode and argument templates.

* **Documentation**
  * Updated configuration templates with examples of per-case and batch execution setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->