### PR TITLE
Add runner.effort config option

### DIFF
--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -21,6 +21,8 @@ _print_lock = threading.Lock()
 class ClaudeCodeRunner(EvalRunner):
     """Runs skills using the Claude Code CLI in non-interactive mode."""
 
+    _VALID_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
+
     def __init__(
         self,
         permissions: Optional[dict] = None,
@@ -31,6 +33,7 @@ class ClaudeCodeRunner(EvalRunner):
         mlflow_experiment: Optional[str] = None,
         mlflow_tracking_uri: Optional[str] = None,
         log_prefix: Optional[str] = None,
+        effort: Optional[str] = None,
     ):
         self._permissions = permissions or {}
         self._subagent_model = subagent_model
@@ -40,6 +43,11 @@ class ClaudeCodeRunner(EvalRunner):
         self._mlflow_experiment = mlflow_experiment
         self._mlflow_tracking_uri = mlflow_tracking_uri
         self._log_prefix = log_prefix
+        if effort and effort not in self._VALID_EFFORTS:
+            raise ValueError(
+                f"Invalid effort '{effort}'. "
+                f"Must be one of: {sorted(self._VALID_EFFORTS)}")
+        self._effort = effort
 
     @property
     def name(self) -> str:
@@ -78,6 +86,9 @@ class ClaudeCodeRunner(EvalRunner):
         ]
         if self._log_prefix:
             cmd.append("--verbose")
+
+        if self._effort:
+            cmd.extend(["--effort", self._effort])
 
         for plugin_dir in self._plugin_dirs:
             cmd.extend(["--plugin-dir", str(plugin_dir)])

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -115,6 +115,7 @@ class RunnerConfig:
     plugin_dirs: list = field(default_factory=list)
     env_strip: list = field(default_factory=list)
     system_prompt: Optional[str] = None
+    effort: Optional[str] = None  # Claude Code: low | medium | high | xhigh | max
 
 
 @dataclass
@@ -254,6 +255,7 @@ class EvalConfig:
             plugin_dirs=runner_raw.get("plugin_dirs", []) or [],
             env_strip=runner_raw.get("env_strip", []) or [],
             system_prompt=runner_raw.get("system_prompt"),
+            effort=runner_raw.get("effort"),
         )
 
         # Models block

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -41,6 +41,7 @@ runner:
   # plugin_dirs: []         # Plugin dirs the evaluated skill needs
   # env_strip: [JIRA_TOKEN] # Env vars to remove before launching the runner
   # system_prompt: ""       # Appended to harness system prompt
+  # effort: high            # Claude Code reasoning effort: low | medium | high | xhigh | max
 
 # Models — defaults for each role (CLI flags override)
 models:

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -24,6 +24,7 @@ Parse `$ARGUMENTS`:
 | `--baseline <run-id>` | no | — | Previous run to compare against |
 | `--no-judge` | no | false | Skip LLM judges, run inline checks only |
 | `--gold` | no | false | Save outputs as gold references after run |
+| `--effort <level>` | no | `runner.effort` from config | Claude Code reasoning effort (`low`/`medium`/`high`/`xhigh`/`max`) |
 
 Check if the config file exists (use the parsed config path, not hardcoded `eval.yaml`):
 
@@ -129,7 +130,8 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
   --output $AGENT_EVAL_RUNS_DIR/<id> \
   [--agent <runner>] \
   [--subagent-model <model>] \
-  [--mlflow-experiment <name>]
+  [--mlflow-experiment <name>] \
+  [--effort <level>]
 ```
 
 Most flags fall back to the config:
@@ -137,6 +139,7 @@ Most flags fall back to the config:
 - `--model` falls back to `models.skill`. If neither is set, execute.py errors out.
 - `--mlflow-experiment` falls back to `mlflow.experiment`.
 - `--skill-args` falls back to `execution.arguments`. In `case` mode, `{field}` placeholders are resolved per case from input.yaml.
+- `--effort` falls back to `runner.effort` (Claude Code only; ignored by other runners).
 
 Override via CLI only when testing different combinations than what the config specifies.
 

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -55,6 +55,9 @@ def main():
     parser.add_argument("--max-budget", type=float, default=None)
     parser.add_argument("--timeout", type=int, default=None)
     parser.add_argument("--mlflow-experiment", default=None)
+    parser.add_argument("--effort", default=None,
+                        choices=["low", "medium", "high", "xhigh", "max"],
+                        help="Claude Code reasoning effort (default: from eval.yaml runner.effort)")
     args = parser.parse_args()
 
     from agent_eval.config import EvalConfig
@@ -95,6 +98,7 @@ def main():
     runner_cls = RUNNERS[agent]
 
     mlflow_experiment = args.mlflow_experiment or config.mlflow.experiment
+    effort = args.effort or config.runner.effort
 
     runner = runner_cls(
         permissions=config.permissions,
@@ -105,6 +109,7 @@ def main():
         mlflow_experiment=mlflow_experiment,
         mlflow_tracking_uri=config.mlflow.tracking_uri,
         log_prefix="eval",
+        effort=effort,
     )
 
     # Resolve timeout and budget: CLI override > config > defaults.
@@ -123,7 +128,7 @@ def main():
     system_prompt = "\n\n".join(p for p in [existing_prompt, _HARNESS_SYSTEM_PROMPT] if p)
 
     # Capture user-facing eval parameters that defined this run, for the report.
-    eval_params = _build_eval_params(args, config, skill_args, max_budget, timeout_s)
+    eval_params = _build_eval_params(args, config, skill_args, max_budget, timeout_s, effort)
 
     # ── Per-case execution ───────────────────────────────────────
     if config.execution.mode == "case":
@@ -196,13 +201,15 @@ def _resolve_arguments(template, case_data):
     return result
 
 
-def _build_eval_params(args, config, skill_args, max_budget, timeout_s):
+def _build_eval_params(args, config, skill_args, max_budget, timeout_s, effort=None):
     """Snapshot the user-facing eval parameters that defined this run.
 
     Surfaced in the HTML report so reviewers can see *what was run* without
     inspecting the harness invocation. Only includes parameters that are
     meaningful to a reader: the dataset/skill args, budget caps, execution
-    mode, and optional flags actually set."""
+    mode, and optional flags actually set. Resolved values (effort, budget,
+    timeout) are passed in so the snapshot reflects what actually ran, not
+    just what was overridden via CLI."""
     params = {
         "skill": args.skill,
         "skill_args": skill_args or "",
@@ -210,8 +217,8 @@ def _build_eval_params(args, config, skill_args, max_budget, timeout_s):
         "max_budget_usd": max_budget,
         "timeout_s": timeout_s,
     }
-    if getattr(args, "effort", None):
-        params["effort"] = args.effort
+    if effort:
+        params["effort"] = effort
     if getattr(args, "mlflow_experiment", None):
         params["mlflow_experiment"] = args.mlflow_experiment
     return params

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -462,6 +462,7 @@ def _render_run_config(run_result, baseline_result=None):
     fields = [
         ("Model", "model"),
         ("Subagent Model", "subagent_model"),
+        ("Effort", "effort"),
         ("Agent", "agent"),
         ("Agent Version", "agent_version"),
         ("Duration", "duration_s"),
@@ -471,6 +472,16 @@ def _render_run_config(run_result, baseline_result=None):
     ]
     # Numeric fields where a baseline delta is meaningful (lower is better)
     numeric_lower_better = {"duration_s", "cost_usd", "num_turns"}
+    # Optional fields that are hidden when not set on either run, to avoid
+    # showing rows of "—" for knobs the user isn't using (e.g. effort).
+    optional_fields = {"effort"}
+
+    def _lookup(rr, key):
+        if not rr:
+            return None
+        if key in rr:
+            return rr.get(key)
+        return (rr.get("eval_params") or {}).get(key)
 
     def _fmt(key, val):
         if val is None or val == "":
@@ -509,13 +520,18 @@ def _render_run_config(run_result, baseline_result=None):
 
     html = '<h2>Run Configuration</h2>\n<dl class="config-grid">\n'
     for label, key in fields:
-        cur_raw = run_result.get(key)
+        cur_raw = _lookup(run_result, key)
         cur = _fmt(key, cur_raw)
+        # Hide optional knobs (e.g. effort) when neither side set them, to
+        # avoid showing a row of "—" for a feature the user isn't using.
+        if (key in optional_fields and cur == "—"
+                and (not has_bl or _fmt(key, _lookup(baseline_result, key)) == "—")):
+            continue
         html += '<div class="kv">'
         html += f'<dt>{label}</dt>'
         html += f'<dd>{_esc(cur)}</dd>'
         if has_bl:
-            bl_raw = baseline_result.get(key)
+            bl_raw = _lookup(baseline_result, key)
             bl = _fmt(key, bl_raw)
             if bl != cur:
                 d = _scalar_delta(key, cur_raw, bl_raw)


### PR DESCRIPTION
## Summary
- Plumb a Claude Code reasoning-effort knob (`low/medium/high/xhigh/max`) through the harness.
- Configurable via `runner.effort` in `eval.yaml`, overridable per-run with `--effort` on `/eval-run`, validated in the runner constructor.
- Surfaced in the HTML report; the row hides itself when no run sets it.

## Test plan
- [ ] Run an eval with `runner.effort: high` in eval.yaml and confirm Claude Code is invoked with `--effort high`.
- [ ] Override with `/eval-run --effort low` and confirm CLI flag wins over config.
- [ ] Pass an invalid effort and confirm the runner raises `ValueError`.
- [ ] Inspect HTML report — Effort row appears for runs that set it, hides for runs that don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable effort levels for Claude Code reasoning operations, allowing control over reasoning depth and execution speed balance. Configure via YAML file or CLI flag with options: low, medium, high, xhigh, max.
  * Effort settings are now displayed in run configuration reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->