### PR TITLE
fix: workspace git init, permissions merge, and report badge rendering

### DIFF
--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -959,7 +959,7 @@ def _render_regressions(summary, config):
     html += "<tr><th>Judge</th><th>Metric</th><th>Threshold</th><th>Actual</th></tr>\n"
     for judge, metric, expected, actual in regressions:
         html += (f'<tr><td>{_esc(judge)}</td><td>{metric}</td>'
-                 f'<td>{expected}</td><td class="fail">{actual}</td></tr>\n')
+                 f'<td>{expected}</td><td><span class="fail">{actual}</span></td></tr>\n')
     html += "</table>\n"
     return html
 
@@ -1303,12 +1303,14 @@ def _md_table_to_html(table_lines):
             # Color-code PASS/FAIL cells: wrap content in a badge span so the
             # `display: inline-block` badge style does not break <td> layout.
             stripped = c.strip()
+            # Strip bold/italic markdown for keyword matching
+            bare = stripped.strip("*").strip("_")
             inner = _md_inline(c)
-            if stripped == "PASS":
+            if bare in ("PASS", "FIXED"):
                 html += f'<td><span class="pass">{inner}</span></td>'
-            elif stripped == "FAIL":
+            elif bare in ("FAIL", "REGRESSION"):
                 html += f'<td><span class="fail">{inner}</span></td>'
-            elif stripped in ("SKIP", "SKIPPED"):
+            elif bare in ("SKIP", "SKIPPED"):
                 html += f'<td><span class="skip">{inner}</span></td>'
             else:
                 html += f"<td>{inner}</td>"

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1304,7 +1304,7 @@ def _md_table_to_html(table_lines):
             # `display: inline-block` badge style does not break <td> layout.
             stripped = c.strip()
             # Strip bold/italic markdown for keyword matching
-            bare = stripped.strip("*").strip("_")
+            bare = stripped.strip("*_")
             inner = _md_inline(c)
             if bare in ("PASS", "FIXED"):
                 html += f'<td><span class="pass">{inner}</span></td>'

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -510,6 +510,16 @@ def _setup_tool_hooks(workspace, config):
     # Carry over permissions (allow, deny, additionalDirectories)
     _carry_over_permissions(settings)
 
+    # Merge eval.yaml permissions.allow into settings.json so that
+    # named subagent types (which may not inherit --allowed-tools from
+    # the parent CLI) still get the harness permission patterns.
+    if config.permissions.get("allow"):
+        harness_allow = _expand_symlink_permissions(list(config.permissions["allow"]))
+        existing = settings.setdefault("permissions", {}).setdefault("allow", [])
+        for pattern in harness_allow:
+            if pattern not in existing:
+                existing.append(pattern)
+
     # Grant access to the project root so symlinked resources (skills,
     # scripts, context) can be read by the sandbox.
     project_root = str(Path.cwd().resolve())

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -17,6 +17,7 @@ import argparse
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -68,6 +69,11 @@ def main():
     if workspace.exists():
         shutil.rmtree(workspace)
     workspace.mkdir(parents=True, mode=0o700)
+
+    # Initialize a bare git repo so Claude Code subagents can discover
+    # the project root and load .claude/settings.json with the expanded
+    # permission patterns (e.g. /private/tmp variants on macOS).
+    subprocess.run(["git", "init", "-q", str(workspace)], check=True)
 
     # Branch on execution mode
     if config.execution.mode == "case":
@@ -186,6 +192,7 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
         case_id = case_dir.name
         case_ws = workspace / "cases" / case_id
         case_ws.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init", "-q", str(case_ws)], check=True)
 
         # Copy ALL files from the dataset case directory (H-2)
         for f in case_dir.iterdir():

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -368,6 +368,19 @@ def _carry_over_permissions(settings):
             "additionalDirectories", []).extend(dirs)
 
 
+def _merge_harness_permissions(settings, config):
+    """Merge eval.yaml permissions.allow into settings so named subagents
+    (which may not inherit --allowed-tools) receive the harness patterns."""
+    allow = (config.permissions or {}).get("allow") if hasattr(config, "permissions") else None
+    if not allow:
+        return
+    harness_allow = _expand_symlink_permissions(list(allow))
+    existing = settings.setdefault("permissions", {}).setdefault("allow", [])
+    for pattern in harness_allow:
+        if pattern not in existing:
+            existing.append(pattern)
+
+
 def _deep_merge(dst, src):
     """Recursively merge src into dst. Lists are extended, dicts merged."""
     for k, v in src.items():
@@ -409,6 +422,7 @@ def _setup_subagent_only_hook(workspace, config):
 
     # Carry over project permissions (allow, deny, additionalDirectories)
     _carry_over_permissions(settings)
+    _merge_harness_permissions(settings, config)
 
     # Grant project root access
     project_root = str(Path.cwd().resolve())
@@ -510,15 +524,7 @@ def _setup_tool_hooks(workspace, config):
     # Carry over permissions (allow, deny, additionalDirectories)
     _carry_over_permissions(settings)
 
-    # Merge eval.yaml permissions.allow into settings.json so that
-    # named subagent types (which may not inherit --allowed-tools from
-    # the parent CLI) still get the harness permission patterns.
-    if config.permissions.get("allow"):
-        harness_allow = _expand_symlink_permissions(list(config.permissions["allow"]))
-        existing = settings.setdefault("permissions", {}).setdefault("allow", [])
-        for pattern in harness_allow:
-            if pattern not in existing:
-                existing.append(pattern)
+    _merge_harness_permissions(settings, config)
 
     # Grant access to the project root so symlinked resources (skills,
     # scripts, context) can be read by the sandbox.


### PR DESCRIPTION
## Summary

- **Report badge rendering**: Wrap regression table values in `<span>` instead of applying fail class to `<td>` (fixes layout). Extend markdown table conversion to recognize FIXED/REGRESSION keywords and strip bold/italic before matching.
- **Workspace git init**: Initialize bare git repos in eval workspaces so Claude Code subagents can discover `.claude/settings.json` and load permission patterns (fixes `/private/tmp` symlink issues on macOS).
- **Permissions merge**: Merge `eval.yaml` `permissions.allow` patterns into each workspace's `settings.json` so named subagent types (which don't inherit `--allowed-tools`) get the same tool access.

## Test plan
- [ ] Run `/eval-run` and verify report HTML renders PASS/FAIL/FIXED/REGRESSION badges correctly
- [ ] Run `/eval-run` in case mode and verify workspace directories contain `.git/`
- [ ] Verify subagents in workspaces can access tools listed in `permissions.allow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved markdown table status detection to handle bold/italic formatting and recognize additional status types including REGRESSION and FIXED.
  * Enhanced HTML rendering for test regression reports.

* **Chores**
  * Initialized git repositories in workspace directories for improved project detection and configuration loading.
  * Refined permission configuration inheritance for tool access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->