### PR TITLE
feat: attach input files as MLflow run artifacts for from-traces extraction

### DIFF
--- a/agent_eval/mlflow/traces.py
+++ b/agent_eval/mlflow/traces.py
@@ -60,49 +60,78 @@ def extract_trace_inputs(traces, max_results: int = 10) -> list:
     """Extract root span inputs from traces for dataset generation.
 
     Args:
-        traces: List of trace objects from mlflow.search_traces().
+        traces: DataFrame or list of trace objects from mlflow.search_traces().
         max_results: Maximum inputs to extract.
 
     Returns:
-        List of dicts with trace_id, input_text, tool_interactions.
+        List of dicts with trace_id, eval_run_id, input_text, tool_interactions.
     """
-    results = []
-    for trace in traces[:max_results]:
-        try:
-            info = trace.info if hasattr(trace, "info") else trace
-            trace_id = getattr(info, "request_id", getattr(info, "trace_id", ""))
+    try:
+        import pandas as pd
+        is_df = isinstance(traces, pd.DataFrame)
+    except ImportError:
+        is_df = False
 
-            # Extract root span input
-            data = trace.data if hasattr(trace, "data") else None
+    if is_df:
+        rows = [traces.iloc[i] for i in range(min(len(traces), max_results))]
+    else:
+        rows = traces[:max_results]
+
+    results = []
+    for trace in rows:
+        try:
             input_text = ""
             tool_interactions = []
+            eval_run_id = ""
 
-            if data and hasattr(data, "spans") and data.spans:
-                root = data.spans[0]
-                inputs = getattr(root, "inputs", {})
-                if isinstance(inputs, dict):
-                    input_text = inputs.get("prompt", inputs.get("input", str(inputs)))
-                elif isinstance(inputs, str):
-                    input_text = inputs
-
-                # Extract tool interactions from child spans
-                for span in data.spans[1:]:
-                    span_name = getattr(span, "name", "")
-                    if "AskUserQuestion" in span_name:
-                        span_inputs = getattr(span, "inputs", {})
-                        span_outputs = getattr(span, "outputs", {})
+            if is_df:
+                trace_id = trace.get("trace_id", "")
+                tags = trace.get("tags", {}) or {}
+                eval_run_id = tags.get("eval_run_id", "") if isinstance(tags, dict) else ""
+                request = trace.get("request", {})
+                if isinstance(request, dict):
+                    input_text = request.get("prompt", request.get("input", ""))
+                spans = trace.get("spans", []) or []
+                for span in spans:
+                    name = span.get("name", "") if isinstance(span, dict) else getattr(span, "name", "")
+                    if "AskUserQuestion" in name:
+                        attrs = span.get("attributes", {}) if isinstance(span, dict) else {}
                         tool_interactions.append({
                             "tool": "AskUserQuestion",
-                            "input": span_inputs,
-                            "output": span_outputs,
+                            "input": attrs,
+                            "output": {},
                         })
+            else:
+                info = trace.info if hasattr(trace, "info") else trace
+                trace_id = getattr(info, "request_id", getattr(info, "trace_id", ""))
+                tags = getattr(info, "tags", {}) or {}
+                eval_run_id = tags.get("eval_run_id", "") if isinstance(tags, dict) else ""
+                data = trace.data if hasattr(trace, "data") else None
+                if data and hasattr(data, "spans") and data.spans:
+                    root = data.spans[0]
+                    inputs = getattr(root, "inputs", {})
+                    if isinstance(inputs, dict):
+                        input_text = inputs.get("prompt", inputs.get("input", str(inputs)))
+                    elif isinstance(inputs, str):
+                        input_text = inputs
+                    for span in data.spans[1:]:
+                        span_name = getattr(span, "name", "")
+                        if "AskUserQuestion" in span_name:
+                            tool_interactions.append({
+                                "tool": "AskUserQuestion",
+                                "input": getattr(span, "inputs", {}),
+                                "output": getattr(span, "outputs", {}),
+                            })
 
             if input_text:
-                results.append({
+                entry = {
                     "trace_id": trace_id,
                     "input_text": input_text,
                     "tool_interactions": tool_interactions,
-                })
+                }
+                if eval_run_id:
+                    entry["eval_run_id"] = eval_run_id
+                results.append(entry)
         except Exception:
             continue
 

--- a/skills/eval-mlflow/scripts/from_traces.py
+++ b/skills/eval-mlflow/scripts/from_traces.py
@@ -30,6 +30,77 @@ from agent_eval.mlflow.experiment import get_experiment_id, resolve_tracking_uri
 from agent_eval.mlflow.traces import extract_trace_inputs
 
 
+def _attach_input_artifacts(extracted, experiment_id):
+    """Enrich extracted traces with input artifacts from linked MLflow runs.
+
+    For each trace with an eval_run_id tag, finds the MLflow run that logged
+    the eval results and downloads batch.yaml or per-case input.yaml artifacts.
+    """
+    import os
+    import tempfile
+
+    client = mlflow.MlflowClient()
+
+    run_ids_by_name = {}
+    for entry in extracted:
+        eval_run_id = entry.get("eval_run_id")
+        if not eval_run_id or eval_run_id in run_ids_by_name:
+            continue
+        try:
+            runs = mlflow.search_runs(
+                experiment_ids=[experiment_id],
+                filter_string=f"tags.mlflow.runName = '{eval_run_id}'",
+                max_results=1,
+            )
+            if not runs.empty:
+                run_ids_by_name[eval_run_id] = runs.iloc[0].run_id
+        except Exception:
+            continue
+
+    if not run_ids_by_name:
+        return
+
+    for entry in extracted:
+        eval_run_id = entry.get("eval_run_id")
+        mlflow_run_id = run_ids_by_name.get(eval_run_id)
+        if not mlflow_run_id:
+            continue
+
+        try:
+            artifacts = client.list_artifacts(mlflow_run_id, "inputs")
+        except Exception:
+            continue
+
+        if not artifacts:
+            continue
+
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                local_path = client.download_artifacts(mlflow_run_id, "inputs", tmp)
+            except Exception:
+                continue
+
+            from pathlib import Path
+            inputs_dir = Path(local_path)
+
+            batch_path = inputs_dir / "batch.yaml"
+            if batch_path.exists():
+                entry["batch_yaml"] = yaml.safe_load(batch_path.read_text())
+
+            for case_dir in sorted(inputs_dir.iterdir()):
+                if case_dir.is_dir():
+                    inp = case_dir / "input.yaml"
+                    if inp.exists():
+                        entry.setdefault("case_inputs", {})[case_dir.name] = (
+                            yaml.safe_load(inp.read_text())
+                        )
+
+    enriched = sum(1 for e in extracted if "batch_yaml" in e or "case_inputs" in e)
+    if enriched:
+        print(f"Enriched {enriched}/{len(extracted)} traces with input artifacts",
+              file=sys.stderr)
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -64,7 +135,7 @@ def main():
         print(f"ERROR: failed to search traces: {e}", file=sys.stderr)
         sys.exit(1)
 
-    if not traces:
+    if traces.empty:
         print(f"No traces found in experiment '{experiment_name}'", file=sys.stderr)
         sys.exit(2)
 
@@ -74,6 +145,9 @@ def main():
     if not extracted:
         print("No usable inputs extracted from traces", file=sys.stderr)
         sys.exit(2)
+
+    # Enrich with input artifacts from linked MLflow runs.
+    _attach_input_artifacts(extracted, exp_id)
 
     # Output as YAML
     yaml.dump(extracted, sys.stdout, default_flow_style=False,

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -156,9 +156,23 @@ def main():
         for tag_key, tag_value in (config.mlflow.tags or {}).items():
             mlflow.set_tag(tag_key, str(tag_value))
 
-        # ── Artifact ─────────────────────────────────────────────
+        # ── Artifacts ────────────────────────────────────────────
         if summary_path.exists():
             mlflow.log_artifact(str(summary_path))
+
+        # Log input files for from-traces extraction.
+        for name in ("batch.yaml", "case_order.yaml"):
+            p = run_dir / name
+            if p.exists():
+                mlflow.log_artifact(str(p), "inputs")
+        cases_dir = run_dir / "cases"
+        if cases_dir.is_dir():
+            for case_dir in sorted(cases_dir.iterdir()):
+                if not case_dir.is_dir():
+                    continue
+                inp = case_dir / "input.yaml"
+                if inp.exists():
+                    mlflow.log_artifact(str(inp), f"inputs/{case_dir.name}")
 
         # ── Per-case results table ───────────────────────────────
         per_case = summary.get("per_case", {})

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -166,6 +166,10 @@ def main():
     )
 
     _save_result(result, args, output_dir, runner, model, eval_params=eval_params)
+
+    # Copy batch input files to output dir for MLflow artifact logging.
+    _copy_input_files_batch(Path(args.workspace), output_dir)
+
     sys.exit(result.exit_code)
 
 
@@ -304,6 +308,11 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
         if result.stderr:
             (case_output / "stderr.log").write_text(result.stderr)
 
+        # Copy input.yaml for MLflow artifact logging.
+        if input_path.exists() and not input_path.is_symlink():
+            import shutil
+            shutil.copy2(input_path, case_output / "input.yaml")
+
         # Copy subagent transcripts
         ws_subagents = case_ws / "subagents"
         if ws_subagents.exists() and ws_subagents.is_dir():
@@ -395,6 +404,15 @@ def _execute_per_case(args, config, runner, output_dir, max_budget, timeout_s,
           f"{sum(1 for r in case_results.values() if r['exit_code'] != 0)} FAIL)")
 
     sys.exit(worst_exit)
+
+
+def _copy_input_files_batch(workspace, output_dir):
+    """Copy batch.yaml and case_order.yaml to output dir for MLflow artifact logging."""
+    import shutil
+    for name in ("batch.yaml", "case_order.yaml"):
+        src = workspace / name
+        if src.exists() and not src.is_symlink():
+            shutil.copy2(src, output_dir / name)
 
 
 def _save_result(result, args, output_dir, runner, model, eval_params=None):


### PR DESCRIPTION
## Summary

- **execute.py**: Copy `batch.yaml` + `case_order.yaml` (batch mode) and per-case `input.yaml` (case mode) from workspace to output directory after execution
- **log_results.py**: Log input files as MLflow run artifacts under `inputs/` path
- **traces.py**: Extract `eval_run_id` from trace tags for run-trace correlation
- **from_traces.py**: Look up MLflow run via `eval_run_id`, download input artifacts, enrich extracted traces with `batch_yaml`/`case_inputs` fields

## Motivation

When using `/eval-dataset --strategy from-traces`, batch-mode skills lack the actual input content because it lives in `batch.yaml` (not in trace spans, which only capture the prompt text). This makes it impossible to reconstruct full test cases from production traces. The batch.yaml for 20 cases is ~55KB, exceeding span attribute limits, so MLflow run artifacts are the right storage mechanism.

## Test plan
- [ ] Run `/eval-run --model opus` on a batch-mode skill
- [ ] Verify `eval/runs/<id>/batch.yaml` exists in output dir
- [ ] Run `/eval-mlflow --run-id <id>` — check MLflow UI shows `inputs/batch.yaml` artifact
- [ ] Run `/eval-dataset --strategy from-traces --count 5` — verify extracted cases include batch content

🤖 Generated with [Claude Code](https://claude.com/claude-code)