### PR TITLE
Prevent preflight --clean from deleting project root

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -7,13 +7,25 @@ from typing import Optional
 import yaml
 
 
-def _validate_relative_path(value: str, field_name: str) -> str:
-    """Reject absolute or parent-traversing paths."""
+def _validate_relative_path(value: str, field_name: str,
+                            reject_root: bool = False) -> str:
+    """Reject absolute or parent-traversing paths.
+
+    Args:
+        reject_root: If True, also reject "." (current directory).
+            Used for output paths where "." would mean the project root
+            and cleaning it would delete the entire project.
+    """
     if not value:
         return value
     p = Path(value)
     if p.is_absolute() or ".." in p.parts:
         raise ValueError(f"{field_name} must be a relative path without '..': {value}")
+    if reject_root and str(p) == ".":
+        raise ValueError(
+            f"{field_name} cannot be '.' (project root) — use a subdirectory. "
+            f"Outputs must be in a named subdirectory so the harness can "
+            f"identify, collect, and clean them without affecting the project.")
     return value
 
 
@@ -163,7 +175,8 @@ class EvalConfig:
         for i, o in enumerate(raw.get("outputs", [])):
             config.outputs.append(OutputConfig(
                 path=_validate_relative_path(
-                    o.get("path", ""), f"outputs[{i}].path"),
+                    o.get("path", ""), f"outputs[{i}].path",
+                    reject_root=True),
                 tool=o.get("tool", ""),
                 schema=o.get("schema", ""),
                 batch_pattern=o.get("batch_pattern", ""),

--- a/skills/eval-run/scripts/preflight.py
+++ b/skills/eval-run/scripts/preflight.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Pre-execution check that project artifact directories are clean.
+"""Pre-execution check that state directories and previous runs are clean.
 
-Skills write artifacts to the project directory (not the workspace).
-Between eval runs, stale artifacts from previous runs contaminate
-results — wrong IDs, stale run reports, inflated file counts.
+Between eval runs, stale state files in tmp/ can contaminate results.
+This script checks for stale state and previous run output, reports
+what it finds, and optionally cleans them.
 
-This script checks all output paths from eval.yaml plus common state
-directories, reports what it finds, and optionally cleans them.
+Output paths from eval.yaml are NOT checked here — they are relative
+to the workspace (created fresh each run), not the project directory.
 
 Usage:
     # Check only (exit 1 if dirty)
@@ -25,13 +25,21 @@ import shutil
 import sys
 from pathlib import Path
 
-import yaml
-
 from agent_eval.config import EvalConfig
 
 
-# State directories that skills write to (not in eval.yaml outputs)
+# State directories that skills write to between runs
 STATE_DIRS = ["tmp"]
+
+
+def _is_dangerous_path(path: Path) -> bool:
+    """Reject paths that are too dangerous to clean.
+
+    Blocks the home directory and the filesystem root. Does NOT use
+    a parents check (every absolute path has / as a parent).
+    """
+    resolved = path.resolve()
+    return resolved in {Path.home().resolve(), Path("/").resolve()}
 
 
 def _find_files(directory: Path) -> list[Path]:
@@ -50,7 +58,9 @@ def main():
     )
     parser.add_argument("--config", default="eval.yaml")
     parser.add_argument("--clean", action="store_true",
-                        help="Remove all found artifacts and state files")
+                        help="Remove stale state files and previous run output")
+    parser.add_argument("--force", action="store_true",
+                        help="Skip confirmation prompt (for non-interactive use)")
     parser.add_argument("--run-id", default=None,
                         help="Also check if eval/runs/<id> already exists")
     args = parser.parse_args()
@@ -59,26 +69,16 @@ def main():
     project_root = Path.cwd()
     runs_dir = Path(os.environ.get("AGENT_EVAL_RUNS_DIR", "eval/runs"))
 
-    # Collect all paths to check
     dirty = {}  # path_label -> list of files
 
-    # 1. Output paths from eval.yaml
-    for output in config.outputs:
-        if not output.path:
-            continue
-        out_path = project_root / output.path
-        files = _find_files(out_path)
-        if files:
-            dirty[output.path] = files
-
-    # 2. State directories
+    # 1. State directories (tmp/)
     for state_dir in STATE_DIRS:
         state_path = project_root / state_dir
         files = _find_files(state_path)
         if files:
             dirty[state_dir] = files
 
-    # 3. Check for existing run output
+    # 2. Previous run output
     run_exists = False
     if args.run_id:
         run_path = project_root / runs_dir / args.run_id
@@ -95,7 +95,6 @@ def main():
     for label, files in sorted(dirty.items()):
         count = len(files)
         total += count
-        # Show a few example filenames
         examples = [f.name for f in files[:5]]
         suffix = f" (+{count - 5} more)" if count > 5 else ""
         print(f"  {label}: {count} files — {', '.join(examples)}{suffix}")
@@ -103,15 +102,33 @@ def main():
     if run_exists:
         run_path = project_root / runs_dir / args.run_id
         run_files = _find_files(run_path)
-        print(f"  {runs_dir}/{args.run_id}: {len(run_files)} files (previous run output)")
+        print(f"  {runs_dir}/{args.run_id}: {len(run_files)} files (previous run)")
 
     if not args.clean:
-        print(f"\n{total} artifact files from previous run(s).")
+        print(f"\n{total} stale files from previous run(s).")
         sys.exit(1)
+
+    # Confirm before cleaning — require --force in non-interactive mode
+    targets = sorted(dirty.keys())
+    if run_exists:
+        targets.append(f"{runs_dir}/{args.run_id}")
+    print(f"\nWill clean: {', '.join(targets)}")
+    if not args.force:
+        if not sys.stdin.isatty():
+            print("--clean requires --force in non-interactive mode.",
+                  file=sys.stderr)
+            sys.exit(1)
+        answer = input("Proceed? [y/N] ").strip().lower()
+        if answer != "y":
+            print("Aborted.")
+            sys.exit(1)
 
     # Clean
     for label, files in dirty.items():
         path = project_root / label
+        if _is_dangerous_path(path):
+            print(f"  SKIPPED (dangerous): {label}", file=sys.stderr)
+            continue
         if path.is_file():
             path.unlink()
         elif path.is_dir():
@@ -121,8 +138,9 @@ def main():
 
     if run_exists and args.run_id:
         run_path = project_root / runs_dir / args.run_id
-        shutil.rmtree(run_path)
-        print(f"  cleaned: {runs_dir}/{args.run_id}")
+        if not _is_dangerous_path(run_path):
+            shutil.rmtree(run_path)
+            print(f"  cleaned: {runs_dir}/{args.run_id}")
 
     print("CLEAN")
 


### PR DESCRIPTION
## Problem

When `outputs.path` was set to `"."` in eval.yaml, `preflight.py --clean` resolved it to the project root and `shutil.rmtree` deleted the entire project directory.

**Root cause**: preflight.py was scanning eval.yaml output paths relative to the project root. But output paths are workspace-relative — the workspace is created fresh each run. Preflight should never touch output paths.

## Fix

**preflight.py**: Remove output path scanning entirely. Only check:
- `tmp/` state files (project-level, persist between runs)
- Previous run output at `$AGENT_EVAL_RUNS_DIR/<run-id>/`

Add confirmation prompt before cleaning (`--force` for CI). Keep `_is_dangerous_path` guard on remaining clean targets.

**config.py**: `_validate_relative_path` now rejects `"."` for output paths (`reject_root=True`) as defense-in-depth — outputs should always be subdirectories, never the project root.

## Test plan

- [ ] `preflight.py --clean` with `outputs.path: "."` in eval.yaml → config load raises ValueError
- [ ] `preflight.py --clean` only removes `tmp/` and previous run dirs, not output dirs
- [ ] `preflight.py --clean` prompts for confirmation on TTY
- [ ] `preflight.py --clean --force` skips prompt (CI use)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Output path validation now rejects root directory references.

* **Improvements**
  * Preflight script refocused to detect stale state with increased safety checks.
  * Cleanup operations now require confirmation and skip risky paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->