### PR TITLE
Eval harness improvements for interactive skill testing

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -156,6 +156,7 @@ class ModelsConfig:
     skill: Optional[str] = None
     subagent: Optional[str] = None
     judge: Optional[str] = None
+    hook: Optional[str] = None
 
 
 @dataclass
@@ -273,6 +274,7 @@ class EvalConfig:
             skill=models_raw.get("skill"),
             subagent=models_raw.get("subagent"),
             judge=models_raw.get("judge"),
+            hook=models_raw.get("hook"),
         )
 
         # MLflow block. Experiment defaults to the eval's top-level

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -94,11 +94,19 @@ class ExecutionConfig:
     Constraints:
     - timeout: subprocess wall-clock timeout in seconds (None = harness default).
     - max_budget_usd: per-invocation cost cap (None = no cap).
+
+    Environment:
+    - env: extra environment variables injected into each case workspace's
+      .claude/settings.json.  Available to both the skill and its hooks.
+      Values starting with ``$`` are resolved from the caller's environment
+      (e.g., ``$JIRA_TOKEN`` → ``os.environ["JIRA_TOKEN"]``).  Missing
+      vars are silently omitted.  Literal values are passed through as-is.
     """
     mode: str = "case"
     arguments: str = ""
     timeout: Optional[int] = None
     max_budget_usd: Optional[float] = None
+    env: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -244,6 +252,7 @@ class EvalConfig:
             arguments=exec_raw.get("arguments", ""),
             timeout=exec_raw.get("timeout"),
             max_budget_usd=exec_raw.get("max_budget_usd"),
+            env=exec_raw.get("env") or {},
         )
 
         # Runner config (block form)

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -338,10 +338,43 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
     # Write aggregated run_result.json
     total_duration = sum(r["duration_s"] for r in case_results.values())
     total_cost = sum(r.get("cost_usd") or 0 for r in case_results.values())
+    total_turns = sum(r.get("num_turns") or 0 for r in case_results.values())
+
+    # Aggregate token_usage across cases
+    agg_tokens = {}
+    for r in case_results.values():
+        tu = r.get("token_usage") or {}
+        for k, v in tu.items():
+            if isinstance(v, (int, float)):
+                agg_tokens[k] = agg_tokens.get(k, 0) + v
+
+    # Aggregate per_model_usage across cases
+    agg_per_model = {}
+    for r in case_results.values():
+        pmu = r.get("per_model_usage") or {}
+        for m, stats in pmu.items():
+            if m not in agg_per_model:
+                agg_per_model[m] = {}
+            for k, v in stats.items():
+                if isinstance(v, (int, float)):
+                    agg_per_model[m][k] = agg_per_model[m].get(k, 0) + v
+
+    # Aggregate per_model_turns across cases
+    agg_per_model_turns = {}
+    for r in case_results.values():
+        pmt = r.get("per_model_turns") or {}
+        for m, t in pmt.items():
+            if isinstance(t, (int, float)):
+                agg_per_model_turns[m] = agg_per_model_turns.get(m, 0) + t
+
     run_meta = {
         "exit_code": worst_exit,
         "duration_s": round(total_duration, 1),
         "cost_usd": round(total_cost, 2),
+        "token_usage": agg_tokens or None,
+        "num_turns": total_turns or None,
+        "per_model_usage": agg_per_model or None,
+        "per_model_turns": agg_per_model_turns or None,
         "num_cases": len(case_results),
         "model": model,
         "agent": runner.name,

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -60,10 +60,14 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
     record = {"files": {}, "tool_calls": [], "case_dir": str(case_dir)}
 
     # --- Annotations (from dataset case directory) ---
+    record["annotations"] = {}
     case_id = case_dir.name
     if config.dataset_path:
-        annotations_path = Path(config.dataset_path) / case_id / "annotations.yaml"
-        if annotations_path.exists():
+        dataset_root = Path(config.dataset_path).resolve()
+        annotations_path = (dataset_root / case_id / "annotations.yaml").resolve()
+        if (annotations_path.is_relative_to(dataset_root)
+                and annotations_path.is_file()
+                and not annotations_path.is_symlink()):
             try:
                 with open(annotations_path) as f:
                     record["annotations"] = yaml.safe_load(f) or {}

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -59,6 +59,17 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
     case_dir = Path(case_dir).resolve()
     record = {"files": {}, "tool_calls": [], "case_dir": str(case_dir)}
 
+    # --- Annotations (from dataset case directory) ---
+    case_id = case_dir.name
+    if config.dataset_path:
+        annotations_path = Path(config.dataset_path) / case_id / "annotations.yaml"
+        if annotations_path.exists():
+            try:
+                with open(annotations_path) as f:
+                    record["annotations"] = yaml.safe_load(f) or {}
+            except (yaml.YAMLError, OSError):
+                pass
+
     # --- File artifacts (from path outputs) ---
     for output in config.outputs:
         if not output.path:

--- a/skills/eval-run/scripts/tools.py
+++ b/skills/eval-run/scripts/tools.py
@@ -109,6 +109,11 @@ def _handle_ask_user(tool_input, config, handler):
     case_overrides = config.get("case_overrides", {})
     hook_model = config.get("hook_model")
     prompt = handler.get("prompt", "")
+    if not prompt and handler.get("prompt_file"):
+        try:
+            prompt = Path(handler["prompt_file"]).read_text()
+        except OSError:
+            pass
     answers = {}
     for q in tool_input.get("questions", []):
         text = q.get("question", "")
@@ -179,10 +184,11 @@ Reply with ONLY the option label text, nothing else."""
 
     try:
         import anthropic
-        client = anthropic.Anthropic()
+        client = anthropic.Anthropic(timeout=30.0)
         response = client.messages.create(
             model=model or "claude-haiku-4-5-20251001",
             max_tokens=256,
+            temperature=0,
             messages=[{"role": "user", "content": prompt}],
         )
         answer = response.content[0].text.strip()

--- a/skills/eval-run/scripts/tools.py
+++ b/skills/eval-run/scripts/tools.py
@@ -99,15 +99,32 @@ def _find_handler(tool_name, tool_input, handlers):
 
 
 def _handle_ask_user(tool_input, config, handler):
-    """Auto-answer AskUserQuestion using case overrides or first option."""
+    """Auto-answer AskUserQuestion using case overrides, LLM, or first option.
+
+    Resolution order for each question:
+    1. Exact match in case_overrides (question text → answer)
+    2. LLM-based answer (haiku) using the handler prompt + case context
+    3. Fallback: pick the first option or "yes"
+    """
     case_overrides = config.get("case_overrides", {})
+    hook_model = config.get("hook_model")
+    prompt = handler.get("prompt", "")
     answers = {}
     for q in tool_input.get("questions", []):
         text = q.get("question", "")
+        options = q.get("options", [])
+
+        # 1. Exact match
         answer = case_overrides.get(text)
+
+        # 2. LLM-based answer
+        if answer is None and options:
+            answer = _llm_answer(text, options, prompt, model=hook_model)
+
+        # 3. Fallback
         if answer is None:
-            options = q.get("options", [])
             answer = options[0]["label"] if options else "yes"
+
         answers[text] = answer
 
     output = {
@@ -121,6 +138,70 @@ def _handle_ask_user(tool_input, config, handler):
         }
     }
     json.dump(output, sys.stdout)
+
+
+def _llm_answer(question, options, handler_prompt, model=None):
+    """Use an LLM to pick the best answer for a question.
+
+    Reads input.yaml and answers.yaml from CWD for case-specific context.
+    Returns the selected option label, or None if the API call fails.
+    """
+    # Load case context
+    case_context = ""
+    for fname in ("input.yaml", "answers.yaml"):
+        p = Path(fname)
+        if p.exists():
+            try:
+                case_context += f"\n--- {fname} ---\n{p.read_text()}\n"
+            except OSError:
+                pass
+
+    option_labels = [o["label"] for o in options]
+    option_list = "\n".join(
+        f"  {i+1}. {o['label']}: {o.get('description', '')}"
+        for i, o in enumerate(options)
+    )
+
+    prompt = f"""You are answering a question on behalf of a user during an automated evaluation run.
+
+Handler instructions: {handler_prompt}
+
+Case context:
+{case_context}
+
+Question: {question}
+
+Available options:
+{option_list}
+
+Based on the handler instructions and case context, which option should be selected?
+Reply with ONLY the option label text, nothing else."""
+
+    try:
+        import anthropic
+        client = anthropic.Anthropic()
+        response = client.messages.create(
+            model=model or "claude-haiku-4-5-20251001",
+            max_tokens=256,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        answer = response.content[0].text.strip()
+        # Verify the answer matches an option label
+        if answer in option_labels:
+            print(f"LLM answered: {answer!r}", file=sys.stderr)
+            return answer
+        # Try fuzzy match — LLM might have added quotes or slight variation
+        answer_lower = answer.lower().strip('"\'')
+        for label in option_labels:
+            if label.lower() == answer_lower:
+                print(f"LLM answered (fuzzy): {label!r}", file=sys.stderr)
+                return label
+        print(f"LLM answer {answer!r} not in options {option_labels}",
+              file=sys.stderr)
+    except Exception as e:
+        print(f"LLM answer failed: {e}", file=sys.stderr)
+
+    return None
 
 
 def _deny(reason):

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import argparse
+import os
 import re
 import shutil
 import sys
@@ -313,6 +314,24 @@ def _expand_symlink_permissions(allow_list):
     return allow_list + extras
 
 
+def _inject_env(settings, config):
+    """Inject execution.env into settings.json env block.
+
+    Values starting with ``$`` are resolved from ``os.environ``.
+    Missing env vars are silently omitted.  Literal values pass through.
+    """
+    if not config.execution.env:
+        return
+    env_block = settings.setdefault("env", {})
+    for key, value in config.execution.env.items():
+        if isinstance(value, str) and value.startswith("$"):
+            resolved = os.environ.get(value[1:])
+            if resolved is not None:
+                env_block[key] = resolved
+        else:
+            env_block[key] = str(value)
+
+
 def _carry_over_permissions(settings):
     """Copy project permissions (allow, deny, additionalDirectories) into settings."""
     import json as _json
@@ -393,6 +412,9 @@ def _setup_subagent_only_hook(workspace, config):
     from agent_eval.agent.stream_capture import setup_subagent_hook
     subagent_dir = str((workspace / "subagents").resolve())
     setup_subagent_hook(settings, subagent_dir)
+
+    # Inject execution.env into settings
+    _inject_env(settings, config)
 
     # Apply user-provided runner.settings last so they can override defaults
     _apply_runner_settings(settings, config)
@@ -491,6 +513,9 @@ def _setup_tool_hooks(workspace, config):
     from agent_eval.agent.stream_capture import setup_subagent_hook
     subagent_dir = str((workspace / "subagents").resolve())
     setup_subagent_hook(settings, subagent_dir)
+
+    # Inject execution.env into settings
+    _inject_env(settings, config)
 
     # Apply user-provided runner.settings last so they can override defaults
     _apply_runner_settings(settings, config)

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -472,8 +472,11 @@ def _setup_tool_hooks(workspace, config):
         hook_matchers.update(patterns)
 
     # Write tool_handlers.yaml
+    handler_data = {"handlers": handlers}
+    if config.models.hook:
+        handler_data["hook_model"] = config.models.hook
     with open(workspace / "tool_handlers.yaml", "w") as f:
-        yaml.dump({"handlers": handlers}, f, default_flow_style=False)
+        yaml.dump(handler_data, f, default_flow_style=False)
 
     # Copy interceptor script
     hooks_dir = workspace / "hooks"


### PR DESCRIPTION
## Summary

Four improvements to support interactive skill evaluation with external services (like jira-emulator for duplicate RFE detection testing):

- **Aggregate per-case metrics** — `run_result.json` now includes top-level `token_usage`, `num_turns`, `per_model_usage` aggregated from per-case results, fixing empty model usage tables in HTML reports
- **`execution.env` support** — eval configs can inject environment variables into workspace `.claude/settings.json`, with `$VAR` syntax for resolving from the caller's environment
- **Annotations in judge records** — judges can now access `outputs["annotations"]` from the dataset's `annotations.yaml`, enabling outcome-aware scoring (e.g., "no RFE expected for confirmed duplicates")
- **LLM-based AskUserQuestion answering** — the PreToolUse hook calls a configurable model (`models.hook`) to answer questions using case context (`input.yaml`, `answers.yaml`), replacing the brittle first-option default with context-aware responses

## Test plan

- [x] 44 existing tests pass
- [x] Tested end-to-end with rfe.create dedup evaluation against jira-emulator
- [x] Verified model usage table renders correctly in HTML report
- [x] Verified LLM answerer correctly identifies duplicates and non-duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variables can now be injected into workspace settings via configuration.
  * Enhanced user question handling with LLM-based answering as fallback when overrides unavailable.
  * Dataset annotations support for per-case evaluation.
  * Expanded run metrics with aggregated token usage, turn counts, and per-model statistics.
  * Configurable hook model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->