### PR TITLE
Discover skills in nested plugins via marketplace.json

### DIFF
--- a/skills/eval-analyze/scripts/find_skills.py
+++ b/skills/eval-analyze/scripts/find_skills.py
@@ -24,6 +24,16 @@ HARNESS_SKILLS = {"eval-setup", "eval-analyze", "eval-dataset", "eval-run",
                    "eval-review", "eval-mlflow", "eval-optimize"}
 
 
+def _resolve_under_cwd(raw, base):
+    """Resolve a path relative to base, rejecting traversal outside CWD."""
+    candidate = (base / Path(raw)).resolve()
+    try:
+        candidate.relative_to(Path.cwd().resolve())
+    except ValueError:
+        return None
+    return candidate
+
+
 def _skills_from_plugin_json(plugin_json):
     """Extract skill directories from a plugin.json file.
 
@@ -36,11 +46,19 @@ def _skills_from_plugin_json(plugin_json):
         if skills_field:
             plugin_root = plugin_json.parent.parent
             if isinstance(skills_field, str):
-                return [str(plugin_root / skills_field.lstrip("./"))]
+                p = _resolve_under_cwd(skills_field, plugin_root)
+                return [str(p)] if p else None
             elif isinstance(skills_field, list):
-                return [str(plugin_root / s.lstrip("./")) for s in skills_field]
-    except Exception:
-        pass
+                result = []
+                for s in skills_field:
+                    if not isinstance(s, str):
+                        continue
+                    p = _resolve_under_cwd(s, plugin_root)
+                    if p:
+                        result.append(str(p))
+                return result or None
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"WARNING: failed to read {plugin_json}: {e}", file=sys.stderr)
     return None
 
 
@@ -53,7 +71,8 @@ def _discover_via_marketplace():
     try:
         with open(marketplace) as f:
             data = json.load(f)
-    except Exception:
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"WARNING: failed to read {marketplace}: {e}", file=sys.stderr)
         return []
 
     dirs = []
@@ -61,7 +80,9 @@ def _discover_via_marketplace():
         source = plugin.get("source", "")
         if not source:
             continue
-        source_path = Path(source.lstrip("./"))
+        source_path = _resolve_under_cwd(source, Path.cwd())
+        if not source_path:
+            continue
         nested_pj = source_path / ".claude-plugin" / "plugin.json"
         if nested_pj.exists():
             from_pj = _skills_from_plugin_json(nested_pj)
@@ -85,10 +106,12 @@ def get_skill_dirs():
     """
     plugin_json = Path(".claude-plugin/plugin.json")
     from_root = _skills_from_plugin_json(plugin_json) if plugin_json.exists() else None
+    from_root = [d for d in (from_root or []) if Path(d).is_dir()]
     if from_root:
         return from_root
 
     from_marketplace = _discover_via_marketplace()
+    from_marketplace = [d for d in from_marketplace if Path(d).is_dir()]
     if from_marketplace:
         return from_marketplace
 

--- a/skills/eval-analyze/scripts/find_skills.py
+++ b/skills/eval-analyze/scripts/find_skills.py
@@ -24,25 +24,74 @@ HARNESS_SKILLS = {"eval-setup", "eval-analyze", "eval-dataset", "eval-run",
                    "eval-review", "eval-mlflow", "eval-optimize"}
 
 
+def _skills_from_plugin_json(plugin_json):
+    """Extract skill directories from a plugin.json file.
+
+    Returns a list of skill dir paths (relative to CWD) or None.
+    """
+    try:
+        with open(plugin_json) as f:
+            manifest = json.load(f)
+        skills_field = manifest.get("skills")
+        if skills_field:
+            plugin_root = plugin_json.parent.parent
+            if isinstance(skills_field, str):
+                return [str(plugin_root / skills_field.lstrip("./"))]
+            elif isinstance(skills_field, list):
+                return [str(plugin_root / s.lstrip("./")) for s in skills_field]
+    except Exception:
+        pass
+    return None
+
+
+def _discover_via_marketplace():
+    """Follow marketplace.json source paths to find nested plugin skill dirs."""
+    marketplace = Path(".claude-plugin/marketplace.json")
+    if not marketplace.exists():
+        return []
+
+    try:
+        with open(marketplace) as f:
+            data = json.load(f)
+    except Exception:
+        return []
+
+    dirs = []
+    for plugin in data.get("plugins", []):
+        source = plugin.get("source", "")
+        if not source:
+            continue
+        source_path = Path(source.lstrip("./"))
+        nested_pj = source_path / ".claude-plugin" / "plugin.json"
+        if nested_pj.exists():
+            from_pj = _skills_from_plugin_json(nested_pj)
+            if from_pj:
+                dirs.extend(from_pj)
+                continue
+        # Default: <source>/skills/
+        default_skills = source_path / "skills"
+        if default_skills.is_dir():
+            dirs.append(str(default_skills))
+    return dirs
+
+
 def get_skill_dirs():
     """Get skill directories for the current project.
 
-    Reads .claude-plugin/plugin.json for a custom 'skills' field.
-    Falls back to the default locations.
+    Priority:
+    1. Root .claude-plugin/plugin.json 'skills' field
+    2. Nested plugins discovered via marketplace.json source paths
+    3. Default locations (.claude/skills, skills)
     """
     plugin_json = Path(".claude-plugin/plugin.json")
-    if plugin_json.exists():
-        try:
-            with open(plugin_json) as f:
-                manifest = json.load(f)
-            skills_field = manifest.get("skills")
-            if skills_field:
-                if isinstance(skills_field, str):
-                    return [skills_field.lstrip("./")]
-                elif isinstance(skills_field, list):
-                    return [s.lstrip("./") for s in skills_field]
-        except Exception:
-            pass
+    from_root = _skills_from_plugin_json(plugin_json) if plugin_json.exists() else None
+    if from_root:
+        return from_root
+
+    from_marketplace = _discover_via_marketplace()
+    if from_marketplace:
+        return from_marketplace
+
     return DEFAULT_SKILL_DIRS
 
 


### PR DESCRIPTION
## Summary

- Teaches `find_skills.py` to follow `marketplace.json` source paths to discover skill directories in nested plugins
- Fixes false "skill not found" validator warnings for wrapper projects like [cc-prose](https://github.com/rhuss/cc-prose) where the plugin lives in a subdirectory (e.g., `./prose`)
- Discovery priority: root `plugin.json` skills field, then marketplace source paths, then default dirs

## Test plan

- [ ] Verified against [cc-prose](https://github.com/rhuss/cc-prose): validator reports `VALID` instead of `INCOMPLETE`, all five prose skills discovered
- [ ] Existing behavior unchanged for projects with root-level plugin.json or default skill dirs

Assisted-By: 🤖 Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved skill-directory discovery: supports marketplace-discovered nested plugins and flexible config formats (string or list).
  * Safer handling: prevents outside-directory traversal, resolves paths, and filters out non-existent directories.
  * Behavior: respects discovery priority and emits warnings when marketplace reads fail.
  * No user-facing interfaces or commands changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->