### PR TITLE
Add per-model turn counts to RunResult and run metadata

### DIFF
--- a/agent_eval/agent/base.py
+++ b/agent_eval/agent/base.py
@@ -24,6 +24,7 @@ class RunResult:
     resolved_model: Optional[str] = None  # Full model ID from runtime
     models_used: Optional[list] = None   # All distinct models observed
     per_model_usage: Optional[dict] = None  # Per-model token/cost breakdown
+    per_model_turns: Optional[dict] = None  # Per-model assistant turn count
     raw_output: Optional[dict] = None  # Runner-specific parsed output
 
 

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -12,10 +12,24 @@ from typing import Optional
 from .base import EvalRunner, RunResult
 from .stream_capture import (
     make_prompt_event, inject_timestamp, extract_usage,
-    count_subagent_turns, setup_subagent_hook,
+    count_subagent_turns, count_subagent_turns_by_model, setup_subagent_hook,
 )
 
 _print_lock = threading.Lock()
+
+
+def _per_model_turns(subagent_dir, stream_ids_by_model):
+    """Combine stream-level per-model turn IDs with subagent transcripts.
+
+    Returns ``{model: turn_count}`` summing stream IDs and any new IDs found
+    in subagent transcripts (deduplicated by message ID). Returns None if no
+    per-model data is available, so the field stays absent rather than {}."""
+    by_model = {m: set(ids) for m, ids in (stream_ids_by_model or {}).items()}
+    new_per_model = count_subagent_turns_by_model(subagent_dir, by_model) or {}
+    counts = {m: len(ids) for m, ids in by_model.items()}
+    for m, n in new_per_model.items():
+        counts[m] = counts.get(m, 0) + n
+    return counts or None
 
 
 class ClaudeCodeRunner(EvalRunner):
@@ -160,12 +174,15 @@ class ClaudeCodeRunner(EvalRunner):
             proc.kill()
             proc.wait()
             duration = time.monotonic() - start
-            token_usage, cost_usd, num_turns, stream_ids, models_seen, per_model_usage = extract_usage(stdout_lines)
+            (token_usage, cost_usd, num_turns, stream_ids, models_seen,
+             per_model_usage, stream_ids_by_model) = extract_usage(stdout_lines)
             # Add subagent turns from captured transcripts, deduplicating
             # against IDs already seen in the stream
             subagent_turns = count_subagent_turns(workspace / "subagents", already_seen=stream_ids)
             if subagent_turns:
                 num_turns = (num_turns or 0) + subagent_turns
+            per_model_turns = _per_model_turns(
+                workspace / "subagents", stream_ids_by_model)
             return RunResult(
                 exit_code=-1,
                 stdout="\n".join(stdout_lines),
@@ -177,6 +194,7 @@ class ClaudeCodeRunner(EvalRunner):
                 resolved_model=resolved_model,
                 models_used=sorted(models_seen) if models_seen else None,
                 per_model_usage=per_model_usage,
+                per_model_turns=per_model_turns,
             )
         except Exception as e:
             duration = time.monotonic() - start
@@ -201,7 +219,8 @@ class ClaudeCodeRunner(EvalRunner):
             except json.JSONDecodeError:
                 pass
 
-        token_usage, cost_usd, num_turns, stream_ids, models_seen, per_model_usage = extract_usage(stdout_lines)
+        (token_usage, cost_usd, num_turns, stream_ids, models_seen,
+         per_model_usage, stream_ids_by_model) = extract_usage(stdout_lines)
         if not cost_usd and isinstance(result_obj, dict):
             cost_usd = result_obj.get("total_cost_usd")
 
@@ -211,6 +230,8 @@ class ClaudeCodeRunner(EvalRunner):
         subagent_turns = count_subagent_turns(workspace / "subagents", already_seen=stream_ids)
         if subagent_turns:
             num_turns = (num_turns or 0) + subagent_turns
+        per_model_turns = _per_model_turns(
+            workspace / "subagents", stream_ids_by_model)
 
         return RunResult(
             exit_code=proc.returncode,
@@ -223,6 +244,7 @@ class ClaudeCodeRunner(EvalRunner):
             resolved_model=resolved_model,
             models_used=sorted(models_seen) if models_seen else None,
             per_model_usage=per_model_usage,
+            per_model_turns=per_model_turns,
             raw_output=raw_output,
         )
 

--- a/agent_eval/agent/stream_capture.py
+++ b/agent_eval/agent/stream_capture.py
@@ -67,17 +67,22 @@ def extract_usage(stdout_lines):
 
     Returns:
         Tuple of (token_usage, cost_usd, num_turns, seen_msg_ids,
-        models_seen, per_model_usage).
+        models_seen, per_model_usage, seen_msg_ids_by_model).
         ``num_turns`` counts all assistant turns visible in the stream.
         ``seen_msg_ids`` is the set of message IDs for deduplication with
         subagent transcripts.
         ``per_model_usage`` is a dict mapping model name to token/cost breakdown,
         or None if modelUsage was absent.
+        ``seen_msg_ids_by_model`` is a dict mapping model name to its set of
+        observed message IDs (for per-model turn counting and deduplication
+        with :func:`count_subagent_turns_by_model`), or None if no assistant
+        events were seen. Per-model turn counts are ``{m: len(ids)}``.
     """
     cost_usd = None
     models_seen = set()
     model_usage = None
     seen_msg_ids = set()
+    seen_msg_ids_by_model = {}
     fb_input = fb_output = fb_cache_read = fb_cache_create = 0
     for line in stdout_lines:
         try:
@@ -86,14 +91,16 @@ def extract_usage(stdout_lines):
             continue
         if obj.get("type") == "assistant":
             msg_id = obj.get("message", {}).get("id")
+            model = obj.get("message", {}).get("model")
             if msg_id:
                 seen_msg_ids.add(msg_id)
+                if model:
+                    seen_msg_ids_by_model.setdefault(model, set()).add(msg_id)
             u = obj.get("message", {}).get("usage", {})
             fb_input += u.get("input_tokens", 0)
             fb_output += u.get("output_tokens", 0)
             fb_cache_read += u.get("cache_read_input_tokens", 0)
             fb_cache_create += u.get("cache_creation_input_tokens", 0)
-            model = obj.get("message", {}).get("model")
             if model:
                 models_seen.add(model)
         elif obj.get("type") == "result":
@@ -133,7 +140,8 @@ def extract_usage(stdout_lines):
             "cache_read": fb_cache_read, "cache_create": fb_cache_create,
         }
     num_turns = len(seen_msg_ids) or None
-    return token_usage, cost_usd, num_turns, seen_msg_ids, models_seen, per_model_usage
+    return (token_usage, cost_usd, num_turns, seen_msg_ids, models_seen,
+            per_model_usage, seen_msg_ids_by_model or None)
 
 
 # ── Subagent turn counting ──────────────────────────────────────────
@@ -182,6 +190,49 @@ def count_subagent_turns(subagent_dir, already_seen=None):
         except OSError:
             continue
     return len(seen) - initial_count
+
+
+def count_subagent_turns_by_model(subagent_dir, already_seen_by_model=None):
+    """Count NEW unique assistant turns per model across subagent transcripts.
+
+    Like :func:`count_subagent_turns` but groups by ``message.model``. Only
+    counts message IDs that aren't already in ``already_seen_by_model[model]``,
+    so callers can pass in IDs already counted from the main stream.
+
+    Args:
+        subagent_dir: Path to directory containing ``*.jsonl`` transcripts.
+        already_seen_by_model: Optional dict mapping model name to a set of
+            already-counted message IDs (from the main stream).
+
+    Returns:
+        Dict mapping model name to count of new assistant turns. Returns an
+        empty dict if the directory is missing or has no assistant turns.
+    """
+    subagent_path = Path(subagent_dir)
+    if not subagent_path.is_dir():
+        return {}
+    seen = {m: set(ids) for m, ids in (already_seen_by_model or {}).items()}
+    initial_counts = {m: len(s) for m, s in seen.items()}
+    for transcript in subagent_path.iterdir():
+        if not transcript.is_file() or transcript.suffix != ".jsonl":
+            continue
+        try:
+            with open(transcript) as f:
+                for line in f:
+                    try:
+                        obj = json.loads(line)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    msg = obj.get("message", {})
+                    if msg.get("role") == "assistant":
+                        msg_id = msg.get("id")
+                        model = msg.get("model")
+                        if msg_id and model:
+                            seen.setdefault(model, set()).add(msg_id)
+        except OSError:
+            continue
+    return {m: len(s) - initial_counts.get(m, 0) for m, s in seen.items()
+            if len(s) - initial_counts.get(m, 0) > 0}
 
 
 # ── Subagent capture via hooks ───────────────────────────────────────

--- a/agent_eval/cli/trace_run.py
+++ b/agent_eval/cli/trace_run.py
@@ -175,7 +175,8 @@ def main():
         (trace_dir / "stderr.log").write_text(stderr)
 
     # run_result.json
-    token_usage, cost_usd, num_turns, stream_ids, models_seen, per_model_usage = extract_usage(stdout_lines)
+    (token_usage, cost_usd, num_turns, stream_ids, models_seen,
+     per_model_usage, _stream_ids_by_model) = extract_usage(stdout_lines)
     # Add subagent turns from captured transcripts, deduplicating
     # against IDs already seen in the stream
     subagent_dir = trace_dir / "subagents"

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -313,6 +313,8 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
             "token_usage": result.token_usage,
             "cost_usd": result.cost_usd,
             "num_turns": result.num_turns,
+            "per_model_usage": result.per_model_usage,
+            "per_model_turns": result.per_model_turns,
         }
 
         # Write per-case run_result.json so score.py can read
@@ -385,6 +387,7 @@ def _save_result(result, args, output_dir, runner, model, eval_params=None):
         "cost_usd": result.cost_usd,
         "per_model_usage": result.per_model_usage,
         "num_turns": result.num_turns,
+        "per_model_turns": result.per_model_turns,
         "model": full_model,
         "subagent_model": subagent_model_str,
         "agent": runner.name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,13 +130,17 @@ def write_transcripts(tmp_path, transcripts):
     for agent_id, messages in transcripts.items():
         lines = []
         for msg_id, role in messages:
-            lines.append(json.dumps({
-                "message": {
-                    "role": role,
-                    "id": msg_id,
-                    "content": [{"type": "text", "text": "..."}],
-                },
-            }))
+            msg = {
+                "role": role,
+                "id": msg_id,
+                "content": [{"type": "text", "text": "..."}],
+            }
+            # Real Claude Code subagent transcripts include `model` on every
+            # assistant message; default to a fixed value so per-model turn
+            # counting has something to attribute to.
+            if role == "assistant":
+                msg["model"] = "claude-sonnet-4-5"
+            lines.append(json.dumps({"message": msg}))
         (subdir / f"agent-{agent_id}.jsonl").write_text("\n".join(lines) + "\n")
     return subdir
 

--- a/tests/test_stream_capture.py
+++ b/tests/test_stream_capture.py
@@ -2,21 +2,23 @@
 
 from conftest import make_assistant, make_result, to_jsonl
 
-from agent_eval.agent.stream_capture import count_subagent_turns, extract_usage
+from agent_eval.agent.stream_capture import (
+    count_subagent_turns, count_subagent_turns_by_model, extract_usage,
+)
 
 
 class TestExtractUsage:
     def test_returns_seen_ids(self, post_2_1_108_stream):
-        """extract_usage returns a 6-tuple including the seen_msg_ids set."""
+        """extract_usage returns a 7-tuple including the seen_msg_ids set."""
         result = extract_usage(post_2_1_108_stream["lines"])
-        assert len(result) == 6
-        _, _, num_turns, seen_msg_ids, _, _ = result
+        assert len(result) == 7
+        _, _, num_turns, seen_msg_ids, _, _, _ = result
         assert isinstance(seen_msg_ids, set)
         assert len(seen_msg_ids) == num_turns
 
     def test_includes_subagent_ids_post_2_1_108(self, post_2_1_108_stream):
         """Post-2.1.108: seen_msg_ids includes foreground subagent message IDs."""
-        _, _, num_turns, seen_ids, _, _ = extract_usage(post_2_1_108_stream["lines"])
+        _, _, num_turns, seen_ids, _, _, _ = extract_usage(post_2_1_108_stream["lines"])
         assert num_turns == 7  # 5 root + 2 foreground subagent
         assert "msg_001" in seen_ids
         assert "msg_sub_001" in seen_ids
@@ -36,11 +38,25 @@ class TestExtractUsage:
                 },
             }),
         ]
-        token_usage, _, _, _, _, per_model = extract_usage(to_jsonl(events))
+        token_usage, _, _, _, _, per_model, _ = extract_usage(to_jsonl(events))
         # Should use modelUsage totals, not assistant event usage
         assert token_usage["input"] == 9000
         assert token_usage["output"] == 3000
         assert per_model["claude-sonnet-4-5"]["cost_usd"] == 0.42
+
+    def test_returns_per_model_msg_ids(self):
+        """seen_msg_ids_by_model groups assistant message IDs by their model."""
+        events = [
+            make_assistant("msg_001", model="claude-opus-4-7"),
+            make_assistant("msg_002", model="claude-opus-4-7"),
+            make_assistant("msg_003", model="claude-sonnet-4-6"),
+        ]
+        _, _, num_turns, _, _, _, by_model = extract_usage(to_jsonl(events))
+        assert by_model == {
+            "claude-opus-4-7": {"msg_001", "msg_002"},
+            "claude-sonnet-4-6": {"msg_003"},
+        }
+        assert num_turns == 3
 
 
 class TestCountSubagentTurns:
@@ -61,10 +77,39 @@ class TestCountSubagentTurns:
         assert count_subagent_turns(tmp_path / "nonexistent") == 0
 
 
+class TestCountSubagentTurnsByModel:
+    def test_returns_empty_for_missing_dir(self, tmp_path):
+        """Non-existent directory returns empty dict."""
+        assert count_subagent_turns_by_model(tmp_path / "nonexistent") == {}
+
+    def test_groups_new_turns_by_model(self, post_2_1_108_stream):
+        """Without already_seen, groups all subagent turns by their model."""
+        per_model = count_subagent_turns_by_model(
+            post_2_1_108_stream["subagent_dir"])
+        # All subagent turns should be attributed to some model. Sum equals
+        # the int returned by count_subagent_turns for the same dir.
+        assert sum(per_model.values()) == 3
+
+    def test_dedupes_against_already_seen_per_model(self, post_2_1_108_stream):
+        """With already_seen_by_model, only NEW per-model IDs are counted."""
+        # Pre-seed with all 3 subagent IDs under whatever model they belong to;
+        # we don't know that model from the fixture, so use the subagent dir's
+        # actual content to construct already_seen_by_model from a first pass.
+        all_seen = count_subagent_turns_by_model(
+            post_2_1_108_stream["subagent_dir"])
+        # Re-pass with the already-counted IDs as "seen" per model — should be 0.
+        # Use the by-model totals from a no-op call as a proxy.
+        # (Simpler: pass an exhaustive set per model.)
+        seeded = {m: {"msg_sub_001", "msg_sub_002", "msg_sub_003"} for m in all_seen}
+        new = count_subagent_turns_by_model(
+            post_2_1_108_stream["subagent_dir"], already_seen_by_model=seeded)
+        assert new == {}
+
+
 class TestCombinedTurnCount:
     def test_no_double_count_post_2_1_108(self, post_2_1_108_stream):
         """Post-2.1.108: combined count deduplicates overlapping IDs."""
-        _, _, stream_turns, stream_ids, _, _ = extract_usage(
+        _, _, stream_turns, stream_ids, _, _, _ = extract_usage(
             post_2_1_108_stream["lines"])
         new_turns = count_subagent_turns(
             post_2_1_108_stream["subagent_dir"], already_seen=stream_ids)
@@ -73,7 +118,7 @@ class TestCombinedTurnCount:
 
     def test_no_overlap_pre_2_1_108(self, pre_2_1_108_stream):
         """Pre-2.1.108: no overlap, sum is correct without dedup changing anything."""
-        _, _, stream_turns, stream_ids, _, _ = extract_usage(
+        _, _, stream_turns, stream_ids, _, _, _ = extract_usage(
             pre_2_1_108_stream["lines"])
         new_turns = count_subagent_turns(
             pre_2_1_108_stream["subagent_dir"], already_seen=stream_ids)


### PR DESCRIPTION
## Summary
- `extract_usage` now returns a 7-tuple including per-model assistant message IDs grouped by model.
- `count_subagent_turns_by_model` groups subagent transcript IDs the same way.
- `ClaudeCodeRunner` combines the two via `_per_model_turns` and surfaces a `per_model_turns` field on `RunResult`.
- `execute.py` writes `per_model_turns` into both per-case results and the aggregate `run_result.json`.
- Downstream consumer is the report — per-model `num_turns` lets us compute per-model cost-per-turn instead of attributing the whole run's turns to whichever model was queried last (lands in #16).

## Test plan
- [ ] `pytest tests/test_stream_capture.py` (already passing locally — 12 tests).
- [ ] Run an eval with mixed-model invocation (parent opus + subagent sonnet). Inspect `run_result.json` and confirm `per_model_turns` shows distinct counts per model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)