### PR TITLE
Inject system prompt to prevent skill from bypassing harness controls

### DIFF
--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -25,6 +25,17 @@ from pathlib import Path
 
 from agent_eval.agent import RUNNERS
 
+_HARNESS_SYSTEM_PROMPT = (
+    "You are running inside an evaluation harness. Tool interception hooks "
+    "and permission controls are in place for safety. You MUST NOT: "
+    "rename, copy, or move scripts to bypass tool filters; "
+    "modify .claude/settings.json or hook scripts; "
+    "disable or work around any harness controls; "
+    "use alternative paths or commands to avoid blocked operations. "
+    "If a tool call is blocked, report it and continue with the remaining "
+    "pipeline steps. Do not attempt workarounds."
+)
+
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__,
@@ -106,6 +117,15 @@ def main():
     timeout_s = args.timeout or opts.get("timeout", 3600)
     max_budget = args.max_budget or opts.get("max_budget_usd", 100.0)
 
+    # Compose system prompt: runner_options.system_prompt (if any) + harness prompt.
+    # The harness prompt is defense-in-depth alongside hook enforcement —
+    # hooks block the tool calls, the prompt prevents the model from wasting
+    # budget on workaround attempts.
+    existing_prompt = ""
+    if isinstance(config.runner_options, dict):
+        existing_prompt = str(config.runner_options.get("system_prompt", "")).strip()
+    system_prompt = "\n\n".join(p for p in [existing_prompt, _HARNESS_SYSTEM_PROMPT] if p)
+
     # Run via the abstraction
     result = runner.run_skill(
         skill_name=args.skill,
@@ -113,6 +133,7 @@ def main():
         workspace=Path(args.workspace),
         model=args.model,
         settings_path=settings_path,
+        system_prompt=system_prompt,
         max_budget_usd=max_budget,
         timeout_s=timeout_s,
     )


### PR DESCRIPTION
## Problem

During eval runs, the evaluated skill worked around tool interception hooks by copying a blocked script (`submit.py`) to a different name that didn't match the filter pattern. This defeats the harness's safety controls.

## Fix

`execute.py` now injects a system prompt via `--append-system-prompt` into every evaluated skill invocation that explicitly forbids:

- Renaming, copying, or moving scripts to bypass tool filters
- Modifying `.claude/settings.json` or hook scripts
- Using alternative paths or commands to avoid blocked operations

If a tool call is blocked, the skill is instructed to report it and continue rather than attempting workarounds.

## Test plan

- [ ] Run an eval where a tool is blocked by input_filters → skill reports the block and continues
- [ ] Skill does not attempt to rename/copy scripts to bypass filters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced safety constraints during skill evaluation by implementing additional guardrails to prevent unauthorized modifications or workaround attempts during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->