### PR TITLE
Fix onion comparison mode with different-sized images

### DIFF
--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -538,6 +538,8 @@ a:hover { text-decoration: underline; }
 /* Onion */
 .img-compare-onion-wrap { display: grid; border: 1px solid var(--border); border-radius: 4px; background: #fff; overflow: hidden; }
 .img-compare-onion-wrap > img { grid-area: 1/1; display: block; width: 100%; height: auto; }
+.img-compare-onion-wrap .onion-top { grid-area: 1/1; background: #fff; }
+.img-compare-onion-wrap .onion-top img { display: block; width: 100%; height: auto; }
 .img-compare-onion input[type="range"] { display: block; width: 100%; margin: 8px 0 0; accent-color: var(--accent); }
 .img-compare-onion .onion-label { text-align: center; font-size: 0.82em; color: var(--text-muted); margin-top: 2px; }
 
@@ -1569,7 +1571,7 @@ def _render_image_compare(gen_uri, ref_uri, gen_label="Generated",
         f'    <div class="img-compare-onion">\n'
         f'      <div class="img-compare-onion-wrap">\n'
         f'        <img src="{ref_uri}" alt="{_esc(ref_label)}">\n'
-        f'        <img class="onion-top" src="{gen_uri}" alt="{_esc(gen_label)}" style="opacity:0.5">\n'
+        f'        <div class="onion-top" style="opacity:0.5"><img src="{gen_uri}" alt="{_esc(gen_label)}"></div>\n'
         f'      </div>\n'
         f'      <input type="range" min="0" max="100" value="50">\n'
         f'      <div class="img-compare-swipe-labels">'


### PR DESCRIPTION
## Summary
- When comparing images of different dimensions in onion mode, the larger image's extra area was fully visible regardless of the opacity slider
- Wrap the top (generated) image in a `<div>` with `background: #fff` — setting opacity on the wrapper makes the white background fade too, correctly dimming the reference across the full area

## Test plan
- [ ] Open a report with image comparisons where generated and gold standard have different aspect ratios
- [ ] Switch to Onion tab and drag the slider to 0% — only the reference should be visible, no extra generated area bleeding through
- [ ] Drag to 100% — only the generated should be visible
- [ ] Verify side-by-side and swipe modes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined image overlay comparison styling and layout structure for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->