### PR TITLE
Restructure eval.yaml into typed config blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,10 @@ skills/eval-optimize/    # Skill: automated refinement loop
 
 Skills projects create an `eval.yaml` config file with:
 - `skill` — skill to evaluate
-- `execution` — `mode` (`case` or `batch`) and `arguments` template with `{field}` placeholders
-- `runner` — agent runner (`claude-code`, etc.), `runner_options` for runner-specific settings
+- `execution` — `mode` (`case` or `batch`), `arguments` template with `{field}` placeholders, optional `timeout`/`max_budget_usd`
+- `runner` — `type` discriminator (`claude-code`, etc.) plus runner-specific `settings`/`plugin_dirs`/`env_strip`/`system_prompt`
+- `models` — defaults for `skill`/`subagent`/`judge` roles (CLI flags override)
+- `mlflow` — `experiment`, optional `tracking_uri`/`tags`
 - `permissions` — `allow`/`deny` tool patterns for headless execution
 - `dataset` — `path` to test cases directory, `schema` describing case structure in natural language
 - `inputs.tools` — tool interception for headless eval: `match` describes what to intercept, `prompt` how to handle it

--- a/README.md
+++ b/README.md
@@ -106,22 +106,35 @@ The harness uses natural language to describe evaluation datasets and skills inp
 name: my-skill-eval
 description: Evaluate the main skill pipeline
 skill: my-skill-name
-runner: claude-code
 
-# Execution — how the skill processes test cases
+# Execution — how the skill processes test cases (runner-agnostic)
 execution:
   mode: case              # case (default) or batch
   arguments: "{prompt}"   # resolved per case from input.yaml fields
+  # timeout: 3600
+  # max_budget_usd: 5.0
+
+# Runner — agent harness + runner-specific knobs
+runner:
+  type: claude-code
+  # settings: {}
+  # plugin_dirs: []
+  # env_strip: [JIRA_TOKEN]
+
+# Models — defaults for each role (CLI flags override)
+models:
+  skill: claude-opus-4-7
+  judge: claude-opus-4-7
+
+# MLflow logging target (optional)
+mlflow:
+  experiment: my-skill-eval
 
 # Permissions — tool access during headless execution
 permissions:
   allow: []            # Tool patterns to allow (empty = all)
   deny:
     - "mcp__*"         # Block MCP tools during eval
-
-# Runner-specific options
-runner_options:
-  settings: ""         # Claude Code settings file
 
 # Dataset — where test cases live and what they look like
 dataset:
@@ -222,7 +235,7 @@ judges:
   # - name: pairwise
   #   description: Compare two runs and pick the better output
   #   prompt_file: eval/prompts/comparison-judge.md
-  #   model: claude-sonnet-4-6
+  #   # model: <model-id>   # Optional override; default is models.judge
 
 # Thresholds for regression detection
 thresholds:
@@ -242,18 +255,25 @@ thresholds:
 - **`context`** — list of file paths loaded and appended to the LLM judge prompt as supplementary material (rubrics, guidelines, examples).
 - **`module`** / **`function`** — external Python code judge for complex validation.
 - **`permissions`** — tool access patterns (`allow`/`deny`) for headless execution. Generic across runners — each runner translates to its platform's mechanism.
-- **`runner_options`** — runner-specific settings (e.g., `settings`, `max_budget_usd` for Claude Code). Ignored by other runners.
+- **`runner`** — `type` discriminator selects the runner implementation; remaining fields (`settings`, `plugin_dirs`, `env_strip`, `system_prompt`) are runner-specific and ignored by other runners.
+- **`models`** — `skill`/`subagent`/`judge` defaults, overridable per-judge or via CLI flags.
+- **`mlflow`** — `experiment` (and optional `tracking_uri`/`tags`) for result logging.
 
 ## Example: eval.yaml for RFE Creator
 
 ```yaml
 name: rfe-creator
 skill: rfe.speedrun
-runner: claude-code
 execution:
   mode: batch
   arguments: "--input batch.yaml --headless --dry-run"
-mlflow_experiment: rfe-eval
+runner:
+  type: claude-code
+models:
+  skill: claude-opus-4-7
+  judge: claude-opus-4-7
+mlflow:
+  experiment: rfe-eval
 permissions:
   deny: ["mcp__atlassian__*"]  # Block Jira writes during eval
 

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -24,23 +24,24 @@ class ClaudeCodeRunner(EvalRunner):
     def __init__(
         self,
         permissions: Optional[dict] = None,
-        runner_options: Optional[dict] = None,
         subagent_model: Optional[str] = None,
         plugin_dirs: Optional[list] = None,
-        mlflow_experiment: Optional[str] = None,
         env_strip: Optional[list] = None,
+        settings: Optional[dict] = None,
+        system_prompt: Optional[str] = None,
+        mlflow_experiment: Optional[str] = None,
+        mlflow_tracking_uri: Optional[str] = None,
         log_prefix: Optional[str] = None,
     ):
-        opts = runner_options or {}
         self._permissions = permissions or {}
         self._subagent_model = subagent_model
-        self._plugin_dirs = plugin_dirs or opts.get("plugin_dirs", [])
+        self._plugin_dirs = plugin_dirs or []
+        self._env_strip = env_strip or []
+        self._settings = settings
+        self._system_prompt = system_prompt
         self._mlflow_experiment = mlflow_experiment
-        self._env_strip = env_strip or opts.get("env_strip", [])
+        self._mlflow_tracking_uri = mlflow_tracking_uri
         self._log_prefix = log_prefix
-        self._settings = opts.get("settings")
-        self._max_budget = opts.get("max_budget_usd")
-        self._system_prompt = opts.get("system_prompt")
 
     @property
     def name(self) -> str:
@@ -263,6 +264,8 @@ class ClaudeCodeRunner(EvalRunner):
             env["CLAUDE_CODE_SUBAGENT_MODEL"] = self._subagent_model
         if self._mlflow_experiment:
             env["MLFLOW_EXPERIMENT_NAME"] = self._mlflow_experiment
+        if self._mlflow_tracking_uri:
+            env["MLFLOW_TRACKING_URI"] = self._mlflow_tracking_uri
         return env
 
 

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -27,7 +27,6 @@ class ClaudeCodeRunner(EvalRunner):
         subagent_model: Optional[str] = None,
         plugin_dirs: Optional[list] = None,
         env_strip: Optional[list] = None,
-        settings: Optional[dict] = None,
         system_prompt: Optional[str] = None,
         mlflow_experiment: Optional[str] = None,
         mlflow_tracking_uri: Optional[str] = None,
@@ -37,7 +36,6 @@ class ClaudeCodeRunner(EvalRunner):
         self._subagent_model = subagent_model
         self._plugin_dirs = plugin_dirs or []
         self._env_strip = env_strip or []
-        self._settings = settings
         self._system_prompt = system_prompt
         self._mlflow_experiment = mlflow_experiment
         self._mlflow_tracking_uri = mlflow_tracking_uri

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -90,9 +90,60 @@ class ExecutionConfig:
     Arguments template placeholders:
     - {field} → substitutes the value of 'field' from input.yaml
     - {field?} → substitutes if present, omitted if missing
+
+    Constraints:
+    - timeout: subprocess wall-clock timeout in seconds (None = harness default).
+    - max_budget_usd: per-invocation cost cap (None = no cap).
     """
     mode: str = "case"
     arguments: str = ""
+    timeout: Optional[int] = None
+    max_budget_usd: Optional[float] = None
+
+
+@dataclass
+class RunnerConfig:
+    """Which agent harness runs the skill, and runner-specific knobs.
+
+    type: discriminator selecting the runner implementation (e.g. claude-code).
+    Other fields are runner-specific; unused fields are harmless for runners
+    that don't read them.
+    """
+    type: str = "claude-code"
+    settings: dict = field(default_factory=dict)
+    plugins: list = field(default_factory=list)
+    plugin_dirs: list = field(default_factory=list)
+    env_strip: list = field(default_factory=list)
+    system_prompt: Optional[str] = None
+
+
+@dataclass
+class MlflowConfig:
+    """MLflow logging target.
+
+    experiment: experiment name (defaults to EvalConfig.name when blank).
+    tracking_uri: MLflow server URI; if unset, falls back to
+        MLFLOW_TRACKING_URI env var.
+    tags: tags applied to every run logged for this eval.
+    """
+    experiment: str = ""
+    tracking_uri: Optional[str] = None
+    tags: dict = field(default_factory=dict)
+
+
+@dataclass
+class ModelsConfig:
+    """Default models for each role.
+
+    Precedence (high to low):
+    - skill: CLI --model > models.skill (must resolve to non-empty)
+    - subagent: CLI --subagent-model > models.subagent > skill model
+    - judge: per-judge JudgeConfig.model > models.judge > EVAL_JUDGE_MODEL
+      env var (must resolve to non-empty for LLM judges)
+    """
+    skill: Optional[str] = None
+    subagent: Optional[str] = None
+    judge: Optional[str] = None
 
 
 @dataclass
@@ -130,13 +181,19 @@ class EvalConfig:
     name: str = ""
     description: str = ""
     skill: str = ""
-    runner: str = "claude-code"
-    runner_options: dict = field(default_factory=dict)
     permissions: dict = field(default_factory=dict)
-    mlflow_experiment: str = ""
 
-    # Execution — how the skill is invoked
+    # Execution — how the skill is invoked (mode, arguments, timeout, budget)
     execution: ExecutionConfig = field(default_factory=ExecutionConfig)
+
+    # Runner — which agent harness + runner-specific config
+    runner: RunnerConfig = field(default_factory=RunnerConfig)
+
+    # Models — default models for skill/subagent/judge roles
+    models: ModelsConfig = field(default_factory=ModelsConfig)
+
+    # MLflow logging target
+    mlflow: MlflowConfig = field(default_factory=MlflowConfig)
 
     # Dataset — natural language schema + path
     dataset_path: str = ""
@@ -181,17 +238,46 @@ class EvalConfig:
         execution = ExecutionConfig(
             mode=exec_raw.get("mode", "case"),
             arguments=exec_raw.get("arguments", ""),
+            timeout=exec_raw.get("timeout"),
+            max_budget_usd=exec_raw.get("max_budget_usd"),
+        )
+
+        # Runner config (block form)
+        runner_raw = raw.get("runner") or {}
+        runner = RunnerConfig(
+            type=runner_raw.get("type", "claude-code"),
+            settings=runner_raw.get("settings", {}) or {},
+            plugins=runner_raw.get("plugins", []) or [],
+            plugin_dirs=runner_raw.get("plugin_dirs", []) or [],
+            env_strip=runner_raw.get("env_strip", []) or [],
+            system_prompt=runner_raw.get("system_prompt"),
+        )
+
+        # Models block
+        models_raw = raw.get("models", {}) or {}
+        models = ModelsConfig(
+            skill=models_raw.get("skill"),
+            subagent=models_raw.get("subagent"),
+            judge=models_raw.get("judge"),
+        )
+
+        # MLflow block (experiment defaults to top-level name)
+        mlflow_raw = raw.get("mlflow", {}) or {}
+        mlflow = MlflowConfig(
+            experiment=mlflow_raw.get("experiment") or raw.get("name", ""),
+            tracking_uri=mlflow_raw.get("tracking_uri"),
+            tags=mlflow_raw.get("tags", {}) or {},
         )
 
         config = cls(
             name=raw.get("name", path.stem),
             description=raw.get("description", ""),
             skill=raw.get("skill", ""),
-            runner=raw.get("runner", "claude-code"),
-            runner_options=raw.get("runner_options", {}),
             permissions=raw.get("permissions", {}),
-            mlflow_experiment=raw.get("mlflow_experiment", raw.get("name", "")),
             execution=execution,
+            runner=runner,
+            models=models,
+            mlflow=mlflow,
             dataset_path=_validate_relative_path(
                 dataset.get("path", ""), "dataset.path"),
             dataset_schema=dataset.get("schema", ""),

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -121,7 +121,10 @@ class RunnerConfig:
 class MlflowConfig:
     """MLflow logging target.
 
-    experiment: experiment name (defaults to EvalConfig.name when blank).
+    experiment: experiment name. Defaults to EvalConfig.name when an
+        `mlflow:` block is present but `experiment` is unset. Stays empty
+        when the eval.yaml has no `mlflow:` block at all — so MLflow
+        tracing/logging is opt-in via the block, not implicit from `name:`.
     tracking_uri: MLflow server URI; if unset, falls back to
         MLFLOW_TRACKING_URI env var.
     tags: tags applied to every run logged for this eval.
@@ -261,10 +264,18 @@ class EvalConfig:
             judge=models_raw.get("judge"),
         )
 
-        # MLflow block (experiment defaults to top-level name)
-        mlflow_raw = raw.get("mlflow", {}) or {}
+        # MLflow block. Experiment defaults to the eval's top-level
+        # `name` only when an `mlflow:` block is present — so omitting
+        # the block entirely leaves MLflow off (no accidental experiment
+        # creation on shared tracking servers).
+        has_mlflow_block = "mlflow" in raw and raw["mlflow"] is not None
+        mlflow_raw = raw.get("mlflow") or {}
+        if has_mlflow_block:
+            experiment = mlflow_raw.get("experiment") or raw.get("name", "")
+        else:
+            experiment = ""
         mlflow = MlflowConfig(
-            experiment=mlflow_raw.get("experiment") or raw.get("name", ""),
+            experiment=experiment,
             tracking_uri=mlflow_raw.get("tracking_uri"),
             tags=mlflow_raw.get("tags", {}) or {},
         )

--- a/agent_eval/mlflow/experiment.py
+++ b/agent_eval/mlflow/experiment.py
@@ -21,6 +21,17 @@ def get_experiment_id(experiment_name: str) -> Optional[str]:
         return None
 
 
+def resolve_tracking_uri(config) -> str:
+    """Resolve MLflow tracking URI with config precedence.
+
+    Precedence: config.mlflow.tracking_uri > MLFLOW_TRACKING_URI env var
+    > local default (http://127.0.0.1:5000).
+    """
+    return (config.mlflow.tracking_uri
+            or os.environ.get("MLFLOW_TRACKING_URI")
+            or "http://127.0.0.1:5000")
+
+
 def setup_experiment(experiment_name: str, tracking_uri: Optional[str] = None):
     """Create or set the MLflow experiment.
 

--- a/eval.yaml
+++ b/eval.yaml
@@ -8,13 +8,28 @@ description: Evaluate the main skill pipeline
 
 # Skill to test
 skill: my-skill-name
-runner: claude-code   # Agent runner: claude-code, opencode, etc.
 
-# Execution — how the skill processes test cases
+# Execution — how the skill processes test cases (runner-agnostic)
 execution:
   mode: case              # per-case (default) or batch
-  arguments: "{prompt}"       # resolved per case from input.yaml fields
+  arguments: "{prompt}"   # resolved per case from input.yaml fields
   # For batch skills: mode: batch, arguments: "--input batch.yaml --headless"
+  # timeout: 3600         # Per-invocation wall-clock timeout (seconds)
+  # max_budget_usd: 5.0   # Per-invocation cost cap
+
+# Runner — agent harness + runner-specific knobs
+runner:
+  type: claude-code              # Discriminator: claude-code, opencode, etc.
+  # settings: {}                 # Claude Code settings overrides
+  # plugin_dirs: []              # Plugin dirs for sub-skills the evaluated skill calls
+  # env_strip: [JIRA_TOKEN]      # Env vars to remove
+  # system_prompt: ""            # Appended to harness system prompt
+
+# Models — defaults for each role (CLI flags override)
+models:
+  skill: claude-opus-4-7         # Required (or pass --model)
+  # subagent: claude-sonnet-4-7  # Defaults to skill model
+  judge: claude-opus-4-7         # Used by LLM and pairwise judges
 
 # Permissions — tool access during headless execution
 permissions:
@@ -22,15 +37,11 @@ permissions:
   deny:                # Tool patterns to block
     - "mcp__*"         # Block all MCP tools during eval
 
-# Runner-specific options (passed to the runner, ignored by others)
-runner_options:
-  settings: ""                   # Claude Code settings file
-  # plugin_dirs: []              # Plugin dirs for sub-skills the evaluated skill calls
-  # max_budget_usd: 5.0         # Per-case budget override
-  # env_strip: [JIRA_TOKEN]     # Env vars to remove
-
-# MLflow experiment name (optional — results logged here)
-mlflow_experiment: my-skill-eval
+# MLflow experiment (optional — results logged here)
+mlflow:
+  experiment: my-skill-eval
+  # tracking_uri: sqlite:///mlflow.db   # Override env var for self-contained runs
+  # tags: { team: ml }
 
 # Dataset — where test cases live and what they look like
 dataset:
@@ -139,7 +150,7 @@ judges:
   # - name: pairwise
   #   description: Compare two runs and pick the better output
   #   prompt_file: eval/prompts/comparison-judge.md
-  #   model: claude-sonnet-4-6
+  #   # model: claude-sonnet-4-7  # Optional override; default is models.judge
 
 # Thresholds for regression detection
 thresholds:

--- a/skills/eval-analyze/SKILL.md
+++ b/skills/eval-analyze/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eval-analyze
-description: Analyze a skill and generate eval.yaml for evaluation. Deeply examines the skill's SKILL.md, sub-skills, scripts, and test cases to produce the full evaluation config — dataset schema, output descriptions, judges, and thresholds. Use this skill whenever someone wants to set up evaluation, test a skill, add quality checks, benchmark a skill, or just created a new skill and needs eval infrastructure. Also triggered automatically by /eval-run when eval.yaml is missing. Even if the user just says "how do I know if my skill is working?" — this is the right starting point.
+description: Analyze a skill and generate eval.yaml for the agent eval harness. Deeply examines the skill's SKILL.md, sub-skills, scripts, and test cases to produce the full evaluation config — execution mode, dataset schema, output descriptions, judges, models, and thresholds. Use this skill whenever someone wants to set up evaluation, test a skill, add quality checks, benchmark a skill, or just created a new skill and needs eval infrastructure. Also triggered automatically by /eval-run when eval.yaml is missing. Even if the user just says "how do I know if my skill is working?" — this is the right starting point.
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent, AskUserQuestion
 ---
@@ -61,7 +61,7 @@ Then check if eval.md (the cached analysis) is still fresh — meaning the SKILL
 python3 ${CLAUDE_SKILL_DIR}/scripts/validate_eval.py memory eval.md
 ```
 
-If FRESH and eval.yaml has a non-empty `dataset.schema`, at least one `outputs` entry with a schema, and at least one judge, report that config is up to date and exit. No work needed. (An INCOMPLETE config with empty sections still needs analysis.)
+If FRESH and eval.yaml has a non-empty `dataset.schema`, at least one `outputs` entry with a schema, at least one judge, and `models.skill` set, report that config is up to date and exit. No work needed. (An INCOMPLETE config — empty sections, or missing `models.skill` from a pre-restructure eval.yaml — still needs analysis.)
 
 If STALE, NO_CONFIG, or `--update` was set, proceed to full analysis.
 
@@ -114,12 +114,15 @@ If no test cases exist, note this clearly and suggest running `/eval-dataset` to
 Combine the skill analysis (Step 3) and dataset exploration (Step 4) into a complete eval.yaml. Read the full template and writing guidance at `${CLAUDE_SKILL_DIR}/references/eval-yaml-template.md`.
 
 Key points:
-- **Execution mode**: determine from the skill analysis whether it expects a single input (`mode: case`) or a batch file (`mode: batch`). Look at `$ARGUMENTS` in the SKILL.md — if it takes one value (a key, prompt, or file path), use `case`. If it takes `--input <file>` with a YAML list, or has parallelism/batch-size controls, use `batch`. When in doubt, use `case`.
-- **Arguments template**: for `case` mode, build a template with `{field}` placeholders matching the input.yaml fields you observed in Step 4 (e.g., `"{strat_key} {adr_file?}"`). For `batch` mode, use the literal arguments string (e.g., `"--input batch.yaml --headless"`).
+- **Execution mode**: determine from the skill analysis whether it expects a single input (`execution.mode: case`) or a batch file (`execution.mode: batch`). Look at `$ARGUMENTS` in the SKILL.md — if it takes one value (a key, prompt, or file path), use `case`. If it takes `--input <file>` with a YAML list, or has parallelism/batch-size controls, use `batch`. When in doubt, use `case`.
+- **Arguments template**: under `execution.arguments`. For `case` mode, build a template with `{field}` placeholders matching the input.yaml fields you observed in Step 4 (e.g., `"{strat_key} {adr_file?}"`). For `batch` mode, use the literal arguments string (e.g., `"--input batch.yaml --headless"`).
+- **Runner**: `runner.type: claude-code` is the default and almost always correct. Only change it if the user has explicitly mentioned another harness.
+- **Models**: set `models.skill` to a sensible default (e.g., `claude-opus-4-7`) so the user doesn't need `--model` on every invocation. Set `models.judge` to the same or a comparable model — LLM and pairwise judges read it. CLI flags override.
+- **MLflow**: set `mlflow.experiment` to `<project>-eval` (or leave blank — it falls back to the top-level `name`).
 - The `dataset.schema` and `outputs[*].schema` fields drive the entire pipeline — be specific, reference actual file/field names you observed
 - If the skill uses AskUserQuestion, calls external services (MCP tools), or runs scripts that interact with APIs, add `inputs.tools` entries. Use `match` to describe what to intercept in natural language (e.g., "any Jira interaction via MCP or scripts"), and `prompt` for how to handle it.
 - Aim for 2-4 inline `check` judges + 1-2 LLM `prompt` judges. Start lean.
-- If `--update`: preserve everything already in the file, only add missing top-level keys
+- If `--update`: preserve everything already in the file, only add missing top-level keys (e.g., add a `models:` block if the user is upgrading from an older config that lacked it)
 
 ## Step 5b: Validate Generated Config
 
@@ -129,7 +132,7 @@ After writing eval.yaml, validate that all references are correct:
 python3 ${CLAUDE_SKILL_DIR}/scripts/validate_eval.py config <config>
 ```
 
-This checks dataset path exists, output paths are relative, judge prompt_file/context/module references resolve, and runner_options.settings exists.
+This checks dataset path exists, output paths are relative, judge prompt_file/context/module references resolve, and runner.settings exists.
 
 **Errors** (exit code 1): fix before proceeding — broken file references, absolute paths, missing modules.
 

--- a/skills/eval-analyze/prompts/analyze-skill.md
+++ b/skills/eval-analyze/prompts/analyze-skill.md
@@ -29,14 +29,14 @@ inputs:
        workspace. List actual filenames you observed in the SKILL.md.>"
 
 outputs:
-  # File artifacts written to disk
+  # File artifacts written to disk — field names match eval.yaml
   - path: "<directory where the pipeline writes final outputs>"
-    description: |
+    schema: |
       <what is produced here — file types, naming patterns, content
        structure. Describe what you actually observed, not generic patterns.>
   # Tool call side effects (if the skill calls external APIs)
   # - tool: "<tool name pattern, e.g. mcp__atlassian__create_issue>"
-  #   description: |
+  #   schema: |
   #     <what this tool call does and what fields in its input/output matter>
 
 sub_skills:
@@ -45,10 +45,14 @@ sub_skills:
     produces: "<what artifacts it writes, if any>"
   # List all sub-skills in pipeline order
 
-execution_mode:
+execution:
+  # Field names match eval.yaml's execution: block — drop them in directly.
   mode: "<case or batch>"
+  arguments: "<template with {field} placeholders from input.yaml>"
   reasoning: |
-    <why you chose this mode — what you observed in the skill>
+    <why you chose this mode — what you observed in the skill.
+     This is analyzer-only context, not copied into eval.yaml.>
+  # mode guidance:
   # case: the skill expects a single input (one problem, one Jira key, one file)
   #   and runs a pipeline on it. $ARGUMENTS is a single value or a few fields.
   #   Examples: /rfe.create "problem statement", /test-plan.create RHAISTRAT-1520
@@ -57,7 +61,7 @@ execution_mode:
   #   Strong signal: the skill has parallelism or batch-size controls
   #   (--batch-size, --parallel, --concurrency).
   #   Examples: /rfe.speedrun --input batch.yaml, /rfe.auto-fix --input ids.yaml
-  arguments_template: "<template with {field} placeholders from input.yaml>"
+  # arguments examples:
   # For case mode: "{prompt}", "{strat_key} {adr_file?}"
   # For batch mode: "--input batch.yaml --headless --dry-run"
 

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -8,9 +8,8 @@ Use this template when generating eval.yaml. Fill in every field from what you o
 name: <project-name>
 description: <one line: what is being evaluated>
 skill: <skill-name>
-runner: claude-code
 
-# Execution — how the skill processes test cases
+# Execution — how the skill processes test cases (runner-agnostic)
 #
 # How to choose the mode:
 # - case (default): the skill expects ONE input and runs a pipeline on it.
@@ -32,19 +31,33 @@ execution:
   arguments: <argument template with {field} placeholders from input.yaml>
   # Case examples: "{prompt}", "{strat_key} {adr_file?}"
   # Batch example: "--input batch.yaml --headless --dry-run"
+  # timeout: 3600           # Per-invocation wall-clock timeout (seconds)
+  # max_budget_usd: 5.0     # Per-invocation cost cap
+
+# Runner — agent harness + runner-specific knobs
+runner:
+  type: claude-code         # Discriminator: claude-code, opencode, etc.
+  # settings: {}            # Runner-specific settings overrides
+  # plugin_dirs: []         # Plugin dirs the evaluated skill needs
+  # env_strip: [JIRA_TOKEN] # Env vars to remove before launching the runner
+  # system_prompt: ""       # Appended to harness system prompt
+
+# Models — defaults for each role (CLI flags override)
+models:
+  skill: <model-id>         # Required (or pass --model)
+  # subagent: <model-id>    # Defaults to skill model
+  judge: <model-id>         # Used by LLM and pairwise judges
 
 # Permissions for headless execution
 permissions:
   allow: []     # Tool patterns to allow (empty = all)
   deny: []      # Tool patterns to block (e.g., "mcp__*")
 
-# Runner-specific options (ignored by other runners)
-runner_options:
-  # settings: eval/config/settings.json
-  # env_strip: [JIRA_TOKEN]
-
-# MLflow experiment (optional)
-mlflow_experiment: <project>-eval
+# MLflow logging target (optional)
+mlflow:
+  experiment: <project>-eval
+  # tracking_uri: sqlite:///mlflow.db   # Override env var for self-contained runs
+  # tags: { team: ml }
 
 # Dataset — describe what you actually observed in the sample case
 dataset:
@@ -128,7 +141,7 @@ judges:
   # - name: pairwise
   #   description: Compare two runs and pick the better output
   #   prompt_file: eval/prompts/comparison-judge.md
-  #   model: claude-sonnet-4-6
+  #   # model: <model-id>   # Optional override; default is models.judge
 
 # Thresholds for regression detection
 thresholds:

--- a/skills/eval-analyze/scripts/validate_eval.py
+++ b/skills/eval-analyze/scripts/validate_eval.py
@@ -106,9 +106,17 @@ def validate_config(path="eval.yaml"):
         if prompt_file and not Path(prompt_file).exists():
             errors.append(f"inputs.tools prompt_file '{prompt_file}' not found")
 
-    settings = config.get("runner_options", {}).get("settings", "")
-    if settings and not Path(settings).exists():
-        errors.append(f"runner_options.settings '{settings}' not found")
+    runner = config.get("runner") or {}
+    settings = runner.get("settings")
+    if isinstance(settings, str) and settings and not Path(settings).exists():
+        errors.append(f"runner.settings '{settings}' not found")
+
+    # --- Models ---
+    models = config.get("models") or {}
+    if not models.get("skill"):
+        warnings.append("No models.skill — eval-run will require --model on every invocation")
+    if not models.get("judge"):
+        warnings.append("No models.judge — LLM/pairwise judges will need EVAL_JUDGE_MODEL or per-judge 'model:'")
 
     # --- Report ---
     if errors:
@@ -121,8 +129,12 @@ def validate_config(path="eval.yaml"):
     elif warnings:
         status = "INCOMPLETE"
 
+    mlflow = config.get("mlflow") or {}
     print(f"{status}: {config.get('name')} (skill={config.get('skill')})")
     print(f"  execution: mode={exec_mode}, arguments={'yes' if execution.get('arguments') else 'no'}")
+    print(f"  runner: {runner.get('type', 'claude-code')}")
+    print(f"  models: skill={models.get('skill', 'unset')}, judge={models.get('judge', 'unset')}")
+    print(f"  mlflow: experiment={mlflow.get('experiment') or config.get('name', 'unset')}")
     print(f"  dataset: {dataset.get('path', 'not set')}")
     print(f"  schema: {'yes' if dataset.get('schema') else 'no'}")
     print(f"  outputs: {len(outputs)} directories")

--- a/skills/eval-mlflow/SKILL.md
+++ b/skills/eval-mlflow/SKILL.md
@@ -33,12 +33,12 @@ print(f'MLFLOW_TRACKING_URI={os.environ.get(\"MLFLOW_TRACKING_URI\", \"not set\"
 "
 ```
 
-If not configured, suggest running `/eval-setup` first. If the server is unreachable but MLFLOW_TRACKING_URI is set (e.g., remote server), proceed — the scripts handle connectivity errors gracefully.
+If not configured, suggest running `/eval-setup` first. The scripts resolve the tracking URI from `mlflow.tracking_uri` in eval.yaml first, then `MLFLOW_TRACKING_URI` env var, then default to `http://127.0.0.1:5000`. If the server is unreachable but a remote URI is set, proceed — the scripts handle connectivity errors gracefully.
 
 ## Step 2: Read Configuration
 
 Read eval.yaml to understand:
-- `mlflow_experiment` — the experiment name
+- `mlflow.experiment` — the experiment name
 - `dataset.path` and `dataset.schema` — where cases are and what they look like
 - `judges` — what was scored (for feedback context)
 
@@ -108,12 +108,12 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/log_results.py \
 ```
 
 This logs:
-- **Params**: skill, runner, model, run_id
+- **Params**: skill, runner.type, model, run_id
 - **Metrics**: per-judge mean and pass_rate, execution metrics (duration, cost, turns), per-model cost/token breakdown
 - **Artifacts**: summary.yaml
 - **Table**: per-case results with case_id, judge, value, rationale
 - **Traces**: one per case (case mode) or one for the run (batch mode), built from stdout.log
-- **Tags**: regressions_detected (yes/no)
+- **Tags**: regressions_detected (yes/no), num_judges, plus any `mlflow.tags` from eval.yaml
 
 ## Step 5: Push Feedback (if `--action push-feedback` or `all`)
 

--- a/skills/eval-mlflow/scripts/attach_feedback.py
+++ b/skills/eval-mlflow/scripts/attach_feedback.py
@@ -39,10 +39,8 @@ except ImportError:
           file=sys.stderr)
     sys.exit(0)
 
-mlflow.set_tracking_uri(os.environ.get("MLFLOW_TRACKING_URI", "http://127.0.0.1:5000"))
-
 from agent_eval.config import EvalConfig
-from agent_eval.mlflow.experiment import log_feedback
+from agent_eval.mlflow.experiment import log_feedback, resolve_tracking_uri
 from agent_eval.mlflow.traces import find_run_traces
 
 
@@ -59,10 +57,11 @@ def main():
     args = parser.parse_args()
 
     config = EvalConfig.from_yaml(args.config)
+    mlflow.set_tracking_uri(resolve_tracking_uri(config))
     runs_dir = Path(os.environ.get("AGENT_EVAL_RUNS_DIR", "eval/runs"))
     run_dir = runs_dir / args.run_id
 
-    experiment_name = config.mlflow_experiment or config.name
+    experiment_name = config.mlflow.experiment or config.name
 
     if args.action == "pull":
         _pull_feedback(run_dir, experiment_name, args)

--- a/skills/eval-mlflow/scripts/from_traces.py
+++ b/skills/eval-mlflow/scripts/from_traces.py
@@ -14,7 +14,6 @@ Usage:
 """
 
 import argparse
-import os
 import sys
 
 import yaml
@@ -26,10 +25,8 @@ except ImportError:
           file=sys.stderr)
     sys.exit(0)
 
-mlflow.set_tracking_uri(os.environ.get("MLFLOW_TRACKING_URI", "http://127.0.0.1:5000"))
-
 from agent_eval.config import EvalConfig
-from agent_eval.mlflow.experiment import get_experiment_id
+from agent_eval.mlflow.experiment import get_experiment_id, resolve_tracking_uri
 from agent_eval.mlflow.traces import extract_trace_inputs
 
 
@@ -44,10 +41,11 @@ def main():
     args = parser.parse_args()
 
     config = EvalConfig.from_yaml(args.config)
-    experiment_name = args.experiment or config.mlflow_experiment or config.name
+    mlflow.set_tracking_uri(resolve_tracking_uri(config))
+    experiment_name = args.experiment or config.mlflow.experiment or config.name
 
     if not experiment_name:
-        print("ERROR: no experiment name (set mlflow_experiment in eval.yaml "
+        print("ERROR: no experiment name (set mlflow.experiment in eval.yaml "
               "or pass --experiment)", file=sys.stderr)
         sys.exit(1)
 

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -28,10 +28,7 @@ except ImportError:
     sys.exit(0)
 
 from agent_eval.config import EvalConfig
-
-# Ensure tracking URI is set — default to localhost server (same as tracing hook)
-_tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "http://127.0.0.1:5000")
-mlflow.set_tracking_uri(_tracking_uri)
+from agent_eval.mlflow.experiment import resolve_tracking_uri
 
 
 # ── Trace builder (extracted to agent_eval/mlflow/trace_builder.py) ──
@@ -49,6 +46,7 @@ def main():
     args = parser.parse_args()
 
     config = EvalConfig.from_yaml(args.config)
+    mlflow.set_tracking_uri(resolve_tracking_uri(config))
     runs_dir = Path(os.environ.get("AGENT_EVAL_RUNS_DIR", "eval/runs"))
     run_dir = runs_dir / args.run_id
 
@@ -69,7 +67,7 @@ def main():
             run_result = json.load(f)
 
     # Set experiment
-    experiment_name = config.mlflow_experiment or config.name
+    experiment_name = config.mlflow.experiment or config.name
     mlflow.set_experiment(experiment_name)
     client = MlflowClient()
 
@@ -83,7 +81,7 @@ def main():
         # ── Params ───────────────────────────────────────────────
         params = {
             "skill": config.skill,
-            "runner": config.runner,
+            "runner": config.runner.type,
             "run_id": args.run_id,
             "model": run_result.get("model", ""),
         }
@@ -154,6 +152,8 @@ def main():
                         has_regressions = True
         mlflow.set_tag("regressions_detected", "yes" if has_regressions else "no")
         mlflow.set_tag("num_judges", str(len(judges)))
+        for tag_key, tag_value in (config.mlflow.tags or {}).items():
+            mlflow.set_tag(tag_key, str(tag_value))
 
         # ── Artifact ─────────────────────────────────────────────
         if summary_path.exists():

--- a/skills/eval-mlflow/scripts/sync_dataset.py
+++ b/skills/eval-mlflow/scripts/sync_dataset.py
@@ -42,10 +42,9 @@ except ImportError:
           file=sys.stderr)
     sys.exit(0)
 
-mlflow.set_tracking_uri(os.environ.get("MLFLOW_TRACKING_URI", "http://127.0.0.1:5000"))
-
 from agent_eval.config import EvalConfig
 from agent_eval.mlflow.datasets import get_or_create_dataset, sync_records
+from agent_eval.mlflow.experiment import resolve_tracking_uri
 
 
 def main():
@@ -59,6 +58,7 @@ def main():
     args = parser.parse_args()
 
     config = EvalConfig.from_yaml(args.config)
+    mlflow.set_tracking_uri(resolve_tracking_uri(config))
 
     # Load mapping
     mapping_path = Path(args.mapping)
@@ -115,7 +115,7 @@ def main():
 
     # Sync to MLflow
     dataset_name = args.dataset_name or config.name or "eval-dataset"
-    experiment_name = config.mlflow_experiment or config.name
+    experiment_name = config.mlflow.experiment or config.name
 
     dataset = get_or_create_dataset(dataset_name, experiment_name)
     if not dataset:

--- a/skills/eval-optimize/SKILL.md
+++ b/skills/eval-optimize/SKILL.md
@@ -13,8 +13,8 @@ The key difference from `/eval-review`: you act autonomously. You read judge rat
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| config (positional) | no | `eval.yaml` | Path to eval config |
-| `--model <model>` | **yes** | — | Model to use for eval runs |
+| `--config <path>` | no | `eval.yaml` | Path to eval config |
+| `--model <model>` | no | `models.skill` from eval.yaml | Model to use for eval runs (overrides config default) |
 | `--max-iterations <N>` | no | 3 | Stop after N improvement cycles |
 | `--run-id <id>` | no | auto-generated | Base run ID (iterations append `-iter-N`) |
 | `--target-judge <name>` | no | all judges | Focus on a specific failing judge |
@@ -30,8 +30,10 @@ python3 -m agent_eval.state init tmp/optimize-config.yaml \
 If no recent eval results exist, run the eval suite first:
 
 ```text
-Use the Skill tool to invoke /eval-run --model <model> --run-id <id>-iter-0 --config <config>
+Use the Skill tool to invoke /eval-run --run-id <id>-iter-0 --config <config> [--model <model>]
 ```
+
+Pass `--model` only if the user provided one — otherwise let `/eval-run` fall back to `models.skill` from eval.yaml. Pass the same model on every iteration for comparable results.
 
 If results already exist (the user just ran `/eval-run`), skip this and use the existing run.
 
@@ -111,7 +113,7 @@ Show each edit before applying. If the change is risky (could affect passing cas
 Run eval again with the baseline flag to detect regressions:
 
 ```text
-Use the Skill tool to invoke /eval-run --model <model> --run-id <id>-iter-<N> --baseline <id>-iter-<N-1> --config <config>
+Use the Skill tool to invoke /eval-run --run-id <id>-iter-<N> --baseline <id>-iter-<N-1> --config <config> [--model <model>]
 ```
 
 Read the new results:

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -15,9 +15,9 @@ Parse `$ARGUMENTS`:
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| config (positional) | no | `eval.yaml` | Path to eval config |
-| `--model <model>` | **yes** | — | Model to use for execution |
-| `--subagent-model <model>` | no | same as model | Model for subagents (e.g., `sonnet` while main is `opus`) |
+| `--config <path>` | no | `eval.yaml` | Path to eval config |
+| `--model <model>` | no | `models.skill` from config | Skill model. Required if `models.skill` is unset in eval.yaml. |
+| `--subagent-model <model>` | no | `models.subagent` → falls back to skill model | Model for subagents (e.g., `claude-sonnet-4-6` while main is `claude-opus-4-7`) |
 | `--skill <name>` | no | from config | Override the skill to test |
 | `--run-id <id>` | no | `YYYY-MM-DD-<model>` | Identifier for this run |
 | `--case <filter>` | no | all cases | Substring match to select cases |
@@ -37,7 +37,7 @@ test -f <config> && echo "CONFIG_EXISTS" || echo "NO_CONFIG"
 Use the Skill tool to invoke /eval-analyze [--skill <skill>]
 ```
 
-Once config exists, read it to extract `skill`, `runner`, `dataset.path`, `outputs`, `inputs.tools`, `traces`, `judges`, and `mlflow_experiment`.
+Once config exists, read it to understand the eval setup — the skill under test, runner, dataset, outputs, judges, models, and any tool interception. The downstream scripts read the same config; you don't need to pass these fields through, just confirm they're present and warn the user about anything missing or surprising.
 
 If `inputs.tools` has entries but the skill uses AskUserQuestion or external APIs, verify the handlers cover those tools. Warn the user if a tool the skill uses isn't intercepted — headless execution may hang.
 
@@ -132,9 +132,13 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
   [--mlflow-experiment <name>]
 ```
 
-Pass `--agent` with the `runner` value from eval.yaml (default: `claude-code`).
+Most flags fall back to the config:
+- `--agent` falls back to `runner.type` (default `claude-code`).
+- `--model` falls back to `models.skill`. If neither is set, execute.py errors out.
+- `--mlflow-experiment` falls back to `mlflow.experiment`.
+- `--skill-args` falls back to `execution.arguments`. In `case` mode, `{field}` placeholders are resolved per case from input.yaml.
 
-The `--skill-args` value is the argument string for the skill invocation (e.g., `"--input batch.yaml --headless"`). If omitted, execute.py uses `execution.arguments` from eval.yaml. In `case` mode, `{field}` placeholders are resolved per case from input.yaml. Override via CLI only when testing different argument combinations.
+Override via CLI only when testing different combinations than what the config specifies.
 
 ### Monitoring Progress
 
@@ -157,33 +161,13 @@ Look for phase markers (`## Phase`, `## Step`, `Batch N/M`), agent counts (`N ag
 
 When you spot an issue, report it to the user with the relevant output lines rather than waiting for completion.
 
-After execution, check the result.
-
-**IMPORTANT**: `run_result.json` is a JSON file written by `execute.py` — do NOT
-use `agent_eval.state init` or `agent_eval.state set` on it (those write YAML,
-which silently corrupts the JSON and causes `report.py` to fail). Use `cat` or
-`python3 -c` to read it:
+After execution, check `run_result.json` for `exit_code`, `duration_s`, `cost_usd`, `num_turns`, and per-model token usage. Read it with `cat` (it's JSON — `agent_eval.state` would corrupt it to YAML).
 
 ```bash
 cat $AGENT_EVAL_RUNS_DIR/<id>/run_result.json
 ```
 
-**run_result.json** contains (all fields written by `execute.py` automatically):
-```json
-{
-  "exit_code": 0,
-  "duration_s": 45.2,
-  "token_usage": {"input": 5000, "output": 2000, "cache_read": 0, "cache_create": 0},
-  "cost_usd": 0.15,
-  "num_turns": 12,
-  "model": "claude-opus-4-6",
-  "subagent_model": "claude-opus-4-6",
-  "agent": "claude-code",
-  "agent_version": "2.1.107"
-}
-```
-
-If `exit_code` is non-zero, report the failure clearly — show the exit code, duration, and the first few lines of `$AGENT_EVAL_RUNS_DIR/<id>/stderr.log`. Do not continue to scoring.
+If `exit_code` is non-zero, report the failure with the exit code, duration, and the first few lines of `$AGENT_EVAL_RUNS_DIR/<id>/stderr.log`. Do not continue to scoring.
 
 ## Step 5: Collect Artifacts
 
@@ -237,27 +221,7 @@ Read the full results:
 python3 -m agent_eval.state read $AGENT_EVAL_RUNS_DIR/<id>/summary.yaml
 ```
 
-**summary.yaml** contains:
-```yaml
-run_id: "2026-04-04-opus"
-judges:
-  has_content:
-    mean: 1.0
-    pass_rate: 1.0
-  output_quality:
-    mean: 4.2
-    pass_rate: null
-per_case:
-  case-001-name:
-    has_content: {value: true, rationale: "Output has 523 chars"}
-    output_quality: {value: 4, rationale: "Good coverage..."}
-pairwise:  # only if --baseline was used
-  run_a: "2026-04-04-opus"
-  run_b: "2026-04-01-sonnet"
-  wins_a: 3
-  wins_b: 1
-  ties: 1
-```
+`summary.yaml` has three sections: `judges` (per-judge `mean` and `pass_rate`), `per_case` (per-case `{value, rationale}` per judge), and `pairwise` (only if `--baseline` was used: `run_a`, `run_b`, `wins_a`, `wins_b`, `ties`).
 
 ## Step 7: Interpret and Report
 
@@ -308,7 +272,7 @@ Suggest next steps (include `--config <config>` if a non-default config was used
 
 ## Step 8: Log to MLflow (optional)
 
-If `mlflow_experiment` is configured in eval.yaml:
+If `mlflow.experiment` is configured in eval.yaml:
 
 ```text
 Use the Skill tool to invoke /eval-mlflow --action log-results --run-id <id> --config <config>

--- a/skills/eval-run/references/tool-interception.md
+++ b/skills/eval-run/references/tool-interception.md
@@ -6,7 +6,7 @@ This documents how `inputs.tools` handlers are resolved and executed during head
 
 1. **eval.yaml** defines handlers with `match` (what to intercept) and `prompt` (how to handle)
 2. **workspace.py** extracts basic tool name patterns from `match` text and writes `tool_handlers.yaml`
-3. **eval-run agent (Step 2b)** reads `tool_handlers.yaml`, interprets the `prompt` field, and adds concrete runtime checks
+3. **eval-run agent (Step 3b)** reads `tool_handlers.yaml`, interprets the `prompt` field, and adds concrete runtime checks
 4. **tools.py** (PreToolUse hook) executes the checks at runtime — no LLM needed during execution
 
 ## tool_handlers.yaml Format
@@ -39,8 +39,8 @@ case_overrides:
 |-------|--------|---------|---------|
 | `match` | workspace.py (from eval.yaml) | eval-run agent | Natural language description of what to intercept |
 | `patterns` | workspace.py (heuristic extraction) | tools.py | Tool name patterns for matching (exact or glob) |
-| `input_filters` | eval-run agent (Step 2b) | tools.py | Regex patterns to match Bash command content. When present with "Bash" in patterns, BOTH must match. |
-| `env_checks` | eval-run agent (Step 2b) | tools.py | Env var validation. Each key is a var name, `must_contain` lists required substrings. All must pass for the tool call to be allowed. |
+| `input_filters` | eval-run agent (Step 3b) | tools.py | Regex patterns to match Bash command content. When present with "Bash" in patterns, BOTH must match. |
+| `env_checks` | eval-run agent (Step 3b) | tools.py | Env var validation. Each key is a var name, `must_contain` lists required substrings. All must pass for the tool call to be allowed. |
 | `prompt` | workspace.py (from eval.yaml) | eval-run agent | Natural language instruction — the agent reads this to generate concrete checks |
 | `case_overrides` | eval-run agent (from dataset answers.yaml) | tools.py | Question → answer map for AskUserQuestion. Checked before auto-accept fallback. |
 
@@ -70,7 +70,7 @@ case_overrides:
 
 Tools with no matching handler pass through (exit 0, no interception).
 
-## What eval-run Agent Does in Step 2b
+## What eval-run Agent Does in Step 3b
 
 Read each handler in `tool_handlers.yaml` and resolve the `prompt` into concrete fields:
 
@@ -91,7 +91,7 @@ Read each handler in `tool_handlers.yaml` and resolve the `prompt` into concrete
   prompt: "Only allow if JIRA_SERVER points to a test instance or emulator."
 ```
 
-**After eval-run agent resolves** (Step 2b):
+**After eval-run agent resolves** (Step 3b):
 ```yaml
 - match: "Any Jira interaction via MCP or scripts calling the Jira API."
   patterns: ["Bash", "mcp__atlassian__*"]

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -100,7 +100,6 @@ def main():
         permissions=config.permissions,
         plugin_dirs=config.runner.plugin_dirs,
         env_strip=config.runner.env_strip,
-        settings=config.runner.settings,
         system_prompt=config.runner.system_prompt,
         subagent_model=subagent_model,
         mlflow_experiment=mlflow_experiment,
@@ -108,9 +107,16 @@ def main():
         log_prefix="eval",
     )
 
-    # Resolve timeout and budget: CLI override > config > defaults
-    timeout_s = args.timeout or config.execution.timeout or 3600
-    max_budget = args.max_budget or config.execution.max_budget_usd or 100.0
+    # Resolve timeout and budget: CLI override > config > defaults.
+    # Use explicit None checks so that 0 is preserved (an operator who
+    # passes --timeout 0 or sets max_budget_usd: 0 in the config gets
+    # exactly that, not the default).
+    timeout_s = (args.timeout if args.timeout is not None
+                 else config.execution.timeout if config.execution.timeout is not None
+                 else 3600)
+    max_budget = (args.max_budget if args.max_budget is not None
+                  else config.execution.max_budget_usd if config.execution.max_budget_usd is not None
+                  else 100.0)
 
     # Compose system prompt: runner.system_prompt (if any) + harness prompt.
     existing_prompt = (config.runner.system_prompt or "").strip()

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -44,21 +44,29 @@ def main():
     parser.add_argument("--skill", required=True)
     parser.add_argument("--skill-args", default=None,
                         help="Skill arguments (default: from eval.yaml execution.arguments)")
-    parser.add_argument("--model", required=True)
+    parser.add_argument("--model", default=None,
+                        help="Skill model (default: from eval.yaml models.skill)")
     parser.add_argument("--output", required=True)
     parser.add_argument("--config", default="eval.yaml",
-                        help="Path to eval.yaml (for permissions and runner_options)")
+                        help="Path to eval.yaml")
     parser.add_argument("--agent", default=None,
-                        help="Agent runner override (default: from config)")
+                        help="Agent runner override (default: from runner.type)")
     parser.add_argument("--subagent-model", default=None)
     parser.add_argument("--max-budget", type=float, default=None)
     parser.add_argument("--timeout", type=int, default=None)
     parser.add_argument("--mlflow-experiment", default=None)
     args = parser.parse_args()
 
-    # Load config for permissions and runner_options
     from agent_eval.config import EvalConfig
     config = EvalConfig.from_yaml(args.config)
+
+    # Resolve model: CLI > config; required to be set somewhere.
+    model = args.model or config.models.skill
+    if not model:
+        print("ERROR: no model specified. Set --model or models.skill in eval.yaml.",
+              file=sys.stderr)
+        sys.exit(1)
+    subagent_model = args.subagent_model or config.models.subagent or model
 
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -79,30 +87,33 @@ def main():
                 skill_args = skill_args.replace("{prompt}", prompt_text.strip())
 
     # Build runner
-    agent = args.agent or config.runner
+    agent = args.agent or config.runner.type
     if agent not in RUNNERS:
         print(f"ERROR: unknown runner '{agent}'. Available: {list(RUNNERS.keys())}",
               file=sys.stderr)
         sys.exit(1)
     runner_cls = RUNNERS[agent]
 
+    mlflow_experiment = args.mlflow_experiment or config.mlflow.experiment
+
     runner = runner_cls(
         permissions=config.permissions,
-        runner_options=config.runner_options,
-        subagent_model=args.subagent_model,
-        mlflow_experiment=args.mlflow_experiment,
+        plugin_dirs=config.runner.plugin_dirs,
+        env_strip=config.runner.env_strip,
+        settings=config.runner.settings,
+        system_prompt=config.runner.system_prompt,
+        subagent_model=subagent_model,
+        mlflow_experiment=mlflow_experiment,
+        mlflow_tracking_uri=config.mlflow.tracking_uri,
         log_prefix="eval",
     )
 
-    # Resolve timeout and budget: CLI override > runner_options > defaults
-    opts = config.runner_options or {}
-    timeout_s = args.timeout or opts.get("timeout", 3600)
-    max_budget = args.max_budget or opts.get("max_budget_usd", 100.0)
+    # Resolve timeout and budget: CLI override > config > defaults
+    timeout_s = args.timeout or config.execution.timeout or 3600
+    max_budget = args.max_budget or config.execution.max_budget_usd or 100.0
 
-    # Compose system prompt: runner_options.system_prompt (if any) + harness prompt.
-    existing_prompt = ""
-    if isinstance(config.runner_options, dict):
-        existing_prompt = str(config.runner_options.get("system_prompt", "")).strip()
+    # Compose system prompt: runner.system_prompt (if any) + harness prompt.
+    existing_prompt = (config.runner.system_prompt or "").strip()
     system_prompt = "\n\n".join(p for p in [existing_prompt, _HARNESS_SYSTEM_PROMPT] if p)
 
     # Capture user-facing eval parameters that defined this run, for the report.
@@ -111,20 +122,22 @@ def main():
     # ── Per-case execution ───────────────────────────────────────
     if config.execution.mode == "case":
         _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
-                          system_prompt, skill_args_template=skill_args,
+                          model, mlflow_experiment, system_prompt,
+                          skill_args_template=skill_args,
                           eval_params=eval_params)
         return
 
     # ── Batch execution (below) ──────────────────────────────────
     print(f"Executing: /{args.skill} {skill_args}", file=sys.stderr)
-    print(f"Agent: {runner.name} | Model: {args.model}", file=sys.stderr)
+    print(f"Agent: {runner.name} | Model: {model}", file=sys.stderr)
     print(f"Workspace: {args.workspace}", file=sys.stderr)
 
     # Set MLflow environment in the workspace settings
-    if args.mlflow_experiment:
+    if mlflow_experiment:
         from agent_eval.mlflow.experiment import inject_tracing_env
         inject_tracing_env(args.workspace, project_root=Path.cwd(),
-                           experiment_name=args.mlflow_experiment)
+                           tracking_uri=config.mlflow.tracking_uri,
+                           experiment_name=mlflow_experiment)
 
     workspace_settings = Path(args.workspace) / ".claude" / "settings.json"
     settings_path = workspace_settings if workspace_settings.exists() else None
@@ -134,14 +147,14 @@ def main():
         skill_name=args.skill,
         args=skill_args,
         workspace=Path(args.workspace),
-        model=args.model,
+        model=model,
         settings_path=settings_path,
         system_prompt=system_prompt,
         max_budget_usd=max_budget,
         timeout_s=timeout_s,
     )
 
-    _save_result(result, args, output_dir, runner, eval_params=eval_params)
+    _save_result(result, args, output_dir, runner, model, eval_params=eval_params)
     sys.exit(result.exit_code)
 
 
@@ -199,7 +212,8 @@ def _build_eval_params(args, config, skill_args, max_budget, timeout_s):
 
 
 def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
-                      system_prompt="", skill_args_template=None, eval_params=None):
+                      model, mlflow_experiment, system_prompt="",
+                      skill_args_template=None, eval_params=None):
     """Execute the skill once per case with case-specific arguments.
 
     `skill_args_template` is the resolved invocation pattern (CLI override
@@ -223,7 +237,7 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
 
     print(f"Executing: /{args.skill} (per-case, {len(case_order)} cases)",
           file=sys.stderr)
-    print(f"Agent: {runner.name} | Model: {args.model}", file=sys.stderr)
+    print(f"Agent: {runner.name} | Model: {model}", file=sys.stderr)
 
     case_results = {}
     worst_exit = 0
@@ -246,10 +260,11 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
                 case_args = _resolve_arguments(case_args, case_data)
 
         # Set MLflow environment per case workspace
-        if args.mlflow_experiment:
+        if mlflow_experiment:
             from agent_eval.mlflow.experiment import inject_tracing_env
             inject_tracing_env(str(case_ws), project_root=Path.cwd(),
-                               experiment_name=args.mlflow_experiment)
+                               tracking_uri=config.mlflow.tracking_uri,
+                               experiment_name=mlflow_experiment)
 
         case_settings = case_ws / ".claude" / "settings.json"
         settings_path = case_settings if case_settings.exists() else None
@@ -261,7 +276,7 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
             skill_name=args.skill,
             args=case_args,
             workspace=case_ws,
-            model=args.model,
+            model=model,
             settings_path=settings_path,
             system_prompt=system_prompt,
             max_budget_usd=max_budget,
@@ -313,7 +328,7 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
         "duration_s": round(total_duration, 1),
         "cost_usd": round(total_cost, 2),
         "num_cases": len(case_results),
-        "model": args.model,
+        "model": model,
         "agent": runner.name,
         "agent_version": getattr(runner, "version", ""),
         "execution_mode": "case",
@@ -334,7 +349,7 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
     sys.exit(worst_exit)
 
 
-def _save_result(result, args, output_dir, runner, eval_params=None):
+def _save_result(result, args, output_dir, runner, model, eval_params=None):
     """Save batch execution results (stdout, stderr, run_result.json)."""
     if result.stdout:
         (output_dir / "stdout.log").write_text(result.stdout)
@@ -352,7 +367,7 @@ def _save_result(result, args, output_dir, runner, eval_params=None):
             if f.is_file() and not f.is_symlink() and f.suffix == ".jsonl":
                 shutil.copy2(f, out_subagents / f.name)
 
-    full_model = result.resolved_model or args.model
+    full_model = result.resolved_model or model
     models_used = result.models_used or []
     subagent_models = [m for m in models_used if m != full_model]
     subagent_model_str = ", ".join(subagent_models) if subagent_models else full_model

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -750,7 +750,9 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
 
     # Build judge type/model lookup from config
     judge_info = {}
-    default_model = os.environ.get("EVAL_JUDGE_MODEL", "claude-sonnet-4-6@20250514")
+    default_model = (config.get("models", {}).get("judge")
+                     or os.environ.get("EVAL_JUDGE_MODEL")
+                     or "—")
     for jc in config.get("judges", []):
         jname = jc.get("name", "")
         if jc.get("check"):

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -208,7 +208,7 @@ def load_judges(config, project_root=None):
         if jc.check:
             scorer = _make_inline_check(jc)
         elif jc.prompt or jc.prompt_file:
-            scorer = _load_llm_judge(jc, project_root)
+            scorer = _load_llm_judge(jc, config, project_root)
         elif jc.module and jc.function:
             scorer = _load_code_judge(jc, project_root)
         else:
@@ -310,7 +310,18 @@ def _load_code_judge(jc, project_root=None):
     return getattr(mod, jc.function)
 
 
-def _load_llm_judge(jc, project_root=None):
+def _resolve_judge_model(jc, config):
+    """Resolve LLM judge model: per-judge > models.judge > env > error."""
+    model = jc.model or config.models.judge or os.environ.get("EVAL_JUDGE_MODEL")
+    if not model:
+        raise RuntimeError(
+            f"No model configured for LLM judge '{jc.name}'. Set per-judge "
+            "'model:', top-level 'models.judge:' in eval.yaml, or "
+            "EVAL_JUDGE_MODEL env var.")
+    return model
+
+
+def _load_llm_judge(jc, config, project_root=None):
     root = Path(project_root).resolve() if project_root else Path.cwd().resolve()
     prompt = jc.prompt
     if not prompt and jc.prompt_file:
@@ -335,7 +346,8 @@ def _load_llm_judge(jc, project_root=None):
     # Use direct Anthropic client when Vertex AI is configured (MLflow's
     # make_judge uses litellm which requires OpenAI API key by default)
     if os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID") or os.environ.get("ANTHROPIC_API_KEY"):
-        return _make_anthropic_llm_judge(jc.name, prompt)
+        judge_model = _resolve_judge_model(jc, config)
+        return _make_anthropic_llm_judge(jc.name, prompt, judge_model)
 
     # MLflow make_judge (requires OpenAI-compatible API key)
     try:
@@ -351,7 +363,7 @@ def _load_llm_judge(jc, project_root=None):
                        "ANTHROPIC_API_KEY, or OPENAI_API_KEY")
 
 
-def _make_anthropic_llm_judge(name, prompt):
+def _make_anthropic_llm_judge(name, prompt, judge_model):
     """Create an LLM judge using the Anthropic client directly.
 
     Falls back to this when MLflow make_judge fails (e.g., no OpenAI key).
@@ -371,8 +383,6 @@ def _make_anthropic_llm_judge(name, prompt):
                 output_text += f"\n### {path}\n\n{content}\n"
             rendered_prompt = rendered_prompt.replace("{{ outputs }}", output_text)
 
-        # Use the best available model; fall back through options
-        judge_model = os.environ.get("EVAL_JUDGE_MODEL", "claude-sonnet-4-6")
         response = client.messages.create(
             model=judge_model,
             max_tokens=1024,
@@ -449,7 +459,7 @@ class PairwiseResult:
 
 
 def compare_runs(run_a_dir, run_b_dir, config, case_ids,
-                 prompt=None, prompt_file=None, model="claude-sonnet-4-6"):
+                 prompt=None, prompt_file=None, model=None):
     """Compare two runs using position-swapped LLM judge."""
     comparison_prompt = prompt
     if not comparison_prompt and prompt_file:
@@ -731,7 +741,15 @@ def cmd_pairwise(args):
         pairwise_jc = next((j for j in config.judges
                             if j.prompt or j.prompt_file), None)
 
-    model = args.model or (pairwise_jc.model if pairwise_jc else "") or "claude-sonnet-4-6"
+    model = (args.model
+             or (pairwise_jc.model if pairwise_jc else "")
+             or config.models.judge
+             or os.environ.get("EVAL_JUDGE_MODEL"))
+    if not model:
+        print("ERROR: no pairwise judge model configured. Set --model, "
+              "pairwise judge 'model:', 'models.judge:' in eval.yaml, or "
+              "EVAL_JUDGE_MODEL env var.", file=sys.stderr)
+        sys.exit(1)
     prompt_file = args.prompt_file or (pairwise_jc.prompt_file if pairwise_jc else "")
 
     print(f"Pairwise comparison: {args.run_id} vs {args.baseline} "

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -156,7 +156,7 @@ def main():
     else:
         # Even without tool interception, set up SubagentStop hook
         # to capture background agent transcripts for tracing.
-        _setup_subagent_only_hook(workspace)
+        _setup_subagent_only_hook(workspace, config)
 
     print(f"WORKSPACE: {workspace}")
     print(f"CASES: {len(case_dirs)}")
@@ -228,7 +228,7 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
         if config.inputs.tools:
             _setup_tool_hooks(case_ws, config)
         else:
-            _setup_subagent_only_hook(case_ws)
+            _setup_subagent_only_hook(case_ws, config)
 
         case_order.append({"case_id": case_id})
 
@@ -342,7 +342,31 @@ def _carry_over_permissions(settings):
             "additionalDirectories", []).extend(dirs)
 
 
-def _setup_subagent_only_hook(workspace):
+def _deep_merge(dst, src):
+    """Recursively merge src into dst. Lists are extended, dicts merged."""
+    for k, v in src.items():
+        if isinstance(v, dict) and isinstance(dst.get(k), dict):
+            _deep_merge(dst[k], v)
+        elif isinstance(v, list) and isinstance(dst.get(k), list):
+            dst[k].extend(v)
+        else:
+            dst[k] = v
+    return dst
+
+
+def _apply_runner_settings(settings, config):
+    """Merge eval.yaml `runner.settings` into the workspace settings dict.
+
+    Lets users add Claude Code settings (model defaults, env, MCP servers,
+    etc.) to a runner without forking the harness. Merged after harness
+    defaults so user overrides win for scalar keys; lists are extended.
+    """
+    user_settings = getattr(config.runner, "settings", None) or {}
+    if user_settings:
+        _deep_merge(settings, user_settings)
+
+
+def _setup_subagent_only_hook(workspace, config):
     """Set up SubagentStop hook without tool interception.
 
     When there are no inputs.tools, we still need the SubagentStop hook
@@ -369,6 +393,9 @@ def _setup_subagent_only_hook(workspace):
     from agent_eval.agent.stream_capture import setup_subagent_hook
     subagent_dir = str((workspace / "subagents").resolve())
     setup_subagent_hook(settings, subagent_dir)
+
+    # Apply user-provided runner.settings last so they can override defaults
+    _apply_runner_settings(settings, config)
 
     with open(settings_dir / "settings.json", "w") as f:
         _json.dump(settings, f, indent=2)
@@ -464,6 +491,9 @@ def _setup_tool_hooks(workspace, config):
     from agent_eval.agent.stream_capture import setup_subagent_hook
     subagent_dir = str((workspace / "subagents").resolve())
     setup_subagent_hook(settings, subagent_dir)
+
+    # Apply user-provided runner.settings last so they can override defaults
+    _apply_runner_settings(settings, config)
 
     with open(settings_dir / "settings.json", "w") as f:
         _json.dump(settings, f, indent=2)

--- a/skills/eval-setup/SKILL.md
+++ b/skills/eval-setup/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Bash, Glob, AskUserQuestion
 
 You are an environment configurator. You ensure the evaluation harness is ready to run — dependencies installed, API keys set, MLflow configured, directories created. Non-destructive: skip steps that are already done, report status.
 
-After setup, the pipeline is: `/eval-analyze` → `/eval-dataset` → `/eval-run` → `/eval-review` or `/eval-optimize` → `/eval-mlflow`.
+After setup, the pipeline is: `/eval-analyze` → `/eval-dataset` → `/eval-run` → `/eval-review` or `/eval-optimize`. `/eval-mlflow` can be invoked at any point after `/eval-run` to log results, sync datasets, or push/pull feedback — `/eval-run` already auto-logs results when `mlflow.experiment` is set in eval.yaml.
 
 ## Step 0: Parse Arguments
 
@@ -84,6 +84,8 @@ echo "MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI:-not set}"
 3. **Remote server** (Databricks, etc.):
    Ask the user for their tracking URI and verify connectivity.
 
+**Per-project pinning**: To pin a tracking URI to a specific eval suite (overriding the env var), set `mlflow.tracking_uri` in eval.yaml. Useful when one machine runs evals against multiple servers. The harness resolves URIs in this order: `mlflow.tracking_uri` in eval.yaml > `MLFLOW_TRACKING_URI` env var > `http://127.0.0.1:5000`.
+
 ## Step 4: Configure API Keys
 
 Check authentication:
@@ -124,7 +126,7 @@ Tracing is configured automatically — `/eval-run` injects the MLflow Stop hook
 
 If `--skip-mlflow` was passed, skip this step.
 
-Check if eval.yaml exists and has `mlflow_experiment` configured:
+Check if eval.yaml exists and has `mlflow.experiment` configured:
 
 ```bash
 test -f eval.yaml && echo "CONFIG_EXISTS" || echo "NO_CONFIG"
@@ -135,13 +137,13 @@ If eval.yaml exists:
 ```bash
 python3 -c "
 from agent_eval.config import EvalConfig
-from agent_eval.mlflow.experiment import setup_experiment
+from agent_eval.mlflow.experiment import setup_experiment, resolve_tracking_uri
 config = EvalConfig.from_yaml('eval.yaml')
-if config.mlflow_experiment:
-    setup_experiment(config.mlflow_experiment)
-    print(f'Experiment created: {config.mlflow_experiment}')
+if config.mlflow.experiment:
+    setup_experiment(config.mlflow.experiment, tracking_uri=resolve_tracking_uri(config))
+    print(f'Experiment created: {config.mlflow.experiment} on {resolve_tracking_uri(config)}')
 else:
-    print('No mlflow_experiment in eval.yaml, skipping')
+    print('No mlflow.experiment in eval.yaml, skipping')
 "
 ```
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,117 @@
+"""Config schema parsing tests."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure agent_eval is importable
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.config import EvalConfig, JudgeConfig, ModelsConfig
+from score import _resolve_judge_model
+
+
+def _write(tmp_path, body):
+    p = tmp_path / "eval.yaml"
+    p.write_text(body)
+    return p
+
+
+def test_execution_block_parses(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+skill: s
+execution:
+  mode: batch
+  arguments: "--in batch.yaml"
+  timeout: 1800
+  max_budget_usd: 25.5
+"""))
+    assert cfg.execution.mode == "batch"
+    assert cfg.execution.arguments == "--in batch.yaml"
+    assert cfg.execution.timeout == 1800
+    assert cfg.execution.max_budget_usd == 25.5
+
+
+def test_runner_block_parses(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+skill: s
+runner:
+  type: claude-code
+  plugin_dirs:
+    - /tmp/p
+  env_strip:
+    - FOO
+  settings:
+    a: 1
+  system_prompt: "be careful"
+"""))
+    assert cfg.runner.type == "claude-code"
+    assert cfg.runner.plugin_dirs == ["/tmp/p"]
+    assert cfg.runner.env_strip == ["FOO"]
+    assert cfg.runner.settings == {"a": 1}
+    assert cfg.runner.system_prompt == "be careful"
+
+
+def test_runner_type_default(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, "name: t\nskill: s\n"))
+    assert cfg.runner.type == "claude-code"
+
+
+def test_models_block_defaults(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+skill: s
+models:
+  skill: claude-opus-4-7
+  judge: claude-opus-4-7
+"""))
+    assert cfg.models.skill == "claude-opus-4-7"
+    assert cfg.models.subagent is None
+    assert cfg.models.judge == "claude-opus-4-7"
+
+
+def test_mlflow_block_parses(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+skill: s
+mlflow:
+  experiment: e1
+  tracking_uri: sqlite:///x.db
+  tags:
+    team: ml
+"""))
+    assert cfg.mlflow.experiment == "e1"
+    assert cfg.mlflow.tracking_uri == "sqlite:///x.db"
+    assert cfg.mlflow.tags == {"team": "ml"}
+
+
+def test_mlflow_experiment_defaults_to_name(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, "name: my-eval\nskill: s\n"))
+    assert cfg.mlflow.experiment == "my-eval"
+
+
+def test_judge_model_resolution_precedence(tmp_path, monkeypatch):
+    """Per-judge `model:` > config.models.judge > EVAL_JUDGE_MODEL > error."""
+    cfg = EvalConfig(name="t", skill="s")
+
+    # 1. Per-judge model wins
+    jc = JudgeConfig(name="j", model="per-judge-model")
+    cfg.models = ModelsConfig(judge="config-judge")
+    monkeypatch.setenv("EVAL_JUDGE_MODEL", "env-model")
+    assert _resolve_judge_model(jc, cfg) == "per-judge-model"
+
+    # 2. config.models.judge used when per-judge unset
+    jc = JudgeConfig(name="j")
+    assert _resolve_judge_model(jc, cfg) == "config-judge"
+
+    # 3. env var used when both unset
+    cfg.models = ModelsConfig()
+    assert _resolve_judge_model(jc, cfg) == "env-model"
+
+    # 4. error when nothing set
+    monkeypatch.delenv("EVAL_JUDGE_MODEL", raising=False)
+    with pytest.raises(RuntimeError, match="No model configured"):
+        _resolve_judge_model(jc, cfg)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -88,9 +88,21 @@ mlflow:
     assert cfg.mlflow.tags == {"team": "ml"}
 
 
-def test_mlflow_experiment_defaults_to_name(tmp_path):
-    cfg = EvalConfig.from_yaml(_write(tmp_path, "name: my-eval\nskill: s\n"))
+def test_mlflow_experiment_defaults_to_name_when_block_present(tmp_path):
+    """`mlflow:` block present but no `experiment:` → fall back to eval name."""
+    cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: my-eval
+skill: s
+mlflow:
+  tracking_uri: sqlite:///x.db
+"""))
     assert cfg.mlflow.experiment == "my-eval"
+
+
+def test_mlflow_disabled_when_block_absent(tmp_path):
+    """No `mlflow:` block → experiment empty, MLflow logging off."""
+    cfg = EvalConfig.from_yaml(_write(tmp_path, "name: my-eval\nskill: s\n"))
+    assert cfg.mlflow.experiment == ""
 
 
 def test_judge_model_resolution_precedence(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Group eval.yaml top-level fields into typed blocks: `execution`, `runner`, `models`, `mlflow`. Remove legacy migration handling — schema is internal.
- Add `resolve_tracking_uri(config)` helper (mlflow.tracking_uri > env > localhost) and apply it in mlflow scripts so per-eval pinning works without env vars. Apply `mlflow.tags` to logged runs.
- Align CLAUDE.md, README, and all eval-* skill docs/prompts/references with the new schema. Document the judge model precedence, switch positional config args to `--config <path>`, and make `--model` optional on `/eval-optimize` (falls back to `models.skill`).

## Test plan
- [x] `pytest tests/` — all 39 tests pass
- [ ] Smoke test `/eval-run --config eval.yaml` against an eval suite
- [ ] Verify `mlflow.tracking_uri` from eval.yaml overrides env var
- [ ] Verify `/eval-optimize` runs without `--model` when `models.skill` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restructured eval config: typed `runner`, top-level `models` defaults, and `mlflow` object for clearer defaults and overrides
  * Per-invocation execution controls: `execution.timeout` and `execution.max_budget_usd`
  * MLflow tracking URI configurable in eval.yaml with precedence over env var; `mlflow.experiment` key supported
  * CLI updates: `--config` flag, `--model` optional (defaults to `models.skill`), and runner/model resolution now follow config-first precedence

* **Documentation**
  * Updated examples, templates, and guidance to reflect new config shape and MLflow/model resolution rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->