### PR TITLE
Make pairwise judge JSON extraction more resilient

### DIFF
--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -568,43 +568,62 @@ def _call_judge(client, system_prompt, user_message, model, max_tokens=8192):
             ],
         )
         text = response.content[0].text
-        # Try extracting JSON from code blocks first
-        if "```json" in text:
-            json_text = text.split("```json")[1].split("```")[0]
-        elif "```" in text:
-            json_text = text.split("```")[1].split("```")[0]
-        else:
-            json_text = text
-        try:
-            return json.loads(json_text.strip()), None
-        except json.JSONDecodeError:
-            # Fallback: extract outermost JSON object containing "preferred"
-            # Walk the text to find balanced braces
-            for start in range(len(text)):
-                if text[start] != "{":
-                    continue
-                depth = 0
-                for end in range(start, len(text)):
-                    if text[end] == "{":
-                        depth += 1
-                    elif text[end] == "}":
-                        depth -= 1
-                    if depth == 0:
-                        candidate = text[start:end + 1]
-                        if '"preferred"' in candidate:
-                            try:
-                                return json.loads(candidate), None
-                            except json.JSONDecodeError:
-                                pass
-                        break
-            # Retry once with a larger budget if the response was truncated.
-            if response.stop_reason == "max_tokens" and max_tokens < 16384:
-                return _call_judge(client, system_prompt, user_message, model,
-                                   max_tokens=max_tokens * 2)
-            return None, (f"Could not parse JSON from response "
-                          f"(stop_reason={response.stop_reason}): {text[:200]}")
+        parsed = _extract_judge_json(text)
+        if parsed is not None:
+            return parsed, None
+        # Retry once with a larger budget if the response was truncated.
+        if response.stop_reason == "max_tokens" and max_tokens < 16384:
+            return _call_judge(client, system_prompt, user_message, model,
+                               max_tokens=max_tokens * 2)
+        return None, (f"Could not parse JSON from response "
+                      f"(stop_reason={response.stop_reason}): {text[:200]}")
     except Exception as e:
         return None, str(e)
+
+
+def _extract_judge_json(text):
+    """Extract a JSON object containing 'preferred' from a judge response."""
+    # strict=False allows unescaped control characters (e.g. literal newlines)
+    # inside strings — judges often format their reasoning with real newlines.
+    def _loads(s):
+        return json.loads(s, strict=False)
+
+    # Try code blocks first.
+    if "```json" in text:
+        json_text = text.split("```json")[1].split("```")[0]
+    elif "```" in text:
+        json_text = text.split("```")[1].split("```")[0]
+    else:
+        json_text = text
+    try:
+        return _loads(json_text.strip())
+    except json.JSONDecodeError:
+        pass
+    # Fallback: extract the outermost balanced JSON object containing "preferred".
+    for start in range(len(text)):
+        if text[start] != "{":
+            continue
+        depth = 0
+        for end in range(start, len(text)):
+            if text[end] == "{":
+                depth += 1
+            elif text[end] == "}":
+                depth -= 1
+            if depth == 0:
+                candidate = text[start:end + 1]
+                if '"preferred"' in candidate:
+                    try:
+                        return _loads(candidate)
+                    except json.JSONDecodeError:
+                        pass
+                break
+    # Last-resort recovery: judge wrote a partial/unclosed JSON object but the
+    # top-level "preferred" verdict is still extractable. Lose the rationale,
+    # keep the verdict — better than counting the case as an error.
+    m = re.search(r'"preferred"\s*:\s*"(A|B|tie)"', text)
+    if m:
+        return {"preferred": m.group(1)}
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -555,14 +555,14 @@ def _get_anthropic_client():
     raise RuntimeError("Set ANTHROPIC_VERTEX_PROJECT_ID or ANTHROPIC_API_KEY")
 
 
-def _call_judge(client, system_prompt, user_message, model):
+def _call_judge(client, system_prompt, user_message, model, max_tokens=8192):
     try:
         response = client.messages.create(
-            model=model, max_tokens=4096,
-            system=("You are a judge comparing two outputs. Be concise in your reasoning. "
-                    "You MUST end your response with a JSON object containing "
-                    "a 'preferred' field set to 'A', 'B', or 'tie'. "
-                    "Example: {\"reasoning\": \"...\", \"preferred\": \"A\"}"),
+            model=model, max_tokens=max_tokens,
+            system=("You are a judge comparing two outputs. "
+                    "You MUST end your response with a JSON object that follows "
+                    "the schema specified in the user prompt and includes a "
+                    "'preferred' field set to 'A', 'B', or 'tie'."),
             messages=[
                 {"role": "user", "content": f"{system_prompt}\n\n{user_message}"},
             ],
@@ -597,7 +597,12 @@ def _call_judge(client, system_prompt, user_message, model):
                             except json.JSONDecodeError:
                                 pass
                         break
-            return None, f"Could not parse JSON from response: {text[:200]}"
+            # Retry once with a larger budget if the response was truncated.
+            if response.stop_reason == "max_tokens" and max_tokens < 16384:
+                return _call_judge(client, system_prompt, user_message, model,
+                                   max_tokens=max_tokens * 2)
+            return None, (f"Could not parse JSON from response "
+                          f"(stop_reason={response.stop_reason}): {text[:200]}")
     except Exception as e:
         return None, str(e)
 


### PR DESCRIPTION
## Summary
Three failure modes were silently dropping verdicts:
- Judges sometimes wrote literal newlines inside string values, which `json.loads` rejects by default. Use `strict=False` so unescaped control characters parse.
- Truncated/unclosed JSON could leave the verdict unparseable even when `\"preferred\":\"A|B|tie\"` appeared verbatim. Add a last-resort regex that recovers just the verdict — losing the rationale is better than losing the whole case.
- The extraction logic was inlined in `_call_judge`, making it hard to test and reuse. Pull it out into `_extract_judge_json`.

> Stacks on top of #13 (max_tokens fix). Merge #13 first, then this PR's diff vs main collapses to just the extraction refactor.

## Test plan
- [ ] Feed `_extract_judge_json` a response with literal newlines inside a string value — confirm it parses.
- [ ] Feed it an unclosed JSON object that still contains `\"preferred\": \"A\"` — confirm the regex fallback returns `{\"preferred\": \"A\"}`.
- [ ] Run the existing pairwise scoring path end-to-end on a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)