### PR TITLE
feat: auto-install Python dependencies via SessionStart hook

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,17 @@
     "skills",
     "agents",
     "mlflow"
-  ]
+  ],
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/ensure_deps.py\" \"${CLAUDE_PLUGIN_DATA}\""
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/scripts/ensure_deps.py
+++ b/scripts/ensure_deps.py
@@ -20,6 +20,14 @@ def main():
     plugin_data = Path(sys.argv[1]) if len(sys.argv) > 1 else None
     plugin_root = Path(__file__).parent.parent
 
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-q", "pyyaml>=6.0"],
+            check=False,
+        )
+
     eval_yaml = _find_eval_yaml(plugin_root)
 
     deps = ["pyyaml>=6.0"]
@@ -31,9 +39,8 @@ def main():
         try:
             import yaml
             config = yaml.safe_load(content) or {}
-        except ImportError:
-            config = {}
-        except Exception:
+        except Exception as e:
+            print(f"ensure_deps: failed to parse {eval_yaml}: {e}", file=sys.stderr)
             config = {}
 
         mlflow_cfg = config.get("mlflow", {})

--- a/scripts/ensure_deps.py
+++ b/scripts/ensure_deps.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Install Python dependencies based on what the project actually needs.
+
+Checks eval.yaml (if it exists) to decide which optional deps to install:
+- pyyaml: always required
+- mlflow[genai]: if mlflow.experiment is configured
+- anthropic[vertex]: if LLM judges or pairwise comparison are configured
+
+Caches a stamp file in CLAUDE_PLUGIN_DATA so installs only run once
+(or when eval.yaml changes).
+"""
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    plugin_data = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+    plugin_root = Path(__file__).parent.parent
+
+    eval_yaml = _find_eval_yaml(plugin_root)
+
+    deps = ["pyyaml>=6.0"]
+    needs_mlflow = False
+    needs_anthropic = False
+
+    if eval_yaml and eval_yaml.exists():
+        content = eval_yaml.read_text()
+        try:
+            import yaml
+            config = yaml.safe_load(content) or {}
+        except ImportError:
+            config = {}
+        except Exception:
+            config = {}
+
+        mlflow_cfg = config.get("mlflow", {})
+        if isinstance(mlflow_cfg, dict) and mlflow_cfg.get("experiment"):
+            needs_mlflow = True
+
+        judges = config.get("judges", [])
+        if isinstance(judges, list):
+            for j in judges:
+                if not isinstance(j, dict):
+                    continue
+                if j.get("prompt") or j.get("prompt_file") or j.get("pairwise"):
+                    needs_anthropic = True
+                    break
+
+    if needs_mlflow:
+        deps.append("mlflow[genai]>=3.5")
+    if needs_anthropic:
+        deps.append("anthropic[vertex]>=0.40")
+
+    stamp = _compute_stamp(deps)
+
+    if plugin_data:
+        plugin_data.mkdir(parents=True, exist_ok=True)
+        stamp_file = plugin_data / "deps.stamp"
+        if stamp_file.exists() and stamp_file.read_text().strip() == stamp:
+            return
+
+    missing = []
+    for dep in deps:
+        pkg = dep.split("[")[0].split(">")[0].split("=")[0]
+        import_name = pkg.replace("-", "_").replace("[", "").replace("]", "")
+        if import_name == "pyyaml":
+            import_name = "yaml"
+        try:
+            __import__(import_name)
+        except ImportError:
+            missing.append(dep)
+
+    if not missing:
+        if plugin_data:
+            stamp_file.write_text(stamp)
+        return
+
+    print(f"Installing: {', '.join(missing)}")
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-q"] + missing,
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"pip install failed: {result.stderr}", file=sys.stderr)
+        return
+
+    if plugin_data:
+        stamp_file.write_text(stamp)
+
+
+def _find_eval_yaml(plugin_root):
+    cwd = Path.cwd()
+    for candidate in [cwd / "eval.yaml", plugin_root / "eval.yaml"]:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _compute_stamp(deps):
+    return hashlib.sha256("|".join(sorted(deps)).encode()).hexdigest()[:12]
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ensure_deps.py
+++ b/scripts/ensure_deps.py
@@ -3,7 +3,7 @@
 
 Checks eval.yaml (if it exists) to decide which optional deps to install:
 - pyyaml: always required
-- mlflow[genai]: if mlflow.experiment is configured
+- mlflow[genai]: if a mlflow block is present in eval.yaml
 - anthropic[vertex]: if LLM judges or pairwise comparison are configured
 
 Caches a stamp file in CLAUDE_PLUGIN_DATA so installs only run once
@@ -30,7 +30,7 @@ def main():
 
     eval_yaml = _find_eval_yaml(plugin_root)
 
-    deps = ["pyyaml>=6.0"]
+    deps = [("pyyaml>=6.0", "yaml")]
     needs_mlflow = False
     needs_anthropic = False
 
@@ -43,8 +43,13 @@ def main():
             print(f"ensure_deps: failed to parse {eval_yaml}: {e}", file=sys.stderr)
             config = {}
 
-        mlflow_cfg = config.get("mlflow", {})
-        if isinstance(mlflow_cfg, dict) and mlflow_cfg.get("experiment"):
+        if not isinstance(config, dict):
+            print(f"ensure_deps: expected mapping in {eval_yaml}, got {type(config).__name__}",
+                  file=sys.stderr)
+            config = {}
+
+        mlflow_block = config.get("mlflow")
+        if mlflow_block is not None:
             needs_mlflow = True
 
         judges = config.get("judges", [])
@@ -57,28 +62,29 @@ def main():
                     break
 
     if needs_mlflow:
-        deps.append("mlflow[genai]>=3.5")
+        deps.append(("mlflow[genai]>=3.5", "mlflow"))
     if needs_anthropic:
-        deps.append("anthropic[vertex]>=0.40")
+        deps.append(("anthropic[vertex]>=0.40", "anthropic"))
 
-    stamp = _compute_stamp(deps)
+    stamp = _compute_stamp([spec for spec, _ in deps])
 
+    stamp_file = None
     if plugin_data:
         plugin_data.mkdir(parents=True, exist_ok=True)
         stamp_file = plugin_data / "deps.stamp"
-        if stamp_file.exists() and stamp_file.read_text().strip() == stamp:
-            return
 
     missing = []
-    for dep in deps:
-        pkg = dep.split("[")[0].split(">")[0].split("=")[0]
-        import_name = pkg.replace("-", "_").replace("[", "").replace("]", "")
-        if import_name == "pyyaml":
-            import_name = "yaml"
+    for spec, import_name in deps:
         try:
             __import__(import_name)
         except ImportError:
-            missing.append(dep)
+            missing.append(spec)
+
+    if not missing and stamp_file:
+        stamp_file.write_text(stamp)
+
+    if not missing:
+        return
 
     if not missing:
         if plugin_data:
@@ -87,14 +93,14 @@ def main():
 
     print(f"Installing: {', '.join(missing)}")
     result = subprocess.run(
-        [sys.executable, "-m", "pip", "install", "-q"] + missing,
+        [sys.executable, "-m", "pip", "install", "-q", *missing],
         capture_output=True, text=True
     )
     if result.returncode != 0:
         print(f"pip install failed: {result.stderr}", file=sys.stderr)
         return
 
-    if plugin_data:
+    if stamp_file:
         stamp_file.write_text(stamp)
 
 

--- a/skills/eval-setup/SKILL.md
+++ b/skills/eval-setup/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: eval-setup
-description: Set up the evaluation environment for the agent-eval-harness. Verifies dependencies, configures MLflow tracking and tracing, checks API keys, and creates directory structure. Use when getting started with evaluation, when dependencies are missing, when /eval-run fails with import errors, or when the user says "set up eval", "configure evaluation", "install dependencies", or "how do I get started testing my skill". Also triggers on "ModuleNotFoundError", "No module named agent_eval", "can't import agent_eval", "mlflow not installed", "missing dependencies", or "pip install agent-eval". Run once per project.
+description: Optional environment configurator for the agent-eval-harness. Configures MLflow tracking, verifies API keys, and troubleshoots dependency issues. Not required for basic usage — dependencies auto-install via SessionStart hook and agent_eval is available via symlinks. Use when the user wants to configure MLflow tracking, troubleshoot import errors, verify the environment, or set up a remote MLflow server. Also triggers on "configure mlflow", "set up tracking", "ModuleNotFoundError", "mlflow not installed", "missing dependencies", or "check my eval environment".
 user-invocable: true
 allowed-tools: Read, Bash, Glob, AskUserQuestion
 ---
 
-You are an environment configurator. You ensure the evaluation harness is ready to run — dependencies installed, API keys set, MLflow configured, directories created. Non-destructive: skip steps that are already done, report status.
+You are an environment configurator. You verify the evaluation harness environment and configure optional integrations like MLflow. Non-destructive: skip steps that are already done, report status.
 
-After setup, the pipeline is: `/eval-analyze` → `/eval-dataset` → `/eval-run` → `/eval-review` or `/eval-optimize`. `/eval-mlflow` can be invoked at any point after `/eval-run` to log results, sync datasets, or push/pull feedback — `/eval-run` already auto-logs results when `mlflow.experiment` is set in eval.yaml. MLflow tracing is handled by `/eval-mlflow` after a run completes — it builds traces from stdout logs and logs them to MLflow. No tracing setup is needed here.
+Most users can skip this skill entirely — dependencies auto-install via the plugin's SessionStart hook, and `agent_eval` is available to scripts via symlinks. This skill is useful for configuring MLflow tracking, troubleshooting dependency issues, or verifying the environment.
+
+The eval pipeline is: `/eval-analyze` → `/eval-dataset` → `/eval-run` → `/eval-review` or `/eval-optimize`. `/eval-mlflow` can be invoked at any point after `/eval-run`. MLflow tracing is handled by `/eval-mlflow` after a run completes. No tracing setup is needed here.
 
 ## Step 0: Parse Arguments
 
@@ -19,9 +21,9 @@ Parse `$ARGUMENTS` for:
 | `--skip-mlflow` | no | false | Skip MLflow setup entirely |
 | `--runs-dir <path>` | no | `eval/runs` | Directory where eval runs are stored |
 
-## Step 1: Install Dependencies
+## Step 1: Install Dependencies (if needed)
 
-The `agent_eval` package is available to skill scripts via symlinks — no pip install needed for it. Only third-party dependencies need to be installed.
+Dependencies are normally auto-installed by the plugin's SessionStart hook. This step is a fallback for mid-session installs or troubleshooting.
 
 Check what's missing:
 


### PR DESCRIPTION
## Summary
- Add `SessionStart` hook to `plugin.json` that runs `scripts/ensure_deps.py` on each session start
- The script reads `eval.yaml` to decide which optional deps are needed:
  - **pyyaml**: always installed
  - **mlflow[genai]**: only if `mlflow.experiment` is configured in eval.yaml
  - **anthropic[vertex]**: only if LLM judges or pairwise comparison are configured
- Only installs what's missing (checks each dep via import before calling pip)
- Caches a stamp file in `CLAUDE_PLUGIN_DATA` so pip only runs when the dep set changes
- Complements `/eval-setup` which handles deps interactively as a fallback for mid-session plugin installs

## How it works
1. `SessionStart` fires on new session, resume, `/clear`, or compaction
2. `ensure_deps.py` checks if `eval.yaml` exists and parses it for mlflow/anthropic usage
3. Computes a stamp from the required dep set and compares to cached stamp
4. If stamp matches → skip (zero overhead). If not → check imports, pip install missing ones

## Test plan
- [ ] Run `python3 scripts/ensure_deps.py /tmp/test-data` — verify pyyaml check runs, stamp file created
- [ ] Create an eval.yaml with `mlflow.experiment: test` — verify mlflow gets added to dep list
- [ ] Add an LLM judge to eval.yaml — verify anthropic gets added to dep list
- [ ] Run twice — verify second run is a no-op (stamp matches)
- [ ] Start a new Claude Code session with the plugin — verify hook fires and deps install silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic dependency installer runs when a session starts to ensure required packages.

* **Chores**
  * Added a runtime installer script to check and install optional dependencies as needed.

* **Documentation**
  * Updated eval-setup guidance to reflect automatic dependency installation and that manual setup is largely optional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->