### PR TITLE
Support [1m] context-window suffix in model names

### DIFF
--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -110,11 +110,12 @@ def main():
         # ── Per-model cost and token breakdown ───────────────────
         per_model = run_result.get("per_model_usage", {})
         if per_model:
+            import re
             for model_name, stats in per_model.items():
                 # Sanitize model name for MLflow metric keys:
                 # only alphanumerics, underscores, dashes, periods, spaces,
                 # colons, and slashes are allowed.
-                safe_name = model_name.replace("@", "-")
+                safe_name = re.sub(r"[^A-Za-z0-9_\-\. :/]", "-", model_name)
                 prefix = f"model/{safe_name}"
                 if stats.get("cost_usd") is not None:
                     mlflow.log_metric(f"{prefix}/cost_usd", stats["cost_usd"])

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -375,7 +375,15 @@ def _save_result(result, args, output_dir, runner, model, eval_params=None):
 
     full_model = result.resolved_model or model
     models_used = result.models_used or []
-    subagent_models = [m for m in models_used if m != full_model]
+    # Claude Code annotates the parent model with bracketed suffixes like
+    # "[1m]" (the 1M-context variant), but server-side per-message model
+    # fields drop the suffix. Compare on the base name so subagents using
+    # the same effective model don't get flagged as a distinct subagent.
+    def _base(name):
+        i = name.find("[")
+        return name[:i] if i >= 0 else name
+    full_base = _base(full_model)
+    subagent_models = [m for m in models_used if _base(m) != full_base]
     subagent_model_str = ", ".join(subagent_models) if subagent_models else full_model
 
     run_meta = {


### PR DESCRIPTION
## Summary
- Claude Code annotates parent models with bracketed suffixes like `[1m]` (1M-context variant), but server-side per-message model fields drop the suffix. Two consequences fixed:
  - `_save_result` compares parent vs subagent models on the base name, so a subagent using the same effective model isn't flagged as distinct (the Subagent Model column was showing a spurious second model).
  - `log_results.py` sanitizes model names with a broader regex so bracketed names produce valid MLflow metric keys.

## Test plan
- [ ] Run an eval with `--model claude-opus-4-7[1m]` and confirm the report shows the parent model only (no spurious subagent).
- [ ] Confirm MLflow metrics are recorded under sanitized keys (no errors logged about invalid characters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)