### PR TITLE
Fix Bash interception that could block all Bash calls

### DIFF
--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -100,16 +100,20 @@ If the case count is 0, stop — the filter matched nothing.
 
 ## Step 3b: Resolve Tool Interception (if `inputs.tools` configured)
 
-If eval.yaml has `inputs.tools` entries, the workspace script generates basic hook patterns from the `match` text. But complex prompts (like "only allow test Jira instances") need you to refine the generated `tool_handlers.yaml`.
+If eval.yaml has `inputs.tools` entries, this step is **mandatory** — it is the dynamic-permission stage of the harness. `workspace.py` only emits a skeleton (`patterns` + the natural-language `prompt`); you must turn the prompt into concrete runtime checks. Do not skip this even when the eval.yaml is unchanged from a prior run — the resolved checks live in the workspace, which is created fresh each time.
 
-Read `${CLAUDE_SKILL_DIR}/references/tool-interception.md` for the full format and field reference. Then read `<workspace>/tool_handlers.yaml` and for each handler:
+**Critical default to fix**: any handler with `patterns: [Bash, ...]` and no `input_filters` is non-functional — the hook will skip it with a stderr warning, and the underlying tool will pass through unchecked. If you intend to gate Bash, you must add `input_filters`.
+
+Read `${CLAUDE_SKILL_DIR}/references/tool-interception.md` for the full format and field reference. Then read `<workspace>/tool_handlers.yaml` and for **every** handler:
 
 1. Read the `match` and `prompt` fields
 2. Resolve the `prompt` into concrete runtime checks:
-   - **For AskUserQuestion**: load per-case answers from dataset `answers.yaml` files into `case_overrides`
-   - **For service interception** (Jira, Slack, etc.): add `env_checks` (which env vars to validate) and `input_filters` (regex patterns for Bash command content)
-   - **For blocking**: ensure `patterns` match correctly — the default deny behavior handles the rest
+   - **For AskUserQuestion**: load per-case answers from dataset `answers.yaml` files into `case_overrides`. If the dataset has none, the auto-accept fallback (first option / "yes") is fine.
+   - **For service interception** (Jira, Slack, etc.): add `env_checks` (which env vars to validate) and `input_filters` (regex patterns for Bash command content). For Bash this is required, not optional.
+   - **For blocking**: explicit MCP patterns (e.g. `mcp__atlassian__*`) deny by default once matched; just confirm the patterns are right.
 3. Write the updated handler back to `tool_handlers.yaml`
+
+Before continuing to Step 4, sanity-check: every `Bash` pattern has matching `input_filters`, and every non-Bash handler either has `env_checks` or is intended to deny by default.
 
 The hook script (`tools.py`) uses these concrete checks at runtime — no LLM needed during execution.
 

--- a/skills/eval-run/references/tool-interception.md
+++ b/skills/eval-run/references/tool-interception.md
@@ -65,6 +65,7 @@ case_overrides:
 2. `input_filters: ["jira", "JIRA_SERVER"]` means the Bash command must contain "jira" or "JIRA_SERVER" (case-insensitive)
 3. A `ls -la` command won't match even though "Bash" is in patterns
 4. If matched and `env_checks` present: same env validation as MCP tools
+5. **A handler with `Bash` in patterns but no `input_filters` is treated as misconfigured**: the hook logs a stderr warning and skips it (pass-through). Without filters, every Bash call would otherwise hit the default-deny in `main()` and the skill could not run.
 
 ### Unmatched Tools
 

--- a/skills/eval-run/scripts/tools.py
+++ b/skills/eval-run/scripts/tools.py
@@ -60,13 +60,29 @@ def main():
 
 
 def _find_handler(tool_name, tool_input, handlers):
-    """Find the first handler that matches the tool call."""
+    """Find the first handler that matches the tool call.
+
+    Bash handlers REQUIRE input_filters — without them, a handler with
+    "Bash" in patterns would silently match every Bash command and the
+    default-deny in main() would block the entire skill. To prevent that
+    footgun, Bash handlers without input_filters are treated as
+    misconfigured: emit a stderr warning and skip (pass-through).
+    Resolve them in eval-run Step 3b before relying on the handler.
+    """
     for h in handlers:
         patterns = h.get("patterns", [])
         input_filters = h.get("input_filters", [])
 
-        # For Bash with input_filters: must match BOTH pattern AND filter
-        if tool_name == "Bash" and "Bash" in patterns and input_filters:
+        if tool_name == "Bash" and "Bash" in patterns:
+            if not input_filters:
+                print(
+                    f"tool_handlers.yaml: handler {h.get('match', '?')!r} "
+                    "has 'Bash' in patterns but no input_filters — "
+                    "skipping (would deny all Bash). Resolve in eval-run "
+                    "Step 3b.",
+                    file=sys.stderr,
+                )
+                continue
             command = tool_input.get("command", "")
             if any(re.search(f, command, re.IGNORECASE) for f in input_filters):
                 return h


### PR DESCRIPTION
## Summary
- A handler declaring `Bash` in `patterns` without `input_filters` was silently matching every Bash invocation, then falling through to `main()`'s default-deny — blocking the entire skill.
- The hook now detects this misconfiguration, prints a stderr warning, and skips the handler so Bash passes through.
- Tighten the eval-run docs and tool-interception reference: Step 3b is now explicitly mandatory and includes a Bash sanity check before execution.

## Test plan
- [ ] Configure a handler with `patterns: [Bash]` and no `input_filters`. Run an eval. Confirm a stderr warning appears and Bash calls aren't denied.
- [ ] Configure a handler with `patterns: [Bash]` AND `input_filters: [\"jira\"]`. Run an eval that invokes `jira` and one that doesn't. Confirm only the matching call is intercepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)