### PR TITLE
Update eval-run skill for LLM answering and annotations

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -170,6 +170,10 @@ class JudgeConfig:
     """
     name: str = ""
     description: str = ""  # What this judge checks (context for LLM judges)
+    # Condition — Python expression evaluated against the outputs dict.
+    # If it returns False, the judge is skipped for that case (not counted
+    # in pass_rate or mean).  Example: "not annotations.get('dedup_is_duplicate')"
+    condition: str = ""
     # Inline code check (returns (bool, str))
     check: str = ""
     # LLM judge / pairwise
@@ -342,6 +346,7 @@ class EvalConfig:
             config.judges.append(JudgeConfig(
                 name=j.get("name", ""),
                 description=j.get("description", ""),
+                condition=j.get("if", ""),
                 check=j.get("check", ""),
                 prompt=j.get("prompt", ""),
                 prompt_file=j.get("prompt_file", ""),

--- a/skills/eval-dataset/SKILL.md
+++ b/skills/eval-dataset/SKILL.md
@@ -135,7 +135,7 @@ dedup_guidance: >
 
 The LLM reads these fields alongside the question and options to pick the right answer. For general clarifying questions, the LLM uses `input.yaml` context — no `answers.yaml` needed. Only create `answers.yaml` when the case has domain-specific decisions (e.g., "is this a duplicate?", "should this be split?") where the correct answer depends on the test scenario.
 
-If unsure what questions the skill asks, leave `answers.yaml` out — the hook falls back to picking the first option or "yes".
+If unsure what questions the skill asks, you can leave `answers.yaml` out — the hook still calls the LLM using `input.yaml` context and the handler prompt, falling back to the first option only if the LLM call fails.
 
 **Annotations for outcome-aware judges**: Judges receive `outputs["annotations"]` — the parsed `annotations.yaml` from each case. If the eval config has judges that check expected outcomes (e.g., `annotations.get("dedup_is_duplicate")` to determine whether no output is correct), add the relevant fields to each case's `annotations.yaml`:
 

--- a/skills/eval-dataset/SKILL.md
+++ b/skills/eval-dataset/SKILL.md
@@ -122,15 +122,32 @@ case-005-ambiguous-phrasing/
 
 **Realism**: Cases should look like something a real user would encounter. Don't generate lorem ipsum or obviously synthetic inputs. Use realistic names, scenarios, and domain language appropriate to the skill.
 
-**Answers for interactive skills**: If eval.yaml has `inputs.tools` entries for AskUserQuestion, the skill asks questions during execution. Each test case should include an `answers.yaml` file mapping likely questions to answers. Check `inputs.tools` for the AskUserQuestion handler's prompt — it describes default answers. Override per case where the expected answer differs:
+**Answers for interactive skills**: If eval.yaml has `inputs.tools` entries for AskUserQuestion, the skill asks questions during execution. The hook uses LLM-based answering (via `models.hook`) that reads `input.yaml` and `answers.yaml` from each case as context. Create `answers.yaml` with **guidance** that tells the LLM how to answer domain-specific questions for this case:
 
 ```yaml
-# answers.yaml — per-case overrides for AskUserQuestion
-"What priority should this have?": "High"
-"Should this be split into multiple items?": "No"
+# answers.yaml — LLM answerer guidance for this case
+dedup_is_duplicate: true
+dedup_guidance: >
+  This RFE is intentionally a rephrased version of an existing RFE
+  about model signature verification. If asked whether existing RFEs
+  cover this need, the answer is yes.
 ```
 
-If unsure what questions the skill asks, leave `answers.yaml` out — the hook script auto-accepts with "yes" or the first option.
+The LLM reads these fields alongside the question and options to pick the right answer. For general clarifying questions, the LLM uses `input.yaml` context — no `answers.yaml` needed. Only create `answers.yaml` when the case has domain-specific decisions (e.g., "is this a duplicate?", "should this be split?") where the correct answer depends on the test scenario.
+
+If unsure what questions the skill asks, leave `answers.yaml` out — the hook falls back to picking the first option or "yes".
+
+**Annotations for outcome-aware judges**: Judges receive `outputs["annotations"]` — the parsed `annotations.yaml` from each case. If the eval config has judges that check expected outcomes (e.g., `annotations.get("dedup_is_duplicate")` to determine whether no output is correct), add the relevant fields to each case's `annotations.yaml`:
+
+```yaml
+# annotations.yaml — fields for outcome-aware judges
+dedup_is_duplicate: true   # or false — tells judges whether no RFE is expected
+tags: [dedup, high-overlap]
+known_issues:
+  - dedup should flag this as overlapping with RHAIRFE-1001
+```
+
+Check the eval.yaml `judges` section for any `check` snippets that access `outputs.get("annotations", {})` — those fields must exist in annotations.yaml for the judge to work correctly.
 
 **Companion files**: If eval.md lists `companion_files` (files the skill reads from disk at runtime — e.g., `strategy.md`, `adr.md`), each test case must include them. In `case` mode, the harness copies all case files into the workspace, so the skill will find them at their expected relative paths. Generate realistic content for these files appropriate to each case's scenario.
 

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -109,14 +109,14 @@ Read `${CLAUDE_SKILL_DIR}/references/tool-interception.md` for the full format a
 
 1. Read the `match` and `prompt` fields
 2. Resolve the `prompt` into concrete runtime checks:
-   - **For AskUserQuestion**: load per-case answers from dataset `answers.yaml` files into `case_overrides`. If the dataset has none, the auto-accept fallback (first option / "yes") is fine.
+   - **For AskUserQuestion**: the hook uses 3-tier answer resolution — (1) exact match from `case_overrides`, (2) LLM call using `models.hook` with the handler `prompt` + case context (`input.yaml`, `answers.yaml`), (3) fallback to first option. If the dataset has `answers.yaml` files with guidance for domain-specific questions (e.g., `dedup_guidance: "this is a duplicate"`), the LLM answerer uses that context. If no `answers.yaml` exists, the LLM still uses `input.yaml` context + the handler prompt. Only add `case_overrides` for questions that need exact deterministic answers.
    - **For service interception** (Jira, Slack, etc.): add `env_checks` (which env vars to validate) and `input_filters` (regex patterns for Bash command content). For Bash this is required, not optional.
    - **For blocking**: explicit MCP patterns (e.g. `mcp__atlassian__*`) deny by default once matched; just confirm the patterns are right.
 3. Write the updated handler back to `tool_handlers.yaml`
 
 Before continuing to Step 4, sanity-check: every `Bash` pattern has matching `input_filters`, and every non-Bash handler either has `env_checks` or is intended to deny by default.
 
-The hook script (`tools.py`) uses these concrete checks at runtime — no LLM needed during execution.
+The hook script (`tools.py`) uses these concrete checks at runtime. AskUserQuestion calls use the `models.hook` LLM for context-aware answers; all other checks are deterministic.
 
 ## Step 4: Execute Skill
 
@@ -210,8 +210,9 @@ Judges receive a record dict with:
 - **Execution metadata**: `outputs["exit_code"]`, `outputs["duration_s"]`, `outputs["cost_usd"]`, `outputs["num_turns"]` (if `traces.metrics` enabled)
 - **Tool calls**: `outputs["tool_calls"]` (if `outputs` has `tool:` entries)
 - **Logs**: `outputs["stdout"]`, `outputs["stderr"]` (if `traces.stdout`/`stderr` enabled)
+- **Annotations**: `outputs["annotations"]` — parsed `annotations.yaml` from the dataset case directory (always present, empty dict if no file). Use for outcome-aware scoring where expected results depend on the test case.
 
-This means judges can check both output quality AND execution efficiency (cost, turns, errors).
+This means judges can check output quality, execution efficiency, AND expected outcomes from annotations.
 
 If `--baseline` was specified, also run pairwise comparison:
 

--- a/skills/eval-run/references/tool-interception.md
+++ b/skills/eval-run/references/tool-interception.md
@@ -56,7 +56,7 @@ case_overrides:
 
 1. Match by pattern: `patterns: ["AskUserQuestion"]`
 2. **Tier 1 — exact match**: look up the question text in `case_overrides`
-3. **Tier 2 — LLM call**: if no exact match and options are available, call the `hook_model` with the question, options, handler `prompt`, and case context (`input.yaml` + `answers.yaml` from CWD). The LLM picks the best option based on context.
+3. **Tier 2 — LLM call**: if no exact match and options are available, call the `hook_model` with the question, options, handler `prompt`, and case context (`input.yaml` + `answers.yaml` from CWD). The LLM picks the best option based on context. **Note**: case files are sent to the LLM API — do not put secrets, credentials, or PII in `input.yaml` or `answers.yaml`.
 4. **Tier 3 — fallback**: pick the first option, or "yes"
 5. Return `permissionDecision: "allow"` with `updatedInput` containing answers
 

--- a/skills/eval-run/references/tool-interception.md
+++ b/skills/eval-run/references/tool-interception.md
@@ -5,9 +5,9 @@ This documents how `inputs.tools` handlers are resolved and executed during head
 ## Flow
 
 1. **eval.yaml** defines handlers with `match` (what to intercept) and `prompt` (how to handle)
-2. **workspace.py** extracts basic tool name patterns from `match` text and writes `tool_handlers.yaml`
+2. **workspace.py** extracts basic tool name patterns from `match` text, writes `tool_handlers.yaml`, and includes `hook_model` from `models.hook`
 3. **eval-run agent (Step 3b)** reads `tool_handlers.yaml`, interprets the `prompt` field, and adds concrete runtime checks
-4. **tools.py** (PreToolUse hook) executes the checks at runtime — no LLM needed during execution
+4. **tools.py** (PreToolUse hook) executes the checks at runtime. AskUserQuestion uses a 3-tier resolution: exact `case_overrides` match → LLM call (using `hook_model`) → first-option fallback. All other tool checks are deterministic.
 
 ## tool_handlers.yaml Format
 
@@ -16,7 +16,10 @@ handlers:
   # AskUserQuestion handler
   - match: "Questions asked to the user via AskUserQuestion."
     patterns: ["AskUserQuestion"]
-    prompt: "Answer based on the test case. Default to 'yes'."
+    prompt: |
+      Answer based on the test case context in input.yaml and answers.yaml.
+      Use answers.yaml guidance for domain-specific decisions.
+      Default: pick the first option or answer "yes" for confirmations.
 
   # External service handler (Jira via MCP AND scripts)
   - match: "Any Jira interaction via MCP tools or scripts."
@@ -27,10 +30,12 @@ handlers:
         must_contain: ["localhost", "emulator", "127.0.0.1", "test"]
     prompt: "Only allow if JIRA_SERVER points to a test instance."
 
-# Per-case answer overrides (from dataset answers.yaml)
+# Model for LLM-based AskUserQuestion answering (from models.hook)
+hook_model: claude-haiku-4-5-20251001
+
+# Per-case exact-match answer overrides (optional — LLM answering is preferred)
 case_overrides:
   "What priority should this have?": "Normal"
-  "Should this be split?": "No"
 ```
 
 ### Fields
@@ -41,17 +46,19 @@ case_overrides:
 | `patterns` | workspace.py (heuristic extraction) | tools.py | Tool name patterns for matching (exact or glob) |
 | `input_filters` | eval-run agent (Step 3b) | tools.py | Regex patterns to match Bash command content. When present with "Bash" in patterns, BOTH must match. |
 | `env_checks` | eval-run agent (Step 3b) | tools.py | Env var validation. Each key is a var name, `must_contain` lists required substrings. All must pass for the tool call to be allowed. |
-| `prompt` | workspace.py (from eval.yaml) | eval-run agent | Natural language instruction — the agent reads this to generate concrete checks |
-| `case_overrides` | eval-run agent (from dataset answers.yaml) | tools.py | Question → answer map for AskUserQuestion. Checked before auto-accept fallback. |
+| `prompt` | workspace.py (from eval.yaml) | eval-run agent, tools.py | Natural language instruction — the agent reads this to generate concrete checks. Also passed to the LLM answerer as context for AskUserQuestion. |
+| `hook_model` | workspace.py (from models.hook) | tools.py | Model ID for LLM-based AskUserQuestion answering. Defaults to `claude-haiku-4-5-20251001`. |
+| `case_overrides` | eval-run agent (optional) | tools.py | Question → answer map for AskUserQuestion. Exact-match tier — checked before LLM and fallback. |
 
 ## How tools.py Handles Each Tool Type
 
 ### AskUserQuestion
 
 1. Match by pattern: `patterns: ["AskUserQuestion"]`
-2. Look up answers in `case_overrides` (question text → answer)
-3. If no override found, auto-accept: pick the first option, or "yes"
-4. Return `permissionDecision: "allow"` with `updatedInput` containing answers
+2. **Tier 1 — exact match**: look up the question text in `case_overrides`
+3. **Tier 2 — LLM call**: if no exact match and options are available, call the `hook_model` with the question, options, handler `prompt`, and case context (`input.yaml` + `answers.yaml` from CWD). The LLM picks the best option based on context.
+4. **Tier 3 — fallback**: pick the first option, or "yes"
+5. Return `permissionDecision: "allow"` with `updatedInput` containing answers
 
 ### MCP Tools (e.g., mcp__atlassian__*)
 
@@ -75,7 +82,7 @@ Tools with no matching handler pass through (exit 0, no interception).
 
 Read each handler in `tool_handlers.yaml` and resolve the `prompt` into concrete fields:
 
-1. **For AskUserQuestion**: Read the prompt for default answers. If the dataset has `answers.yaml` files per case, load them into `case_overrides`.
+1. **For AskUserQuestion**: The LLM answerer handles most questions automatically using the handler `prompt` + case context. Only add `case_overrides` entries for questions that need exact deterministic answers. The `answers.yaml` file in each case directory provides guidance the LLM reads at runtime — you don't need to load it into `case_overrides`.
 
 2. **For service interception** (Jira, Slack, etc.): Read the prompt and add:
    - `env_checks`: which env vars to validate and what values indicate test instances
@@ -117,6 +124,7 @@ Read each handler in `tool_handlers.yaml` and resolve the `prompt` into concrete
         }
     ],
     "files": {...},
+    "annotations": {...},
     "exit_code": 0,
     "cost_usd": 0.15,
     ...

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -864,7 +864,11 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
         status_cls = "skip"
         status_label = "—"
 
-        if isinstance(thresh, dict):
+        if pass_rate is None and mean is None:
+            # All cases skipped (condition was false) — show SKIP pill
+            status_cls = "skip"
+            status_label = "SKIP"
+        elif isinstance(thresh, dict):
             if "min_pass_rate" in thresh and pass_rate is not None:
                 thresh_str = f"&ge; {_pct(thresh['min_pass_rate'])}"
                 ok = pass_rate >= thresh["min_pass_rate"]
@@ -1292,6 +1296,8 @@ def _md_table_to_html(table_lines):
                 html += f'<td><span class="pass">{inner}</span></td>'
             elif stripped == "FAIL":
                 html += f'<td><span class="fail">{inner}</span></td>'
+            elif stripped in ("SKIP", "SKIPPED"):
+                html += f'<td><span class="skip">{inner}</span></td>'
             else:
                 html += f"<td>{inner}</td>"
         html += "</tr>\n"
@@ -1384,17 +1390,21 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
         case_dir = cases_dir / case_id
         label = case_id
 
-        # Count pass/fail — bool judges: True=pass, False=fail
+        # Count pass/fail/skip — bool judges: True=pass, False=fail
         # Numeric judges (LLM): pass if score >= threshold min_mean
+        # None values: skipped (condition was false)
         thresholds = config.get("thresholds", {})
         passed = 0
         failed = 0
+        skipped = 0
         total = len(case_results)
         for jname, r in case_results.items():
             if not isinstance(r, dict):
                 continue
             val = r.get("value")
-            if val is True:
+            if val is None:
+                skipped += 1
+            elif val is True:
                 passed += 1
             elif val is False:
                 failed += 1
@@ -1421,9 +1431,11 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
         else:
             accent_class = f"case-{status}"
 
+        scored = total - skipped
+        skip_note = f", {skipped} skip" if skipped else ""
         html += (f'<details open class="case {accent_class}"><summary>'
                  f'<span class="{status}">{_esc(str(label))}</span> '
-                 f'<span class="skip">({passed}/{total} pass)</span>'
+                 f'<span class="skip">({passed}/{scored} pass{skip_note})</span>'
                  f'{pw_badge}</summary>\n')
 
         # Judge results table
@@ -1435,7 +1447,9 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
             rat = str(jresult.get("rationale", ""))
             err = jresult.get("error", "")
 
-            if val is True:
+            if val is None:
+                val_html = '<span class="skip">SKIP</span>'
+            elif val is True:
                 val_html = '<span class="pass">PASS</span>'
             elif val is False:
                 val_html = '<span class="fail">FAIL</span>'
@@ -1473,8 +1487,12 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
         # Output files — when baseline is provided, skip files under output_paths
         # since those will appear in the baseline diff section below.
         has_baseline = bl_cases_dir and (bl_cases_dir / case_id).exists()
+        # Execution logs — not skill output, exclude from the report
+        _EXEC_LOGS = {"stdout.log", "stderr.log", "run_result.json"}
         if case_dir.exists():
             files = sorted(f for f in case_dir.rglob("*") if f.is_file()
+                           and f.name not in _EXEC_LOGS
+                           and not str(f.relative_to(case_dir)).startswith("subagents/")
                            and not any(str(f.relative_to(case_dir)).startswith(sp)
                                        for sp in shared_paths))
             if has_baseline:

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -865,9 +865,21 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
         status_label = "—"
 
         if pass_rate is None and mean is None:
-            # All cases skipped (condition was false) — show SKIP pill
-            status_cls = "skip"
-            status_label = "SKIP"
+            # No aggregatable values — distinguish skip from error by
+            # checking per-case results for this judge
+            per_case = summary.get("per_case", {})
+            has_errors = any(
+                isinstance((per_case.get(c) or {}).get(judge_name), dict)
+                and (per_case[c][judge_name].get("error")
+                     or per_case[c][judge_name].get("value") is False)
+                for c in per_case
+            )
+            if has_errors:
+                status_cls = "fail"
+                status_label = "ERROR"
+            else:
+                status_cls = "skip"
+                status_label = "SKIP"
         elif isinstance(thresh, dict):
             if "min_pass_rate" in thresh and pass_rate is not None:
                 thresh_str = f"&ge; {_pct(thresh['min_pass_rate'])}"
@@ -1487,11 +1499,13 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
         # Output files — when baseline is provided, skip files under output_paths
         # since those will appear in the baseline diff section below.
         has_baseline = bl_cases_dir and (bl_cases_dir / case_id).exists()
-        # Execution logs — not skill output, exclude from the report
-        _EXEC_LOGS = {"stdout.log", "stderr.log", "run_result.json"}
+        # Execution logs at the case root — not skill output, exclude from
+        # the report.  Only exclude root-level files, not nested ones with the
+        # same name (a skill could legitimately produce artifacts/stdout.log).
+        _EXEC_LOG_PATHS = {"stdout.log", "stderr.log", "run_result.json"}
         if case_dir.exists():
             files = sorted(f for f in case_dir.rglob("*") if f.is_file()
-                           and f.name not in _EXEC_LOGS
+                           and str(f.relative_to(case_dir)) not in _EXEC_LOG_PATHS
                            and not str(f.relative_to(case_dir)).startswith("subagents/")
                            and not any(str(f.relative_to(case_dir)).startswith(sp)
                                        for sp in shared_paths))

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -231,16 +231,16 @@ def load_judges(config, project_root=None):
                   file=sys.stderr)
             continue
         if scorer:
-            judges.append((jc.name, scorer))
+            judges.append((jc.name, scorer, jc.condition))
     return judges
 
 
 def score_cases(judges, case_dirs, config, run_id=None):
     """Score all cases with all judges in parallel."""
     if not case_dirs:
-        return {"per_case": {}, "aggregated": {n: {"values": [], "mean": None, "pass_rate": None} for n, _ in judges}}
+        return {"per_case": {}, "aggregated": {n: {"values": [], "mean": None, "pass_rate": None} for n, _, _c in judges}}
     per_case = {}
-    aggregated = {name: {"values": []} for name, _ in judges}
+    aggregated = {name: {"values": []} for name, _, _c in judges}
     parallelism = min(len(case_dirs), os.cpu_count() or 4)
     lock = threading.Lock()
     completed = 0
@@ -249,7 +249,24 @@ def score_cases(judges, case_dirs, config, run_id=None):
         case_id = case_dir.name
         record = load_case_record(case_dir, config, run_id=run_id)
         case_results = {}
-        for name, scorer in judges:
+        for name, scorer, condition in judges:
+            # Check condition — skip if it evaluates to False
+            if condition:
+                try:
+                    annotations = record.get("annotations", {})
+                    if not eval(condition, {"__builtins__": {}},
+                                {"annotations": annotations, "outputs": record}):
+                        case_results[name] = {
+                            "value": None,
+                            "rationale": f"Skipped: condition '{condition}' is false",
+                        }
+                        continue
+                except Exception as e:
+                    case_results[name] = {
+                        "value": None,
+                        "rationale": f"Condition error: {e}",
+                    }
+                    continue
             try:
                 result = scorer(outputs=record)
                 # Normalize — accepts (bool, str) tuples, Feedback, primitives
@@ -761,7 +778,7 @@ def cmd_judges(args):
 
     judges = load_judges(config, project_root)
     print(f"Scoring {len(case_dirs)} cases with {len(judges)} judges: "
-          f"{[n for n, _ in judges]}")
+          f"{[n for n, *_ in judges]}")
 
     judge_results = score_cases(judges, case_dirs, config, run_id=args.run_id)
 

--- a/skills/eval-setup/SKILL.md
+++ b/skills/eval-setup/SKILL.md
@@ -41,7 +41,7 @@ If `--skip-mlflow` was NOT passed, also install mlflow:
 pip install 'mlflow[genai]>=3.5'
 ```
 
-For LLM judges and pairwise comparison (optional):
+For LLM judges, pairwise comparison, and LLM-based AskUserQuestion answering in hooks:
 
 ```bash
 pip install 'anthropic[vertex]>=0.40'
@@ -123,6 +123,27 @@ export AGENT_EVAL_RUNS_DIR=<path>
 ```
 
 All harness scripts read this env var. The directory is created automatically by `check_env.py --fix`.
+
+## Step 5b: Check Skill-Specific Environment Variables
+
+If eval.yaml exists and has `execution.env` entries with `$VAR` references, those variables must be set in the caller's environment at eval-run time. Check whether they're available:
+
+```bash
+test -f eval.yaml && PYTHONPATH=${CLAUDE_SKILL_DIR}/scripts python3 -c "
+from agent_eval.config import EvalConfig
+config = EvalConfig.from_yaml('eval.yaml')
+import os
+for key, value in config.execution.env.items():
+    if isinstance(value, str) and value.startswith('\$'):
+        var_name = value[1:]
+        status = 'set' if os.environ.get(var_name) else 'NOT SET'
+        print(f'  {key}: \${var_name} → {status}')
+    else:
+        print(f'  {key}: {value} (literal)')
+" 2>/dev/null
+```
+
+If any `$VAR` references are unset, warn the user — they'll need to `export` them before running `/eval-run`. Common examples: `JIRA_SERVER` for jira-emulator, `JIRA_TOKEN` for Jira API access.
 
 ## Step 6: Create MLflow Experiment
 

--- a/skills/eval-setup/SKILL.md
+++ b/skills/eval-setup/SKILL.md
@@ -139,8 +139,9 @@ for key, value in config.execution.env.items():
         status = 'set' if os.environ.get(var_name) else 'NOT SET'
         print(f'  {key}: \${var_name} → {status}')
     else:
-        print(f'  {key}: {value} (literal)')
-" 2>/dev/null
+        # Mask literal values to avoid leaking credentials in logs
+        print(f'  {key}: (literal, {len(str(value))} chars)')
+" 2>&1 || echo "  (could not parse eval.yaml)"
 ```
 
 If any `$VAR` references are unset, warn the user — they'll need to `export` them before running `/eval-run`. Common examples: `JIRA_SERVER` for jira-emulator, `JIRA_TOKEN` for Jira API access.


### PR DESCRIPTION
## Summary

Update the eval-run SKILL.md to document two recent harness features:

- **Step 3b**: Document 3-tier AskUserQuestion resolution (exact match → LLM call via `models.hook` → fallback) and `answers.yaml` as LLM context for domain-specific questions
- **Step 6**: Add `outputs["annotations"]` to the judge record dict so judge authors know dataset annotations are available for outcome-aware scoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Prefer LLM-driven, case-specific answer guidance; require per-case annotations for outcome validation and clarify when per-case guidance is optional.
  * Clarified three-tier AskUserQuestion resolution: exact deterministic match, context-aware LLM answer using case files, then fallback.

* **New Features**
  * Judges can be conditionally skipped per case based on evaluated case outputs/annotations.

* **Improvements**
  * Reports mark skipped/errored judges, count skips in summaries, and filter execution log artifacts from output listings.

* **Setup**
  * Added preflight checks for required environment variables before running evaluations; LLM hook dependency noted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->