### PR TITLE
Add Makefile and local dev marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "agent-eval-harness-dev",
+  "owner": {
+    "name": "opendatahub-io"
+  },
+  "metadata": {
+    "description": "Local development marketplace for the agent-eval-harness plugin."
+  },
+  "plugins": [
+    {
+      "name": "agent-eval-harness",
+      "version": "0.1.0",
+      "description": "Agent and skill evaluation harness with MLflow integration",
+      "author": {
+        "name": "opendatahub-io"
+      },
+      "source": "./",
+      "homepage": "https://github.com/opendatahub-io/agent-eval-harness",
+      "repository": "https://github.com/opendatahub-io/agent-eval-harness"
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.PHONY: validate install uninstall test test-e2e test-all help
+
+MARKETPLACE := agent-eval-harness-dev
+PLUGIN := agent-eval-harness@$(MARKETPLACE)
+
+validate:
+	claude plugin validate ./
+
+install:
+	@claude plugin rm $(PLUGIN) 2>/dev/null || true
+	@claude plugin marketplace rm $(MARKETPLACE) 2>/dev/null || true
+	@claude plugin marketplace add ./ && echo "Marketplace added."
+	claude plugin install $(PLUGIN)
+
+uninstall:
+	@echo "Removing plugin..."
+	@claude plugin rm $(PLUGIN) 2>/dev/null || echo "Plugin not installed"
+	@echo "Removing marketplace..."
+	@claude plugin marketplace rm $(MARKETPLACE) 2>/dev/null || echo "Marketplace not installed"
+
+test:
+	python3 -m pytest tests/ -v
+
+test-e2e:
+	python3 -m pytest tests/e2e/ -v -s -m e2e
+
+test-all:
+	python3 -m pytest tests/ -v -s -m ""
+
+help:
+	@echo "Available targets:"
+	@echo "  validate   - Validate plugin manifest"
+	@echo "  install    - Install plugin persistently via local marketplace"
+	@echo "  uninstall  - Remove plugin and local marketplace"
+	@echo "  test       - Run unit tests"
+	@echo "  test-e2e   - Run e2e tests (requires ANTHROPIC_API_KEY)"
+	@echo "  test-all   - Run all tests"


### PR DESCRIPTION
## Summary

- Add a `Makefile` with `validate`, `install`, `uninstall`, `test`, `test-e2e`, and `test-all` targets
- Add `.claude-plugin/marketplace.json` to enable persistent local plugin installation

## Why a marketplace.json?

The README documents two installation methods:

1. **Registry:** `claude plugin install agent-eval-harness@opendatahub-skills`
2. **Session-only:** `claude --plugin-dir ./agent-eval-harness`

For local development, the `--plugin-dir` flag only loads the plugin for a single session. To install the plugin *persistently* (so it's available across sessions without extra flags), `claude plugin install` requires a marketplace registry. There is no way to persistently install a local plugin without one.

The `marketplace.json` wraps the existing `plugin.json` (which is unchanged) as a local dev marketplace, so `make install` can register it and install the plugin in one step.

## Usage

```bash
make install     # Register local marketplace + install plugin
make uninstall   # Remove plugin + marketplace
make validate    # Validate plugin manifest
make test        # Unit tests
make test-e2e    # E2E tests (requires ANTHROPIC_API_KEY)
make test-all    # All tests
```

## Test plan

- [x] `make install` registers marketplace and installs plugin
- [x] `make install` is idempotent (clean re-install on repeated runs)
- [x] `make uninstall` removes both plugin and marketplace
- [x] `make validate` passes
- [ ] Verify existing `claude plugin install agent-eval-harness@opendatahub-skills` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added local development marketplace support to enable installing and managing the agent-eval-harness plugin.
  * Introduced reusable make targets for validation, install/uninstall, and various test runs (unit/e2e/help).

* **New Features**
  * Improved skill discovery: now prioritizes declared skills, and falls back to discovering nested or marketplace-provided skill directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->