### PR TITLE
Add workload-agnostic run metrics (cost/turn, $/Mtok)

### DIFF
--- a/agent_eval/agent/base.py
+++ b/agent_eval/agent/base.py
@@ -24,6 +24,7 @@ class RunResult:
     resolved_model: Optional[str] = None  # Full model ID from runtime
     models_used: Optional[list] = None   # All distinct models observed
     per_model_usage: Optional[dict] = None  # Per-model token/cost breakdown
+    per_model_turns: Optional[dict] = None  # Per-model assistant turn count
     raw_output: Optional[dict] = None  # Runner-specific parsed output
 
 

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -12,10 +12,24 @@ from typing import Optional
 from .base import EvalRunner, RunResult
 from .stream_capture import (
     make_prompt_event, inject_timestamp, extract_usage,
-    count_subagent_turns, setup_subagent_hook,
+    count_subagent_turns, count_subagent_turns_by_model, setup_subagent_hook,
 )
 
 _print_lock = threading.Lock()
+
+
+def _per_model_turns(subagent_dir, stream_ids_by_model):
+    """Combine stream-level per-model turn IDs with subagent transcripts.
+
+    Returns ``{model: turn_count}`` summing stream IDs and any new IDs found
+    in subagent transcripts (deduplicated by message ID). Returns None if no
+    per-model data is available, so the field stays absent rather than {}."""
+    by_model = {m: set(ids) for m, ids in (stream_ids_by_model or {}).items()}
+    new_per_model = count_subagent_turns_by_model(subagent_dir, by_model) or {}
+    counts = {m: len(ids) for m, ids in by_model.items()}
+    for m, n in new_per_model.items():
+        counts[m] = counts.get(m, 0) + n
+    return counts or None
 
 
 class ClaudeCodeRunner(EvalRunner):
@@ -160,12 +174,15 @@ class ClaudeCodeRunner(EvalRunner):
             proc.kill()
             proc.wait()
             duration = time.monotonic() - start
-            token_usage, cost_usd, num_turns, stream_ids, models_seen, per_model_usage = extract_usage(stdout_lines)
+            (token_usage, cost_usd, num_turns, stream_ids, models_seen,
+             per_model_usage, stream_ids_by_model) = extract_usage(stdout_lines)
             # Add subagent turns from captured transcripts, deduplicating
             # against IDs already seen in the stream
             subagent_turns = count_subagent_turns(workspace / "subagents", already_seen=stream_ids)
             if subagent_turns:
                 num_turns = (num_turns or 0) + subagent_turns
+            per_model_turns = _per_model_turns(
+                workspace / "subagents", stream_ids_by_model)
             return RunResult(
                 exit_code=-1,
                 stdout="\n".join(stdout_lines),
@@ -177,6 +194,7 @@ class ClaudeCodeRunner(EvalRunner):
                 resolved_model=resolved_model,
                 models_used=sorted(models_seen) if models_seen else None,
                 per_model_usage=per_model_usage,
+                per_model_turns=per_model_turns,
             )
         except Exception as e:
             duration = time.monotonic() - start
@@ -201,7 +219,8 @@ class ClaudeCodeRunner(EvalRunner):
             except json.JSONDecodeError:
                 pass
 
-        token_usage, cost_usd, num_turns, stream_ids, models_seen, per_model_usage = extract_usage(stdout_lines)
+        (token_usage, cost_usd, num_turns, stream_ids, models_seen,
+         per_model_usage, stream_ids_by_model) = extract_usage(stdout_lines)
         if not cost_usd and isinstance(result_obj, dict):
             cost_usd = result_obj.get("total_cost_usd")
 
@@ -211,6 +230,8 @@ class ClaudeCodeRunner(EvalRunner):
         subagent_turns = count_subagent_turns(workspace / "subagents", already_seen=stream_ids)
         if subagent_turns:
             num_turns = (num_turns or 0) + subagent_turns
+        per_model_turns = _per_model_turns(
+            workspace / "subagents", stream_ids_by_model)
 
         return RunResult(
             exit_code=proc.returncode,
@@ -223,6 +244,7 @@ class ClaudeCodeRunner(EvalRunner):
             resolved_model=resolved_model,
             models_used=sorted(models_seen) if models_seen else None,
             per_model_usage=per_model_usage,
+            per_model_turns=per_model_turns,
             raw_output=raw_output,
         )
 

--- a/agent_eval/agent/stream_capture.py
+++ b/agent_eval/agent/stream_capture.py
@@ -67,17 +67,22 @@ def extract_usage(stdout_lines):
 
     Returns:
         Tuple of (token_usage, cost_usd, num_turns, seen_msg_ids,
-        models_seen, per_model_usage).
+        models_seen, per_model_usage, seen_msg_ids_by_model).
         ``num_turns`` counts all assistant turns visible in the stream.
         ``seen_msg_ids`` is the set of message IDs for deduplication with
         subagent transcripts.
         ``per_model_usage`` is a dict mapping model name to token/cost breakdown,
         or None if modelUsage was absent.
+        ``seen_msg_ids_by_model`` is a dict mapping model name to its set of
+        observed message IDs (for per-model turn counting and deduplication
+        with :func:`count_subagent_turns_by_model`), or None if no assistant
+        events were seen. Per-model turn counts are ``{m: len(ids)}``.
     """
     cost_usd = None
     models_seen = set()
     model_usage = None
     seen_msg_ids = set()
+    seen_msg_ids_by_model = {}
     fb_input = fb_output = fb_cache_read = fb_cache_create = 0
     for line in stdout_lines:
         try:
@@ -86,14 +91,16 @@ def extract_usage(stdout_lines):
             continue
         if obj.get("type") == "assistant":
             msg_id = obj.get("message", {}).get("id")
+            model = obj.get("message", {}).get("model")
             if msg_id:
                 seen_msg_ids.add(msg_id)
+                if model:
+                    seen_msg_ids_by_model.setdefault(model, set()).add(msg_id)
             u = obj.get("message", {}).get("usage", {})
             fb_input += u.get("input_tokens", 0)
             fb_output += u.get("output_tokens", 0)
             fb_cache_read += u.get("cache_read_input_tokens", 0)
             fb_cache_create += u.get("cache_creation_input_tokens", 0)
-            model = obj.get("message", {}).get("model")
             if model:
                 models_seen.add(model)
         elif obj.get("type") == "result":
@@ -133,7 +140,8 @@ def extract_usage(stdout_lines):
             "cache_read": fb_cache_read, "cache_create": fb_cache_create,
         }
     num_turns = len(seen_msg_ids) or None
-    return token_usage, cost_usd, num_turns, seen_msg_ids, models_seen, per_model_usage
+    return (token_usage, cost_usd, num_turns, seen_msg_ids, models_seen,
+            per_model_usage, seen_msg_ids_by_model or None)
 
 
 # ── Subagent turn counting ──────────────────────────────────────────
@@ -182,6 +190,49 @@ def count_subagent_turns(subagent_dir, already_seen=None):
         except OSError:
             continue
     return len(seen) - initial_count
+
+
+def count_subagent_turns_by_model(subagent_dir, already_seen_by_model=None):
+    """Count NEW unique assistant turns per model across subagent transcripts.
+
+    Like :func:`count_subagent_turns` but groups by ``message.model``. Only
+    counts message IDs that aren't already in ``already_seen_by_model[model]``,
+    so callers can pass in IDs already counted from the main stream.
+
+    Args:
+        subagent_dir: Path to directory containing ``*.jsonl`` transcripts.
+        already_seen_by_model: Optional dict mapping model name to a set of
+            already-counted message IDs (from the main stream).
+
+    Returns:
+        Dict mapping model name to count of new assistant turns. Returns an
+        empty dict if the directory is missing or has no assistant turns.
+    """
+    subagent_path = Path(subagent_dir)
+    if not subagent_path.is_dir():
+        return {}
+    seen = {m: set(ids) for m, ids in (already_seen_by_model or {}).items()}
+    initial_counts = {m: len(s) for m, s in seen.items()}
+    for transcript in subagent_path.iterdir():
+        if not transcript.is_file() or transcript.suffix != ".jsonl":
+            continue
+        try:
+            with open(transcript) as f:
+                for line in f:
+                    try:
+                        obj = json.loads(line)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    msg = obj.get("message", {})
+                    if msg.get("role") == "assistant":
+                        msg_id = msg.get("id")
+                        model = msg.get("model")
+                        if msg_id and model:
+                            seen.setdefault(model, set()).add(msg_id)
+        except OSError:
+            continue
+    return {m: len(s) - initial_counts.get(m, 0) for m, s in seen.items()
+            if len(s) - initial_counts.get(m, 0) > 0}
 
 
 # ── Subagent capture via hooks ───────────────────────────────────────

--- a/agent_eval/cli/trace_run.py
+++ b/agent_eval/cli/trace_run.py
@@ -175,7 +175,8 @@ def main():
         (trace_dir / "stderr.log").write_text(stderr)
 
     # run_result.json
-    token_usage, cost_usd, num_turns, stream_ids, models_seen, per_model_usage = extract_usage(stdout_lines)
+    (token_usage, cost_usd, num_turns, stream_ids, models_seen,
+     per_model_usage, _stream_ids_by_model) = extract_usage(stdout_lines)
     # Add subagent turns from captured transcripts, deduplicating
     # against IDs already seen in the stream
     subagent_dir = trace_dir / "subagents"

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -313,6 +313,8 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
             "token_usage": result.token_usage,
             "cost_usd": result.cost_usd,
             "num_turns": result.num_turns,
+            "per_model_usage": result.per_model_usage,
+            "per_model_turns": result.per_model_turns,
         }
 
         # Write per-case run_result.json so score.py can read
@@ -385,6 +387,7 @@ def _save_result(result, args, output_dir, runner, model, eval_params=None):
         "cost_usd": result.cost_usd,
         "per_model_usage": result.per_model_usage,
         "num_turns": result.num_turns,
+        "per_model_turns": result.per_model_turns,
         "model": full_model,
         "subagent_model": subagent_model_str,
         "agent": runner.name,

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -524,7 +524,7 @@ def _render_run_config(run_result, baseline_result=None):
                 html += f'<dd class="bl">{_esc(bl)}{delta_html}</dd>'
         html += '</div>\n'
     html += "</dl>\n"
-    html += _render_token_usage(run_result, baseline_result)
+    html += _render_model_usage(run_result, baseline_result)
     html += _render_eval_params(run_result)
     return html
 
@@ -612,10 +612,15 @@ def _render_eval_params(run_result):
     )
 
 
-def _render_token_usage(run_result, baseline_result=None):
-    """Render token usage: a Total mini-table aggregating all models, plus
-    one mini-table per individual model when per_model_usage is available.
-    All tables share the .config-table layout for visual alignment."""
+def _render_model_usage(run_result, baseline_result=None):
+    """Render model usage: token counts, cost, cache hit rate, and derived
+    per-turn / per-Mtok efficiency metrics. One column per model plus an
+    optional Total column when more than one model is present.
+
+    Per-turn rows (cost / turn, output tokens / turn) require num_turns,
+    which the runner only reports at the whole-run level. They render in
+    the Total column for multi-model runs, and in the single model's
+    column for single-model runs (where they're unambiguous)."""
     tokens = run_result.get("token_usage") or {}
     bl_tokens = (baseline_result or {}).get("token_usage") or {}
     per_model = run_result.get("per_model_usage") or {}
@@ -626,94 +631,134 @@ def _render_token_usage(run_result, baseline_result=None):
 
     has_bl = bool(bl_tokens) or bool(bl_per_model)
 
-    def _fmt(usage, key):
+    def _compute(usage, key):
+        """Return numeric value for a key, or None if not derivable."""
         if not usage:
+            return None
+        inp = usage.get("input", 0) or 0
+        out = usage.get("output", 0) or 0
+        cr = usage.get("cache_read", 0) or 0
+        cw = usage.get("cache_create", 0) or 0
+        cost = usage.get("cost_usd")
+        turns = usage.get("num_turns")
+        total_in = inp + cr + cw
+        total_tokens = total_in + out
+        if key == "input":         return inp or None
+        if key == "output":        return out or None
+        if key == "cache_read":    return cr or None
+        if key == "cache_create":  return cw or None
+        if key == "cost_usd":      return cost
+        if key == "hit":           return (cr / total_in) if total_in else None
+        if key == "cpt":           return (cost / turns) if (cost is not None and turns) else None
+        if key == "opt":           return (out / turns) if (out and turns) else None
+        if key == "mtok":          return (cost / total_tokens * 1_000_000) if (cost is not None and total_tokens) else None
+        return None
+
+    def _fmt(usage, key):
+        v = _compute(usage, key)
+        if v is None:
             return "—"
         if key == "hit":
-            inp = usage.get("input", 0) or 0
-            cr = usage.get("cache_read", 0) or 0
-            cw = usage.get("cache_create", 0) or 0
-            total_in = inp + cr + cw
-            return f"{cr / total_in:.1%}" if total_in else "—"
-        v = usage.get(key, 0) or 0
+            return f"{v:.1%}"
         if key == "cost_usd":
             return f"${v:.2f}"
+        if key == "cpt":
+            return f"${v:.4f}"
+        if key == "mtok":
+            return f"${v:.2f}"
+        if key == "opt":
+            return f"{v:,.0f}"
         return f"{v:,}"
 
-    # token_usage doesn't include cost_usd; pull it from run_result for the total
-    def _total(usage_dict, run_data):
-        if not usage_dict and not run_data:
-            return None
-        merged = dict(usage_dict or {})
-        if run_data and "cost_usd" in run_data:
-            merged["cost_usd"] = run_data.get("cost_usd")
-        return merged
-
-    metrics = [
-        ("Input", "input"),
-        ("Output", "output"),
-        ("Cache read", "cache_read"),
-        ("Cache write", "cache_create"),
-        ("Hit", "hit"),
-        ("Cost", "cost_usd"),
-    ]
-    # higher-is-better metrics; everything else assumed lower-is-better
+    # Higher-is-better metrics; everything else assumed lower-is-better.
+    # cache_read raw count is higher-better as a proxy for cache exploitation.
     higher_better = {"cache_read", "hit"}
-
-    def _hit_rate(u):
-        if not u:
-            return None
-        inp = u.get("input", 0) or 0
-        cr = u.get("cache_read", 0) or 0
-        cw = u.get("cache_create", 0) or 0
-        t = inp + cr + cw
-        return cr / t if t else None
+    # Percentage-point delta (vs %) for these rate-like metrics
+    pp_delta = {"hit"}
 
     def _delta(cur, bl, key):
         """Return (arrow, delta_str, css_class) or (None, None, None)."""
-        if not cur or not bl:
+        cur_v = _compute(cur, key)
+        bl_v = _compute(bl, key)
+        if cur_v is None or bl_v is None or bl_v == 0:
             return (None, None, None)
-        if key == "hit":
-            cur_v = _hit_rate(cur)
-            bl_v = _hit_rate(bl)
-            if cur_v is None or bl_v is None:
-                return (None, None, None)
-            diff = cur_v - bl_v
+        diff = cur_v - bl_v
+        if key in pp_delta:
             if abs(diff) < 0.0005:
                 return ("→", "0pp", "delta-flat")
             arrow = "↑" if diff > 0 else "↓"
             sign = "+" if diff > 0 else ""
-            return (arrow, f"{sign}{diff * 100:.1f}pp",
-                    "delta-good" if (diff > 0) == (key in higher_better) else "delta-bad")
-        cur_v = cur.get(key, 0) or 0
-        bl_v = bl.get(key, 0) or 0
-        if bl_v == 0:
-            return (None, None, None)
-        diff = cur_v - bl_v
+            cls = "delta-good" if (diff > 0) == (key in higher_better) else "delta-bad"
+            return (arrow, f"{sign}{diff * 100:.1f}pp", cls)
         if diff == 0:
             return ("→", "0%", "delta-flat")
         pct = (diff / bl_v) * 100
         arrow = "↑" if diff > 0 else "↓"
         sign = "+" if diff > 0 else ""
-        return (arrow, f"{sign}{pct:.1f}%",
-                "delta-good" if (diff > 0) == (key in higher_better) else "delta-bad")
+        cls = "delta-good" if (diff > 0) == (key in higher_better) else "delta-bad"
+        return (arrow, f"{sign}{pct:.1f}%", cls)
 
-    cur_total = _total(tokens, run_result)
-    bl_total = _total(bl_tokens, baseline_result)
+    # Inject cost_usd and num_turns into a usage dict so derived metrics
+    # can be computed. Used for the Total column (whole-run aggregate).
+    def _enrich(usage_dict, run_data):
+        if not usage_dict and not run_data:
+            return None
+        merged = dict(usage_dict or {})
+        if run_data:
+            if "cost_usd" in run_data:
+                merged["cost_usd"] = run_data.get("cost_usd")
+            if "num_turns" in run_data:
+                merged["num_turns"] = run_data.get("num_turns")
+        return merged
+
+    cur_total = _enrich(tokens, run_result)
+    bl_total = _enrich(bl_tokens, baseline_result)
     models = sorted(set(per_model) | set(bl_per_model))
     show_total = bool(cur_total or bl_total) and len(models) != 1
+
+    # Build per-model usage dicts. Inject per-model num_turns when the runner
+    # captured it (cross-model runs); fall back to whole-run num_turns when a
+    # side's run had only one model (per-turn rows are then unambiguous).
+    cur_pmt = run_result.get("per_model_turns") or {}
+    bl_pmt = (baseline_result or {}).get("per_model_turns") or {}
+    cur_per_model = {m: dict(per_model.get(m) or {}) for m in models}
+    bl_per_model_d = {m: dict(bl_per_model.get(m) or {}) for m in models}
+    cur_only_model = next(iter(per_model)) if len(per_model) == 1 else None
+    bl_only_model = next(iter(bl_per_model)) if len(bl_per_model) == 1 else None
+    for m in models:
+        if cur_pmt.get(m) is not None:
+            cur_per_model[m].setdefault("num_turns", cur_pmt[m])
+        elif m == cur_only_model and run_result.get("num_turns") is not None:
+            cur_per_model[m].setdefault("num_turns", run_result["num_turns"])
+        if bl_pmt.get(m) is not None:
+            bl_per_model_d[m].setdefault("num_turns", bl_pmt[m])
+        elif (m == bl_only_model and baseline_result
+              and baseline_result.get("num_turns") is not None):
+            bl_per_model_d[m].setdefault("num_turns", baseline_result["num_turns"])
 
     # Build column list: optional Total, then each model
     columns = []
     if show_total:
         columns.append(("Total", cur_total, bl_total))
     for m in models:
-        columns.append((m, per_model.get(m), bl_per_model.get(m)))
+        columns.append((m, cur_per_model.get(m) or None, bl_per_model_d.get(m) or None))
 
     if not columns:
         return ""
 
-    html = '<h3 class="subsection-heading">Token Usage</h3>\n'
+    metrics = [
+        ("Input tokens", "input"),
+        ("Output tokens", "output"),
+        ("Cache read", "cache_read"),
+        ("Cache write", "cache_create"),
+        ("Cache hit", "hit"),
+        ("Cost", "cost_usd"),
+        ("Cost / turn", "cpt"),
+        ("Output tokens / turn", "opt"),
+        ("Cost / Mtok", "mtok"),
+    ]
+
+    html = '<h3 class="subsection-heading">Model Usage</h3>\n'
     html += '<table class="usage-table">\n'
     html += '<tr><th></th>'
     for label, _, _ in columns:

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -675,6 +675,45 @@ def _merge_summary(run_id, key, data, runs_dir=None):
         yaml.dump(summary, f, default_flow_style=False, allow_unicode=True)
 
 
+def compute_run_metrics(run_result):
+    """Derive model/runner-level efficiency metrics from run_result.json.
+
+    These are workload-agnostic: cost per turn, output tokens per turn,
+    cache hit rate, and effective per-million-token prices. They stay
+    flat across runs of the same model+effort, so they're useful for
+    cross-model and cross-effort comparisons.
+
+    Returns None if the required fields are missing.
+    """
+    if not run_result:
+        return None
+    cost = run_result.get("cost_usd")
+    turns = run_result.get("num_turns")
+    tokens = run_result.get("token_usage") or {}
+    inp = tokens.get("input", 0) or 0
+    out = tokens.get("output", 0) or 0
+    cr = tokens.get("cache_read", 0) or 0
+    cw = tokens.get("cache_create", 0) or 0
+    total_in = inp + cr + cw
+
+    total_tokens = total_in + out
+
+    metrics = {}
+    if isinstance(cost, (int, float)) and isinstance(turns, int) and turns > 0:
+        metrics["cost_per_turn_usd"] = round(cost / turns, 6)
+    if isinstance(turns, int) and turns > 0 and out:
+        metrics["output_tokens_per_turn"] = round(out / turns, 2)
+    if total_in > 0:
+        metrics["cache_hit_rate"] = round(cr / total_in, 6)
+    # Effective $/Mtok across all token types (input + cache_read + cache_create
+    # + output), weighted by actual volume. Captures cache benefit: a high
+    # cache_read share pulls this below the model's list price. Useful for
+    # cross-model comparison at fixed effort and similar workload patterns.
+    if isinstance(cost, (int, float)) and total_tokens > 0:
+        metrics["cost_per_mtok_usd"] = round(cost / total_tokens * 1_000_000, 4)
+    return metrics or None
+
+
 def cmd_judges(args):
     config = EvalConfig.from_yaml(args.config)
     runs_dir = _get_runs_dir()
@@ -700,6 +739,22 @@ def cmd_judges(args):
         for name, agg in judge_results.get("aggregated", {}).items()
     }, runs_dir)
     _merge_summary(args.run_id, "per_case", judge_results.get("per_case", {}), runs_dir)
+
+    # Workload-agnostic run metrics for cross-run / cross-model comparison
+    rr_path = runs_dir / args.run_id / "run_result.json"
+    if rr_path.exists():
+        with open(rr_path) as f:
+            run_result = json.load(f)
+        run_metrics = compute_run_metrics(run_result)
+        if run_metrics:
+            _merge_summary(args.run_id, "run_metrics", run_metrics, runs_dir)
+            for k, v in run_metrics.items():
+                if "rate" in k:
+                    print(f"  {k}: {v:.1%}")
+                elif "cost" in k:
+                    print(f"  {k}: ${v:.4f}")
+                else:
+                    print(f"  {k}: {v:,.1f}")
 
     # Regression detection
     has_regressions = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,13 +130,17 @@ def write_transcripts(tmp_path, transcripts):
     for agent_id, messages in transcripts.items():
         lines = []
         for msg_id, role in messages:
-            lines.append(json.dumps({
-                "message": {
-                    "role": role,
-                    "id": msg_id,
-                    "content": [{"type": "text", "text": "..."}],
-                },
-            }))
+            msg = {
+                "role": role,
+                "id": msg_id,
+                "content": [{"type": "text", "text": "..."}],
+            }
+            # Real Claude Code subagent transcripts include `model` on every
+            # assistant message; default to a fixed value so per-model turn
+            # counting has something to attribute to.
+            if role == "assistant":
+                msg["model"] = "claude-sonnet-4-5"
+            lines.append(json.dumps({"message": msg}))
         (subdir / f"agent-{agent_id}.jsonl").write_text("\n".join(lines) + "\n")
     return subdir
 

--- a/tests/test_stream_capture.py
+++ b/tests/test_stream_capture.py
@@ -2,21 +2,23 @@
 
 from conftest import make_assistant, make_result, to_jsonl
 
-from agent_eval.agent.stream_capture import count_subagent_turns, extract_usage
+from agent_eval.agent.stream_capture import (
+    count_subagent_turns, count_subagent_turns_by_model, extract_usage,
+)
 
 
 class TestExtractUsage:
     def test_returns_seen_ids(self, post_2_1_108_stream):
-        """extract_usage returns a 6-tuple including the seen_msg_ids set."""
+        """extract_usage returns a 7-tuple including the seen_msg_ids set."""
         result = extract_usage(post_2_1_108_stream["lines"])
-        assert len(result) == 6
-        _, _, num_turns, seen_msg_ids, _, _ = result
+        assert len(result) == 7
+        _, _, num_turns, seen_msg_ids, _, _, _ = result
         assert isinstance(seen_msg_ids, set)
         assert len(seen_msg_ids) == num_turns
 
     def test_includes_subagent_ids_post_2_1_108(self, post_2_1_108_stream):
         """Post-2.1.108: seen_msg_ids includes foreground subagent message IDs."""
-        _, _, num_turns, seen_ids, _, _ = extract_usage(post_2_1_108_stream["lines"])
+        _, _, num_turns, seen_ids, _, _, _ = extract_usage(post_2_1_108_stream["lines"])
         assert num_turns == 7  # 5 root + 2 foreground subagent
         assert "msg_001" in seen_ids
         assert "msg_sub_001" in seen_ids
@@ -36,11 +38,25 @@ class TestExtractUsage:
                 },
             }),
         ]
-        token_usage, _, _, _, _, per_model = extract_usage(to_jsonl(events))
+        token_usage, _, _, _, _, per_model, _ = extract_usage(to_jsonl(events))
         # Should use modelUsage totals, not assistant event usage
         assert token_usage["input"] == 9000
         assert token_usage["output"] == 3000
         assert per_model["claude-sonnet-4-5"]["cost_usd"] == 0.42
+
+    def test_returns_per_model_msg_ids(self):
+        """seen_msg_ids_by_model groups assistant message IDs by their model."""
+        events = [
+            make_assistant("msg_001", model="claude-opus-4-7"),
+            make_assistant("msg_002", model="claude-opus-4-7"),
+            make_assistant("msg_003", model="claude-sonnet-4-6"),
+        ]
+        _, _, num_turns, _, _, _, by_model = extract_usage(to_jsonl(events))
+        assert by_model == {
+            "claude-opus-4-7": {"msg_001", "msg_002"},
+            "claude-sonnet-4-6": {"msg_003"},
+        }
+        assert num_turns == 3
 
 
 class TestCountSubagentTurns:
@@ -61,10 +77,39 @@ class TestCountSubagentTurns:
         assert count_subagent_turns(tmp_path / "nonexistent") == 0
 
 
+class TestCountSubagentTurnsByModel:
+    def test_returns_empty_for_missing_dir(self, tmp_path):
+        """Non-existent directory returns empty dict."""
+        assert count_subagent_turns_by_model(tmp_path / "nonexistent") == {}
+
+    def test_groups_new_turns_by_model(self, post_2_1_108_stream):
+        """Without already_seen, groups all subagent turns by their model."""
+        per_model = count_subagent_turns_by_model(
+            post_2_1_108_stream["subagent_dir"])
+        # All subagent turns should be attributed to some model. Sum equals
+        # the int returned by count_subagent_turns for the same dir.
+        assert sum(per_model.values()) == 3
+
+    def test_dedupes_against_already_seen_per_model(self, post_2_1_108_stream):
+        """With already_seen_by_model, only NEW per-model IDs are counted."""
+        # Pre-seed with all 3 subagent IDs under whatever model they belong to;
+        # we don't know that model from the fixture, so use the subagent dir's
+        # actual content to construct already_seen_by_model from a first pass.
+        all_seen = count_subagent_turns_by_model(
+            post_2_1_108_stream["subagent_dir"])
+        # Re-pass with the already-counted IDs as "seen" per model — should be 0.
+        # Use the by-model totals from a no-op call as a proxy.
+        # (Simpler: pass an exhaustive set per model.)
+        seeded = {m: {"msg_sub_001", "msg_sub_002", "msg_sub_003"} for m in all_seen}
+        new = count_subagent_turns_by_model(
+            post_2_1_108_stream["subagent_dir"], already_seen_by_model=seeded)
+        assert new == {}
+
+
 class TestCombinedTurnCount:
     def test_no_double_count_post_2_1_108(self, post_2_1_108_stream):
         """Post-2.1.108: combined count deduplicates overlapping IDs."""
-        _, _, stream_turns, stream_ids, _, _ = extract_usage(
+        _, _, stream_turns, stream_ids, _, _, _ = extract_usage(
             post_2_1_108_stream["lines"])
         new_turns = count_subagent_turns(
             post_2_1_108_stream["subagent_dir"], already_seen=stream_ids)
@@ -73,7 +118,7 @@ class TestCombinedTurnCount:
 
     def test_no_overlap_pre_2_1_108(self, pre_2_1_108_stream):
         """Pre-2.1.108: no overlap, sum is correct without dedup changing anything."""
-        _, _, stream_turns, stream_ids, _, _ = extract_usage(
+        _, _, stream_turns, stream_ids, _, _, _ = extract_usage(
             pre_2_1_108_stream["lines"])
         new_turns = count_subagent_turns(
             pre_2_1_108_stream["subagent_dir"], already_seen=stream_ids)


### PR DESCRIPTION
## Summary
- `compute_run_metrics` derives stable efficiency metrics from `run_result.json`: `cost_per_turn_usd`, `output_tokens_per_turn`, `cache_hit_rate`, `cost_per_mtok_usd`.
- `cmd_judges` writes them into `summary.yaml` as `run_metrics` so future analysis can cite stable numbers that stay flat across runs of the same model + effort — useful for cross-model comparison and detecting model/runner drift independent of workload variance.
- Rename `_render_token_usage` → `_render_model_usage` and add the derived metric rows alongside raw token counts. Per-model cost-per-turn rows use `per_model_turns` (from #15) so a multi-model run attributes cost correctly per model.

> Stacks on top of #15 (per-model turns). Merge #15 first, then this PR's diff vs main collapses to just the run metrics work.

## Test plan
- [ ] Run an eval and inspect `summary.yaml` — confirm `run_metrics` block contains all four fields with sensible values.
- [ ] Render the report and confirm Model Usage table shows Cost/turn, Output tokens/turn, and Cost/Mtok rows.
- [ ] For a multi-model run, confirm per-model Cost/turn uses each model's own turn count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)