### PR TITLE
Prevent eval-analyze from generating "." as output path

### DIFF
--- a/skills/eval-analyze/prompts/analyze-skill.md
+++ b/skills/eval-analyze/prompts/analyze-skill.md
@@ -32,10 +32,15 @@ inputs:
 
 outputs:
   # File artifacts written to disk — field names match eval.yaml
-  - path: "<directory where the pipeline writes final outputs>"
+  # IMPORTANT: path must be a named subdirectory (e.g., "output", "artifacts"),
+  # never "." — the harness cleans output dirs between runs.
+  # For stdout-only skills, use "output" as a conventional empty directory.
+  - path: "<named subdirectory for outputs, e.g. 'output' or 'artifacts'>"
     schema: |
       <what is produced here — file types, naming patterns, content
-       structure. Describe what you actually observed, not generic patterns.>
+       structure. Describe what you actually observed, not generic patterns.
+       If the skill writes to stdout rather than files, note that judges
+       should read outputs["stdout"] instead of outputs["files"].>
   # Tool call side effects (if the skill calls external APIs)
   # - tool: "<tool name pattern, e.g. mcp__atlassian__create_issue>"
   #   schema: |

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -116,9 +116,13 @@ inputs:
     #     Only allow if targeting a test instance or emulator.
 
 # Outputs — what the skill produces (files on disk or tool calls)
+# IMPORTANT: path must be a named subdirectory (e.g., "output", "artifacts").
+# Never use "." — the harness cleans output dirs between runs, and "." would
+# delete the entire project. For skills that only write to stdout (captured
+# via traces.stdout), use "output" as a conventional empty directory.
 outputs:
   # File artifacts on disk
-  - path: <output directory>
+  - path: <output directory, e.g. "output" or "artifacts" — never ".">
     schema: |
       <natural language description of artifacts in this directory>
     # batch_pattern: "PREFIX-{n:03d}"


### PR DESCRIPTION
## Summary

- Add explicit constraints to the analyze-skill prompt and eval-yaml template to prohibit `.` as an output path
- Guide the LLM agent toward `"output"` as the conventional directory for stdout-only skills

## Problem

When `/eval-analyze` analyzed a stdout-only skill (the [cc-prose](https://github.com/rhuss/cc-prose) humanizer), the LLM agent generated `path: .` in the `outputs` section of `eval.yaml`. This passed generation but failed at `/eval-run` preflight:

```
ValueError: outputs[0].path cannot be '.' (project root) — use a subdirectory.
Outputs must be in a named subdirectory so the harness can identify, collect,
and clean them without affecting the project.
```

The runtime validation in `_validate_relative_path(reject_root=True)` correctly catches this, but the generation prompts had no guidance to prevent it in the first place.

## Test plan

- [ ] Re-run `/eval-analyze` on a stdout-only skill and verify the generated `outputs.path` is a named subdirectory, not `.`

Assisted-By: 🤖 Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated output path requirements to mandate named subdirectories instead of current directory notation
  * Clarified how stdout-only skills should declare outputs
  * Enhanced guidance for judges accessing stdout vs file-based outputs
  * Improved template documentation and harness-related clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->