### PR TITLE
fix: resolve plugin_dirs to absolute paths in per-case execution

### DIFF
--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -100,9 +100,13 @@ def main():
     mlflow_experiment = args.mlflow_experiment or config.mlflow.experiment
     effort = args.effort or config.runner.effort
 
+    # Resolve plugin_dirs relative to project root (CWD) so they survive
+    # the workspace CWD change — keeps plugin names stable.
+    resolved_plugin_dirs = [str(Path(d).resolve()) for d in config.runner.plugin_dirs] if config.runner.plugin_dirs else []
+
     runner = runner_cls(
         permissions=config.permissions,
-        plugin_dirs=config.runner.plugin_dirs,
+        plugin_dirs=resolved_plugin_dirs,
         env_strip=config.runner.env_strip,
         system_prompt=config.runner.system_prompt,
         subagent_model=subagent_model,

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -181,9 +181,12 @@ def _find_gold_standard_image(case_id: str, dataset_path: str):
     """Find a gold standard image for a case from the dataset annotations."""
     if not dataset_path:
         return None
-    case_ds = Path(dataset_path) / case_id
+    dataset_root = Path(dataset_path).resolve()
+    case_ds = (dataset_root / case_id).resolve()
+    if not case_ds.is_relative_to(dataset_root):
+        return None
     ann_path = case_ds / "annotations.yaml"
-    if not ann_path.is_file():
+    if not ann_path.is_file() or ann_path.is_symlink():
         return None
     ann = _load_yaml(ann_path)
     gold_name = ann.get("gold_diagram")
@@ -193,8 +196,10 @@ def _find_gold_standard_image(case_id: str, dataset_path: str):
     full_stem = gold_name  # e.g. "gold-standard.drawio"
     for suffix in _IMAGE_SUFFIXES:
         for candidate_name in [f"{full_stem}{suffix}", f"{stem}{suffix}"]:
-            candidate = case_ds / candidate_name
-            if candidate.is_file():
+            candidate = (case_ds / candidate_name).resolve()
+            if (candidate.is_relative_to(dataset_root)
+                    and candidate.is_file()
+                    and not candidate.is_symlink()):
                 return candidate
     return None
 
@@ -1787,6 +1792,9 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
                         elif curr_uri:
                             diffs.append((f"{out_path}/{name} (new)",
                                 _render_standalone_image(curr_uri, name)))
+                        elif base_uri:
+                            diffs.append((f"{out_path}/{name} (deleted)",
+                                _render_standalone_image(base_uri, f"{name} (baseline)")))
                         continue
                     # Text comparison
                     try:
@@ -1826,6 +1834,8 @@ def _wrap_section(content: str) -> str:
 def generate_report(config, summary, run_result, run_dir,
                     review=None, baseline_dir=None,
                     baseline_summary=None, baseline_result=None):
+    global _img_compare_counter
+    _img_compare_counter = 0
     name = config.get("name", "Eval")
     run_id = summary.get("run_id", run_dir.name)
 
@@ -1853,8 +1863,6 @@ def generate_report(config, summary, run_result, run_dir,
     html += _wrap_section(_render_regressions(summary, config))
     html += _wrap_section(_render_shared_outputs(run_dir, config))
     html += _render_per_case(summary, run_dir, config, baseline_dir, review)
-    global _img_compare_counter
-    _img_compare_counter = 0
     html += f"\n<script>{TOGGLE_SCRIPT}</script>\n"
     html += f"<script>{IMAGE_COMPARE_SCRIPT}</script>\n"
     html += "</body>\n</html>\n"


### PR DESCRIPTION
## Summary
- Resolve `plugin_dirs` to absolute paths in `execute.py` before passing to the runner
- In per-case mode, the runner's CWD is the case workspace directory, so relative paths like `"."` resolve to the workspace instead of the project root
- This caused plugin names to be derived from case directory names (e.g., `case-001-eval-analyze:skill-diagram`) instead of the original project name (e.g., `diagram-skills:skill-diagram`), breaking skill invocations

## Test plan
- [ ] Run `eval-run` with `plugin_dirs: ["."]` in per-case mode — verify skills are invoked with the correct plugin prefix
- [ ] Verify internal skill chaining (e.g., `skill-diagram` invoking `diagram-layout`) resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plugin directory path resolution so configured plugin paths remain correct after working-directory changes.

* **New Features**
  * Runner results now surface detected permission-denial events so permission issues are reported alongside run output.
  * HTML eval reports now include interactive image comparisons (current vs baseline vs gold).

* **Documentation**
  * Added testing instructions and guidance for marking externally-constrained dataset fields.

* **Tests**
  * Added unit and skipped-by-default E2E tests and fixture for external-state scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->