### PR TITLE
Add OpenAI-compatible EvalRunner for vLLM/KServe endpoints

### DIFF
--- a/agent_eval/agent/__init__.py
+++ b/agent_eval/agent/__init__.py
@@ -2,9 +2,15 @@
 
 from .base import EvalRunner, RunResult
 from .claude_code import ClaudeCodeRunner
+from .openai_compatible import OpenAICompatibleRunner
 
 RUNNERS = {
     "claude-code": ClaudeCodeRunner,
+    "openai-compatible": OpenAICompatibleRunner,
 }
 
-__all__ = ["EvalRunner", "RunResult", "ClaudeCodeRunner", "RUNNERS"]
+__all__ = [
+    "EvalRunner", "RunResult",
+    "ClaudeCodeRunner", "OpenAICompatibleRunner",
+    "RUNNERS",
+]

--- a/agent_eval/agent/openai_compatible.py
+++ b/agent_eval/agent/openai_compatible.py
@@ -28,6 +28,7 @@ class OpenAICompatibleRunner(EvalRunner):
         system_prompt: Optional[str] = None,
         max_tokens: int = 512,
         temperature: float = 0.3,
+        **kwargs,
     ):
         self._base_url = base_url or os.environ.get("OPENAI_BASE_URL", "")
         if not self._base_url:
@@ -109,8 +110,9 @@ class OpenAICompatibleRunner(EvalRunner):
                 exit_code = 1
                 stderr_text = "API returned empty choices array"
             else:
-                response_text = choices[0]["message"]["content"]
-                stdout_lines.append(response_text)
+                response_text = choices[0].get("message", {}).get("content") or ""
+                if response_text:
+                    stdout_lines.append(response_text)
 
             usage = body.get("usage", {})
             if usage:
@@ -140,9 +142,12 @@ class OpenAICompatibleRunner(EvalRunner):
 
         if exit_code == 0 and response_text:
             (artifacts_dir / "response.md").write_text(response_text)
-        else:
+        elif exit_code != 0:
             (artifacts_dir / "error.txt").write_text(
                 f"Runner failed (exit_code={exit_code}): {stderr_text}")
+        else:
+            (artifacts_dir / "empty_response.txt").write_text(
+                "Model returned empty content (HTTP 200 but no output)")
 
         run_result = {
             "exit_code": exit_code,

--- a/agent_eval/agent/openai_compatible.py
+++ b/agent_eval/agent/openai_compatible.py
@@ -13,8 +13,12 @@ import os
 import time
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlparse
 
 from .base import EvalRunner, RunResult
+
+
+_MAX_RESPONSE_BYTES = 50 * 1024 * 1024  # 50 MB hard cap
 
 
 class OpenAICompatibleRunner(EvalRunner):
@@ -36,6 +40,13 @@ class OpenAICompatibleRunner(EvalRunner):
                 "OpenAI-compatible runner requires base_url argument or "
                 "OPENAI_BASE_URL environment variable"
             )
+        parsed = urlparse(self._base_url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"base_url must use http or https scheme, got: {parsed.scheme!r}"
+            )
+        if not parsed.netloc:
+            raise ValueError("base_url must include a host (netloc is empty)")
         self._api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
         self._default_model = default_model
         self._system_prompt = system_prompt
@@ -103,7 +114,12 @@ class OpenAICompatibleRunner(EvalRunner):
         try:
             req = urllib.request.Request(api_url, data=payload, headers=headers)
             with urllib.request.urlopen(req, timeout=timeout_s) as resp:
-                body = json.loads(resp.read().decode())
+                raw = resp.read(_MAX_RESPONSE_BYTES + 1)
+                if len(raw) > _MAX_RESPONSE_BYTES:
+                    raise ValueError(
+                        f"Response exceeded {_MAX_RESPONSE_BYTES} byte limit"
+                    )
+                body = json.loads(raw.decode())
 
             choices = body.get("choices", [])
             if not choices:
@@ -169,5 +185,5 @@ class OpenAICompatibleRunner(EvalRunner):
             cost_usd=cost_usd,
             num_turns=1,
             resolved_model=effective_model,
-            raw_output=body if exit_code == 0 else None,
+            raw_output=body,
         )

--- a/agent_eval/agent/openai_compatible.py
+++ b/agent_eval/agent/openai_compatible.py
@@ -69,8 +69,10 @@ class OpenAICompatibleRunner(EvalRunner):
         effective_model = model or self._default_model
         effective_system = system_prompt or self._system_prompt or ""
         api_url = self._base_url.rstrip("/")
+        if api_url.endswith("/v1"):
+            api_url = api_url[:-3]
         if not api_url.endswith("/v1/chat/completions"):
-            api_url = api_url.rstrip("/") + "/v1/chat/completions"
+            api_url = api_url + "/v1/chat/completions"
 
         messages = []
         if effective_system:
@@ -95,14 +97,20 @@ class OpenAICompatibleRunner(EvalRunner):
         response_text = ""
         token_usage = None
         cost_usd = None
+        body = None
 
         try:
             req = urllib.request.Request(api_url, data=payload, headers=headers)
             with urllib.request.urlopen(req, timeout=timeout_s) as resp:
                 body = json.loads(resp.read().decode())
 
-            response_text = body["choices"][0]["message"]["content"]
-            stdout_lines.append(response_text)
+            choices = body.get("choices", [])
+            if not choices:
+                exit_code = 1
+                stderr_text = "API returned empty choices array"
+            else:
+                response_text = choices[0]["message"]["content"]
+                stdout_lines.append(response_text)
 
             usage = body.get("usage", {})
             if usage:
@@ -156,4 +164,5 @@ class OpenAICompatibleRunner(EvalRunner):
             cost_usd=cost_usd,
             num_turns=1,
             resolved_model=effective_model,
+            raw_output=body if exit_code == 0 else None,
         )

--- a/agent_eval/agent/openai_compatible.py
+++ b/agent_eval/agent/openai_compatible.py
@@ -1,0 +1,159 @@
+"""OpenAI-compatible API runner implementation.
+
+Evaluates models served via any OpenAI-compatible endpoint (vLLM, KServe,
+Ollama, LiteLLM, etc.) by sending prompts to /v1/chat/completions.
+
+Unlike the Claude Code runner which invokes skills via the CLI, this runner
+sends the test case input directly to the model as a chat completion request
+and captures the response as the output artifact.
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+from .base import EvalRunner, RunResult
+
+
+class OpenAICompatibleRunner(EvalRunner):
+    """Runs evaluation cases against an OpenAI-compatible chat completions API."""
+
+    def __init__(
+        self,
+        base_url: str = "",
+        api_key: str = "",
+        default_model: str = "",
+        system_prompt: Optional[str] = None,
+        max_tokens: int = 512,
+        temperature: float = 0.3,
+    ):
+        self._base_url = base_url or os.environ.get("OPENAI_BASE_URL", "")
+        if not self._base_url:
+            raise ValueError(
+                "OpenAI-compatible runner requires base_url argument or "
+                "OPENAI_BASE_URL environment variable"
+            )
+        self._api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+        self._default_model = default_model
+        self._system_prompt = system_prompt
+        self._max_tokens = max_tokens
+        self._temperature = temperature
+
+    @property
+    def name(self) -> str:
+        return "openai-compatible"
+
+    def run_skill(
+        self,
+        skill_name: str,
+        args: str,
+        workspace: Path,
+        model: str,
+        settings_path: Optional[Path] = None,
+        system_prompt: Optional[str] = None,
+        max_budget_usd: float = 5.0,
+        timeout_s: int = 600,
+    ) -> RunResult:
+        """Send the prompt to the model and capture the response.
+
+        For this runner, `args` is the resolved prompt (the diff to review).
+        The response is written to workspace/artifacts/response.md only on
+        success; on failure the artifacts directory is left empty so judges
+        can distinguish infra errors from bad model output.
+        """
+        import urllib.request
+        import urllib.error
+
+        effective_model = model or self._default_model
+        effective_system = system_prompt or self._system_prompt or ""
+        api_url = self._base_url.rstrip("/")
+        if not api_url.endswith("/v1/chat/completions"):
+            api_url = api_url.rstrip("/") + "/v1/chat/completions"
+
+        messages = []
+        if effective_system:
+            messages.append({"role": "system", "content": effective_system})
+        messages.append({"role": "user", "content": args})
+
+        payload = json.dumps({
+            "model": effective_model,
+            "messages": messages,
+            "max_tokens": self._max_tokens,
+            "temperature": self._temperature,
+        }).encode()
+
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        start = time.monotonic()
+        stdout_lines = []
+        stderr_text = ""
+        exit_code = 0
+        response_text = ""
+        token_usage = None
+        cost_usd = None
+
+        try:
+            req = urllib.request.Request(api_url, data=payload, headers=headers)
+            with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+                body = json.loads(resp.read().decode())
+
+            response_text = body["choices"][0]["message"]["content"]
+            stdout_lines.append(response_text)
+
+            usage = body.get("usage", {})
+            if usage:
+                token_usage = {
+                    "input": usage.get("prompt_tokens", 0),
+                    "output": usage.get("completion_tokens", 0),
+                }
+
+        except urllib.error.HTTPError as e:
+            exit_code = 1
+            try:
+                err_body = e.read().decode()[:500]
+            except Exception:
+                err_body = "(could not read error body)"
+            stderr_text = f"HTTP {e.code}: {err_body}"
+        except urllib.error.URLError as e:
+            exit_code = 1
+            stderr_text = f"Connection error: {e.reason}"
+        except Exception as e:
+            exit_code = 1
+            stderr_text = str(e)
+
+        duration = time.monotonic() - start
+
+        artifacts_dir = workspace / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+        if exit_code == 0 and response_text:
+            (artifacts_dir / "response.md").write_text(response_text)
+        else:
+            (artifacts_dir / "error.txt").write_text(
+                f"Runner failed (exit_code={exit_code}): {stderr_text}")
+
+        run_result = {
+            "exit_code": exit_code,
+            "duration_s": round(duration, 2),
+            "token_usage": token_usage,
+            "cost_usd": cost_usd,
+            "num_turns": 1,
+            "model": effective_model,
+        }
+        (workspace / "run_result.json").write_text(json.dumps(run_result, indent=2))
+        (workspace / "stdout.log").write_text("\n".join(stdout_lines))
+
+        return RunResult(
+            exit_code=exit_code,
+            stdout="\n".join(stdout_lines),
+            stderr=stderr_text,
+            duration_s=duration,
+            token_usage=token_usage,
+            cost_usd=cost_usd,
+            num_turns=1,
+            resolved_model=effective_model,
+        )

--- a/tests/test_openai_compatible.py
+++ b/tests/test_openai_compatible.py
@@ -384,6 +384,15 @@ class TestRunSkillURLConstruction:
         )
         assert result.exit_code == 0
 
+    def test_v1_suffix_not_doubled(self, mock_server, tmp_path):
+        """base_url ending in /v1 should not produce /v1/v1/chat/completions."""
+        runner = OpenAICompatibleRunner(base_url=f"{mock_server}/v1")
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 0
+
 
 class TestRunSkillErrors:
     """Test error handling paths."""
@@ -469,6 +478,20 @@ class TestRunSkillErrors:
         # (because the condition is `exit_code == 0 and response_text`)
         assert not (tmp_path / "artifacts" / "response.md").exists()
 
+    def test_empty_choices_array_returns_error(self, mock_server, tmp_path):
+        _MockHandler.response_body = {
+            "id": "chatcmpl-abc",
+            "choices": [],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 1
+        assert "empty choices" in result.stderr
+
 
 class TestRunSkillReturnType:
     """Verify RunResult fields and types."""
@@ -509,6 +532,23 @@ class TestRunSkillReturnType:
         assert result.per_model_usage is None
         assert result.per_model_turns is None
         assert result.permission_denials is None
+
+    def test_raw_output_contains_response_body(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.raw_output is not None
+        assert "choices" in result.raw_output
+
+    def test_raw_output_none_on_error(self, mock_server, tmp_path):
+        _MockHandler.response_code = 500
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
         assert result.raw_output is None
 
 

--- a/tests/test_openai_compatible.py
+++ b/tests/test_openai_compatible.py
@@ -5,8 +5,6 @@ import sys
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 from threading import Thread
-from unittest.mock import patch
-
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -112,6 +110,26 @@ class TestOpenAICompatibleInit:
         assert runner._max_tokens == 1024
         assert runner._temperature == 0.7
 
+    def test_rejects_file_scheme(self):
+        with pytest.raises(ValueError, match="http or https"):
+            OpenAICompatibleRunner(base_url="file:///etc/passwd")
+
+    def test_rejects_ftp_scheme(self):
+        with pytest.raises(ValueError, match="http or https"):
+            OpenAICompatibleRunner(base_url="ftp://evil.com/payload")
+
+    def test_rejects_data_scheme(self):
+        with pytest.raises(ValueError, match="http or https"):
+            OpenAICompatibleRunner(base_url="data:text/plain,hello")
+
+    def test_rejects_empty_netloc(self):
+        with pytest.raises(ValueError, match="host"):
+            OpenAICompatibleRunner(base_url="http://")
+
+    def test_accepts_https_scheme(self):
+        runner = OpenAICompatibleRunner(base_url="https://api.example.com")
+        assert runner._base_url == "https://api.example.com"
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # PART 3: run_skill() with a real local HTTP mock server
@@ -138,47 +156,53 @@ def _make_completion_response(content="Hello world", prompt_tokens=10,
     }
 
 
-class _MockHandler(BaseHTTPRequestHandler):
-    """HTTP handler that returns configurable responses."""
+class _MockState:
+    """Per-test state container for the mock HTTP server."""
 
-    response_body = _make_completion_response()
-    response_code = 200
-    last_request_body = None
-    last_request_headers = None
+    def __init__(self):
+        self.response_body = _make_completion_response()
+        self.response_code = 200
+        self.last_request_body = None
+        self.last_request_headers = None
 
-    def do_POST(self):
-        content_length = int(self.headers.get("Content-Length", 0))
-        body = self.rfile.read(content_length)
-        _MockHandler.last_request_body = json.loads(body)
-        _MockHandler.last_request_headers = dict(self.headers)
 
-        self.send_response(_MockHandler.response_code)
-        self.send_header("Content-Type", "application/json")
-        self.end_headers()
-        self.wfile.write(json.dumps(_MockHandler.response_body).encode())
+def _make_handler(state: _MockState):
+    """Factory that returns a handler class bound to the given state instance."""
 
-    def log_message(self, format, *args):
-        pass  # Suppress noisy HTTP logging
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            state.last_request_body = json.loads(body)
+            state.last_request_headers = dict(self.headers)
+
+            self.send_response(state.response_code)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(state.response_body).encode())
+
+        def log_message(self, format, *args):
+            pass
+
+    return Handler
 
 
 @pytest.fixture
-def mock_server():
-    """Start a local HTTP server and yield its base URL."""
-    server = HTTPServer(("127.0.0.1", 0), _MockHandler)
+def mock_state():
+    """Fresh per-test state for the mock server (xdist-safe)."""
+    return _MockState()
+
+
+@pytest.fixture
+def mock_server(mock_state):
+    """Start a local HTTP server with isolated state and yield its base URL."""
+    handler_cls = _make_handler(mock_state)
+    server = HTTPServer(("127.0.0.1", 0), handler_cls)
     port = server.server_address[1]
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     yield f"http://127.0.0.1:{port}"
     server.shutdown()
-
-
-@pytest.fixture(autouse=True)
-def reset_handler():
-    """Reset mock handler state between tests."""
-    _MockHandler.response_body = _make_completion_response()
-    _MockHandler.response_code = 200
-    _MockHandler.last_request_body = None
-    _MockHandler.last_request_headers = None
 
 
 class TestRunSkillSuccess:
@@ -199,8 +223,8 @@ class TestRunSkillSuccess:
         assert result.resolved_model == "test-model"
         assert result.duration_s > 0
 
-    def test_response_written_to_artifacts(self, mock_server, tmp_path):
-        _MockHandler.response_body = _make_completion_response(
+    def test_response_written_to_artifacts(self, mock_server, mock_state, tmp_path):
+        mock_state.response_body = _make_completion_response(
             content="Review looks good!")
         runner = OpenAICompatibleRunner(base_url=mock_server)
         runner.run_skill(
@@ -225,8 +249,8 @@ class TestRunSkillSuccess:
         assert data["num_turns"] == 1
         assert data["duration_s"] >= 0
 
-    def test_stdout_log_written(self, mock_server, tmp_path):
-        _MockHandler.response_body = _make_completion_response(
+    def test_stdout_log_written(self, mock_server, mock_state, tmp_path):
+        mock_state.response_body = _make_completion_response(
             content="response text")
         runner = OpenAICompatibleRunner(base_url=mock_server)
         runner.run_skill(
@@ -237,8 +261,8 @@ class TestRunSkillSuccess:
         assert log.exists()
         assert "response text" in log.read_text()
 
-    def test_token_usage_extracted(self, mock_server, tmp_path):
-        _MockHandler.response_body = _make_completion_response(
+    def test_token_usage_extracted(self, mock_server, mock_state, tmp_path):
+        mock_state.response_body = _make_completion_response(
             prompt_tokens=42, completion_tokens=17)
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
@@ -247,8 +271,8 @@ class TestRunSkillSuccess:
         )
         assert result.token_usage == {"input": 42, "output": 17}
 
-    def test_token_usage_in_run_result_json(self, mock_server, tmp_path):
-        _MockHandler.response_body = _make_completion_response(
+    def test_token_usage_in_run_result_json(self, mock_server, mock_state, tmp_path):
+        mock_state.response_body = _make_completion_response(
             prompt_tokens=100, completion_tokens=50)
         runner = OpenAICompatibleRunner(base_url=mock_server)
         runner.run_skill(
@@ -258,10 +282,10 @@ class TestRunSkillSuccess:
         data = json.loads((tmp_path / "run_result.json").read_text())
         assert data["token_usage"] == {"input": 100, "output": 50}
 
-    def test_no_usage_field_returns_none(self, mock_server, tmp_path):
+    def test_no_usage_field_returns_none(self, mock_server, mock_state, tmp_path):
         body = _make_completion_response()
         del body["usage"]
-        _MockHandler.response_body = body
+        mock_state.response_body = body
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
             skill_name="s", args="a",
@@ -273,31 +297,31 @@ class TestRunSkillSuccess:
 class TestRunSkillRequestFormat:
     """Verify the HTTP request sent to the endpoint."""
 
-    def test_sends_user_message(self, mock_server, tmp_path):
+    def test_sends_user_message(self, mock_server, mock_state, tmp_path):
         runner = OpenAICompatibleRunner(base_url=mock_server)
         runner.run_skill(
             skill_name="review", args="Review this diff",
             workspace=tmp_path, model="m",
         )
-        body = _MockHandler.last_request_body
+        body = mock_state.last_request_body
         messages = body["messages"]
         assert len(messages) == 1
         assert messages[0]["role"] == "user"
         assert messages[0]["content"] == "Review this diff"
 
-    def test_sends_system_prompt_from_constructor(self, mock_server, tmp_path):
+    def test_sends_system_prompt_from_constructor(self, mock_server, mock_state, tmp_path):
         runner = OpenAICompatibleRunner(
             base_url=mock_server, system_prompt="Be concise")
         runner.run_skill(
             skill_name="s", args="prompt",
             workspace=tmp_path, model="m",
         )
-        messages = _MockHandler.last_request_body["messages"]
+        messages = mock_state.last_request_body["messages"]
         assert len(messages) == 2
         assert messages[0] == {"role": "system", "content": "Be concise"}
         assert messages[1]["role"] == "user"
 
-    def test_run_skill_system_prompt_overrides_constructor(self, mock_server, tmp_path):
+    def test_run_skill_system_prompt_overrides_constructor(self, mock_server, mock_state, tmp_path):
         runner = OpenAICompatibleRunner(
             base_url=mock_server, system_prompt="Default system")
         runner.run_skill(
@@ -305,54 +329,54 @@ class TestRunSkillRequestFormat:
             workspace=tmp_path, model="m",
             system_prompt="Override system",
         )
-        messages = _MockHandler.last_request_body["messages"]
+        messages = mock_state.last_request_body["messages"]
         assert messages[0]["content"] == "Override system"
 
-    def test_model_sent_in_request(self, mock_server, tmp_path):
+    def test_model_sent_in_request(self, mock_server, mock_state, tmp_path):
         runner = OpenAICompatibleRunner(base_url=mock_server)
         runner.run_skill(
             skill_name="s", args="a",
             workspace=tmp_path, model="mistral-7b-instruct",
         )
-        assert _MockHandler.last_request_body["model"] == "mistral-7b-instruct"
+        assert mock_state.last_request_body["model"] == "mistral-7b-instruct"
 
-    def test_default_model_used_when_arg_empty(self, mock_server, tmp_path):
+    def test_default_model_used_when_arg_empty(self, mock_server, mock_state, tmp_path):
         runner = OpenAICompatibleRunner(
             base_url=mock_server, default_model="llama-3-8b")
         runner.run_skill(
             skill_name="s", args="a",
             workspace=tmp_path, model="",
         )
-        assert _MockHandler.last_request_body["model"] == "llama-3-8b"
+        assert mock_state.last_request_body["model"] == "llama-3-8b"
 
-    def test_max_tokens_and_temperature_sent(self, mock_server, tmp_path):
+    def test_max_tokens_and_temperature_sent(self, mock_server, mock_state, tmp_path):
         runner = OpenAICompatibleRunner(
             base_url=mock_server, max_tokens=2048, temperature=0.9)
         runner.run_skill(
             skill_name="s", args="a",
             workspace=tmp_path, model="m",
         )
-        body = _MockHandler.last_request_body
+        body = mock_state.last_request_body
         assert body["max_tokens"] == 2048
         assert body["temperature"] == 0.9
 
-    def test_authorization_header_sent(self, mock_server, tmp_path):
+    def test_authorization_header_sent(self, mock_server, mock_state, tmp_path):
         runner = OpenAICompatibleRunner(
             base_url=mock_server, api_key="sk-secret-key")
         runner.run_skill(
             skill_name="s", args="a",
             workspace=tmp_path, model="m",
         )
-        assert _MockHandler.last_request_headers["Authorization"] == "Bearer sk-secret-key"
+        assert mock_state.last_request_headers["Authorization"] == "Bearer sk-secret-key"
 
-    def test_no_auth_header_when_no_key(self, mock_server, tmp_path, monkeypatch):
+    def test_no_auth_header_when_no_key(self, mock_server, mock_state, tmp_path, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         runner = OpenAICompatibleRunner(base_url=mock_server)
         runner.run_skill(
             skill_name="s", args="a",
             workspace=tmp_path, model="m",
         )
-        assert "Authorization" not in _MockHandler.last_request_headers
+        assert "Authorization" not in mock_state.last_request_headers
 
 
 class TestRunSkillURLConstruction:
@@ -397,9 +421,9 @@ class TestRunSkillURLConstruction:
 class TestRunSkillErrors:
     """Test error handling paths."""
 
-    def test_http_error_returns_nonzero_exit(self, mock_server, tmp_path):
-        _MockHandler.response_code = 500
-        _MockHandler.response_body = {"error": "Internal server error"}
+    def test_http_error_returns_nonzero_exit(self, mock_server, mock_state, tmp_path):
+        mock_state.response_code = 500
+        mock_state.response_body = {"error": "Internal server error"}
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
             skill_name="s", args="a",
@@ -408,9 +432,9 @@ class TestRunSkillErrors:
         assert result.exit_code == 1
         assert "HTTP 500" in result.stderr
 
-    def test_http_401_reports_auth_error(self, mock_server, tmp_path):
-        _MockHandler.response_code = 401
-        _MockHandler.response_body = {"error": "Unauthorized"}
+    def test_http_401_reports_auth_error(self, mock_server, mock_state, tmp_path):
+        mock_state.response_code = 401
+        mock_state.response_body = {"error": "Unauthorized"}
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
             skill_name="s", args="a",
@@ -419,9 +443,9 @@ class TestRunSkillErrors:
         assert result.exit_code == 1
         assert "401" in result.stderr
 
-    def test_http_429_reports_rate_limit(self, mock_server, tmp_path):
-        _MockHandler.response_code = 429
-        _MockHandler.response_body = {"error": "Rate limit exceeded"}
+    def test_http_429_reports_rate_limit(self, mock_server, mock_state, tmp_path):
+        mock_state.response_code = 429
+        mock_state.response_body = {"error": "Rate limit exceeded"}
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
             skill_name="s", args="a",
@@ -441,9 +465,9 @@ class TestRunSkillErrors:
         assert result.exit_code == 1
         assert "Connection" in result.stderr or "error" in result.stderr.lower()
 
-    def test_error_written_to_artifact(self, mock_server, tmp_path):
-        _MockHandler.response_code = 503
-        _MockHandler.response_body = {"error": "Service unavailable"}
+    def test_error_written_to_artifact(self, mock_server, mock_state, tmp_path):
+        mock_state.response_code = 503
+        mock_state.response_body = {"error": "Service unavailable"}
         runner = OpenAICompatibleRunner(base_url=mock_server)
         runner.run_skill(
             skill_name="s", args="a",
@@ -455,8 +479,8 @@ class TestRunSkillErrors:
         # No response.md when errored
         assert not (tmp_path / "artifacts" / "response.md").exists()
 
-    def test_run_result_json_on_error(self, mock_server, tmp_path):
-        _MockHandler.response_code = 500
+    def test_run_result_json_on_error(self, mock_server, mock_state, tmp_path):
+        mock_state.response_code = 500
         runner = OpenAICompatibleRunner(base_url=mock_server)
         runner.run_skill(
             skill_name="s", args="a",
@@ -466,9 +490,9 @@ class TestRunSkillErrors:
         assert data["exit_code"] == 1
         assert data["num_turns"] == 1
 
-    def test_empty_response_text_writes_empty_response_marker(self, mock_server, tmp_path):
+    def test_empty_response_text_writes_empty_response_marker(self, mock_server, mock_state, tmp_path):
         body = _make_completion_response(content="")
-        _MockHandler.response_body = body
+        mock_state.response_body = body
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
             skill_name="s", args="a",
@@ -480,8 +504,8 @@ class TestRunSkillErrors:
         assert empty_marker.exists()
         assert "empty content" in empty_marker.read_text().lower()
 
-    def test_empty_choices_array_returns_error(self, mock_server, tmp_path):
-        _MockHandler.response_body = {
+    def test_empty_choices_array_returns_error(self, mock_server, mock_state, tmp_path):
+        mock_state.response_body = {
             "id": "chatcmpl-abc",
             "choices": [],
             "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
@@ -493,6 +517,9 @@ class TestRunSkillErrors:
         )
         assert result.exit_code == 1
         assert "empty choices" in result.stderr
+        # Body is still available for debugging even with empty choices
+        assert result.raw_output is not None
+        assert result.raw_output["choices"] == []
 
 
 class TestRunSkillReturnType:
@@ -544,13 +571,14 @@ class TestRunSkillReturnType:
         assert result.raw_output is not None
         assert "choices" in result.raw_output
 
-    def test_raw_output_none_on_error(self, mock_server, tmp_path):
-        _MockHandler.response_code = 500
+    def test_raw_output_none_on_transport_error(self, mock_server, mock_state, tmp_path):
+        mock_state.response_code = 500
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
             skill_name="s", args="a",
             workspace=tmp_path, model="m",
         )
+        # body is None on transport/HTTP errors (never parsed)
         assert result.raw_output is None
 
 
@@ -594,9 +622,9 @@ class TestABCCompliance:
 class TestEdgeCases:
     """Edge cases and boundary conditions."""
 
-    def test_large_response_handled(self, mock_server, tmp_path):
+    def test_large_response_handled(self, mock_server, mock_state, tmp_path):
         large_content = "x" * 100_000
-        _MockHandler.response_body = _make_completion_response(
+        mock_state.response_body = _make_completion_response(
             content=large_content)
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
@@ -606,8 +634,8 @@ class TestEdgeCases:
         assert result.exit_code == 0
         assert len(result.stdout) == 100_000
 
-    def test_unicode_response(self, mock_server, tmp_path):
-        _MockHandler.response_body = _make_completion_response(
+    def test_unicode_response(self, mock_server, mock_state, tmp_path):
+        mock_state.response_body = _make_completion_response(
             content="你好世界 🌍 مرحبا")
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
@@ -617,7 +645,7 @@ class TestEdgeCases:
         assert result.exit_code == 0
         assert "你好世界" in result.stdout
 
-    def test_special_chars_in_prompt(self, mock_server, tmp_path):
+    def test_special_chars_in_prompt(self, mock_server, mock_state, tmp_path):
         prompt = 'Review this: `def f(): "quoted" & <html>`'
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
@@ -625,7 +653,7 @@ class TestEdgeCases:
             workspace=tmp_path, model="m",
         )
         assert result.exit_code == 0
-        sent = _MockHandler.last_request_body["messages"][-1]["content"]
+        sent = mock_state.last_request_body["messages"][-1]["content"]
         assert sent == prompt
 
     def test_workspace_created_if_not_exists(self, mock_server, tmp_path):
@@ -639,9 +667,9 @@ class TestEdgeCases:
         assert (workspace / "artifacts" / "response.md").exists()
         assert (workspace / "run_result.json").exists()
 
-    def test_multiline_response(self, mock_server, tmp_path):
+    def test_multiline_response(self, mock_server, mock_state, tmp_path):
         content = "Line 1\nLine 2\nLine 3\n"
-        _MockHandler.response_body = _make_completion_response(content=content)
+        mock_state.response_body = _make_completion_response(content=content)
         runner = OpenAICompatibleRunner(base_url=mock_server)
         result = runner.run_skill(
             skill_name="s", args="a",
@@ -650,9 +678,9 @@ class TestEdgeCases:
         assert result.exit_code == 0
         assert (tmp_path / "artifacts" / "response.md").read_text() == content
 
-    def test_null_content_does_not_crash(self, mock_server, tmp_path):
+    def test_null_content_does_not_crash(self, mock_server, mock_state, tmp_path):
         """Endpoints may return content: null (tool-use, content-filter)."""
-        _MockHandler.response_body = {
+        mock_state.response_body = {
             "id": "chatcmpl-abc",
             "choices": [{"message": {"role": "assistant", "content": None}}],
             "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},

--- a/tests/test_openai_compatible.py
+++ b/tests/test_openai_compatible.py
@@ -1,0 +1,609 @@
+"""Tests for OpenAICompatibleRunner and RUNNERS registry integrity."""
+
+import json
+import sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from threading import Thread
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.agent import RUNNERS, EvalRunner, RunResult
+from agent_eval.agent.base import EvalRunner as BaseRunner, RunResult as BaseResult
+from agent_eval.agent.claude_code import ClaudeCodeRunner
+from agent_eval.agent.openai_compatible import OpenAICompatibleRunner
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PART 1: Registry and backward-compatibility tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestRunnersRegistry:
+    """Verify RUNNERS dict and old runners remain intact."""
+
+    def test_claude_code_registered(self):
+        assert "claude-code" in RUNNERS
+        assert RUNNERS["claude-code"] is ClaudeCodeRunner
+
+    def test_openai_compatible_registered(self):
+        assert "openai-compatible" in RUNNERS
+        assert RUNNERS["openai-compatible"] is OpenAICompatibleRunner
+
+    def test_all_runners_are_subclasses(self):
+        for key, cls in RUNNERS.items():
+            assert issubclass(cls, BaseRunner), f"{key} is not an EvalRunner subclass"
+
+    def test_exports_complete(self):
+        from agent_eval.agent import __all__
+        assert "EvalRunner" in __all__
+        assert "RunResult" in __all__
+        assert "ClaudeCodeRunner" in __all__
+        assert "OpenAICompatibleRunner" in __all__
+        assert "RUNNERS" in __all__
+
+    def test_claude_code_runner_instantiates(self):
+        runner = ClaudeCodeRunner()
+        assert runner.name == "claude-code"
+
+    def test_openai_compatible_runner_name(self):
+        runner = OpenAICompatibleRunner(base_url="http://localhost:8000")
+        assert runner.name == "openai-compatible"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PART 2: OpenAICompatibleRunner unit tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestOpenAICompatibleInit:
+    """Test constructor validation and defaults."""
+
+    def test_requires_base_url(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        with pytest.raises(ValueError, match="requires base_url"):
+            OpenAICompatibleRunner()
+
+    def test_accepts_base_url_arg(self):
+        runner = OpenAICompatibleRunner(base_url="http://localhost:8000")
+        assert runner._base_url == "http://localhost:8000"
+
+    def test_reads_base_url_from_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://env-host:9000")
+        runner = OpenAICompatibleRunner()
+        assert runner._base_url == "http://env-host:9000"
+
+    def test_arg_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_BASE_URL", "http://env-host:9000")
+        runner = OpenAICompatibleRunner(base_url="http://arg-host:8000")
+        assert runner._base_url == "http://arg-host:8000"
+
+    def test_reads_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-123")
+        runner = OpenAICompatibleRunner(base_url="http://localhost:8000")
+        assert runner._api_key == "sk-test-123"
+
+    def test_api_key_arg_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+        runner = OpenAICompatibleRunner(
+            base_url="http://localhost:8000", api_key="sk-arg")
+        assert runner._api_key == "sk-arg"
+
+    def test_default_params(self):
+        runner = OpenAICompatibleRunner(base_url="http://localhost:8000")
+        assert runner._max_tokens == 512
+        assert runner._temperature == 0.3
+        assert runner._system_prompt is None
+        assert runner._default_model == ""
+
+    def test_custom_params(self):
+        runner = OpenAICompatibleRunner(
+            base_url="http://localhost:8000",
+            default_model="mistral-7b",
+            system_prompt="You are helpful.",
+            max_tokens=1024,
+            temperature=0.7,
+        )
+        assert runner._default_model == "mistral-7b"
+        assert runner._system_prompt == "You are helpful."
+        assert runner._max_tokens == 1024
+        assert runner._temperature == 0.7
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PART 3: run_skill() with a real local HTTP mock server
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _make_completion_response(content="Hello world", prompt_tokens=10,
+                              completion_tokens=5, model="test-model"):
+    """Build a standard OpenAI-compatible completion response."""
+    return {
+        "id": "chatcmpl-abc123",
+        "object": "chat.completion",
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": content},
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    """HTTP handler that returns configurable responses."""
+
+    response_body = _make_completion_response()
+    response_code = 200
+    last_request_body = None
+    last_request_headers = None
+
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length)
+        _MockHandler.last_request_body = json.loads(body)
+        _MockHandler.last_request_headers = dict(self.headers)
+
+        self.send_response(_MockHandler.response_code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(_MockHandler.response_body).encode())
+
+    def log_message(self, format, *args):
+        pass  # Suppress noisy HTTP logging
+
+
+@pytest.fixture
+def mock_server():
+    """Start a local HTTP server and yield its base URL."""
+    server = HTTPServer(("127.0.0.1", 0), _MockHandler)
+    port = server.server_address[1]
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}"
+    server.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def reset_handler():
+    """Reset mock handler state between tests."""
+    _MockHandler.response_body = _make_completion_response()
+    _MockHandler.response_code = 200
+    _MockHandler.last_request_body = None
+    _MockHandler.last_request_headers = None
+
+
+class TestRunSkillSuccess:
+    """Tests for successful completion calls."""
+
+    def test_basic_completion(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="review",
+            args="Please review this code",
+            workspace=tmp_path,
+            model="test-model",
+        )
+        assert result.exit_code == 0
+        assert result.stdout == "Hello world"
+        assert result.stderr == ""
+        assert result.num_turns == 1
+        assert result.resolved_model == "test-model"
+        assert result.duration_s > 0
+
+    def test_response_written_to_artifacts(self, mock_server, tmp_path):
+        _MockHandler.response_body = _make_completion_response(
+            content="Review looks good!")
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        runner.run_skill(
+            skill_name="review", args="code here",
+            workspace=tmp_path, model="m",
+        )
+        artifact = tmp_path / "artifacts" / "response.md"
+        assert artifact.exists()
+        assert artifact.read_text() == "Review looks good!"
+
+    def test_run_result_json_written(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        runner.run_skill(
+            skill_name="review", args="code",
+            workspace=tmp_path, model="gpt-4",
+        )
+        result_file = tmp_path / "run_result.json"
+        assert result_file.exists()
+        data = json.loads(result_file.read_text())
+        assert data["exit_code"] == 0
+        assert data["model"] == "gpt-4"
+        assert data["num_turns"] == 1
+        assert data["duration_s"] >= 0
+
+    def test_stdout_log_written(self, mock_server, tmp_path):
+        _MockHandler.response_body = _make_completion_response(
+            content="response text")
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        log = tmp_path / "stdout.log"
+        assert log.exists()
+        assert "response text" in log.read_text()
+
+    def test_token_usage_extracted(self, mock_server, tmp_path):
+        _MockHandler.response_body = _make_completion_response(
+            prompt_tokens=42, completion_tokens=17)
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.token_usage == {"input": 42, "output": 17}
+
+    def test_token_usage_in_run_result_json(self, mock_server, tmp_path):
+        _MockHandler.response_body = _make_completion_response(
+            prompt_tokens=100, completion_tokens=50)
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        data = json.loads((tmp_path / "run_result.json").read_text())
+        assert data["token_usage"] == {"input": 100, "output": 50}
+
+    def test_no_usage_field_returns_none(self, mock_server, tmp_path):
+        body = _make_completion_response()
+        del body["usage"]
+        _MockHandler.response_body = body
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.token_usage is None
+
+
+class TestRunSkillRequestFormat:
+    """Verify the HTTP request sent to the endpoint."""
+
+    def test_sends_user_message(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        runner.run_skill(
+            skill_name="review", args="Review this diff",
+            workspace=tmp_path, model="m",
+        )
+        body = _MockHandler.last_request_body
+        messages = body["messages"]
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == "Review this diff"
+
+    def test_sends_system_prompt_from_constructor(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(
+            base_url=mock_server, system_prompt="Be concise")
+        runner.run_skill(
+            skill_name="s", args="prompt",
+            workspace=tmp_path, model="m",
+        )
+        messages = _MockHandler.last_request_body["messages"]
+        assert len(messages) == 2
+        assert messages[0] == {"role": "system", "content": "Be concise"}
+        assert messages[1]["role"] == "user"
+
+    def test_run_skill_system_prompt_overrides_constructor(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(
+            base_url=mock_server, system_prompt="Default system")
+        runner.run_skill(
+            skill_name="s", args="prompt",
+            workspace=tmp_path, model="m",
+            system_prompt="Override system",
+        )
+        messages = _MockHandler.last_request_body["messages"]
+        assert messages[0]["content"] == "Override system"
+
+    def test_model_sent_in_request(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="mistral-7b-instruct",
+        )
+        assert _MockHandler.last_request_body["model"] == "mistral-7b-instruct"
+
+    def test_default_model_used_when_arg_empty(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(
+            base_url=mock_server, default_model="llama-3-8b")
+        runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="",
+        )
+        assert _MockHandler.last_request_body["model"] == "llama-3-8b"
+
+    def test_max_tokens_and_temperature_sent(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(
+            base_url=mock_server, max_tokens=2048, temperature=0.9)
+        runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        body = _MockHandler.last_request_body
+        assert body["max_tokens"] == 2048
+        assert body["temperature"] == 0.9
+
+    def test_authorization_header_sent(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(
+            base_url=mock_server, api_key="sk-secret-key")
+        runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert _MockHandler.last_request_headers["Authorization"] == "Bearer sk-secret-key"
+
+    def test_no_auth_header_when_no_key(self, mock_server, tmp_path, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert "Authorization" not in _MockHandler.last_request_headers
+
+
+class TestRunSkillURLConstruction:
+    """Test URL path appending logic."""
+
+    def test_appends_path_to_bare_host(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        # Should succeed — means it hit mock_server/v1/chat/completions
+        assert result.exit_code == 0
+
+    def test_does_not_double_append_full_path(self, mock_server, tmp_path):
+        full_url = f"{mock_server}/v1/chat/completions"
+        runner = OpenAICompatibleRunner(base_url=full_url)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 0
+
+    def test_trailing_slash_stripped(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=f"{mock_server}/")
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 0
+
+
+class TestRunSkillErrors:
+    """Test error handling paths."""
+
+    def test_http_error_returns_nonzero_exit(self, mock_server, tmp_path):
+        _MockHandler.response_code = 500
+        _MockHandler.response_body = {"error": "Internal server error"}
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 1
+        assert "HTTP 500" in result.stderr
+
+    def test_http_401_reports_auth_error(self, mock_server, tmp_path):
+        _MockHandler.response_code = 401
+        _MockHandler.response_body = {"error": "Unauthorized"}
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 1
+        assert "401" in result.stderr
+
+    def test_http_429_reports_rate_limit(self, mock_server, tmp_path):
+        _MockHandler.response_code = 429
+        _MockHandler.response_body = {"error": "Rate limit exceeded"}
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 1
+        assert "429" in result.stderr
+
+    def test_connection_error_returns_nonzero_exit(self, tmp_path):
+        runner = OpenAICompatibleRunner(
+            base_url="http://127.0.0.1:1")  # nothing listening
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+            timeout_s=3,
+        )
+        assert result.exit_code == 1
+        assert "Connection" in result.stderr or "error" in result.stderr.lower()
+
+    def test_error_written_to_artifact(self, mock_server, tmp_path):
+        _MockHandler.response_code = 503
+        _MockHandler.response_body = {"error": "Service unavailable"}
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        error_file = tmp_path / "artifacts" / "error.txt"
+        assert error_file.exists()
+        assert "503" in error_file.read_text()
+        # No response.md when errored
+        assert not (tmp_path / "artifacts" / "response.md").exists()
+
+    def test_run_result_json_on_error(self, mock_server, tmp_path):
+        _MockHandler.response_code = 500
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        data = json.loads((tmp_path / "run_result.json").read_text())
+        assert data["exit_code"] == 1
+        assert data["num_turns"] == 1
+
+    def test_empty_response_text_treated_as_error(self, mock_server, tmp_path):
+        body = _make_completion_response(content="")
+        _MockHandler.response_body = body
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        # Empty content → exit_code 0 but no response.md written
+        # (because the condition is `exit_code == 0 and response_text`)
+        assert not (tmp_path / "artifacts" / "response.md").exists()
+
+
+class TestRunSkillReturnType:
+    """Verify RunResult fields and types."""
+
+    def test_returns_run_result_instance(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert isinstance(result, RunResult)
+
+    def test_duration_is_positive_float(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert isinstance(result.duration_s, float)
+        assert result.duration_s > 0
+
+    def test_cost_usd_is_none(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        # OpenAI-compatible endpoints don't report cost
+        assert result.cost_usd is None
+
+    def test_optional_fields_are_none(self, mock_server, tmp_path):
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.models_used is None
+        assert result.per_model_usage is None
+        assert result.per_model_turns is None
+        assert result.permission_denials is None
+        assert result.raw_output is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PART 4: Integration with EvalRunner ABC
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestABCCompliance:
+    """Verify OpenAICompatibleRunner fully implements EvalRunner."""
+
+    def test_is_subclass_of_eval_runner(self):
+        assert issubclass(OpenAICompatibleRunner, EvalRunner)
+
+    def test_implements_name_property(self):
+        runner = OpenAICompatibleRunner(base_url="http://localhost:8000")
+        assert isinstance(runner.name, str)
+        assert runner.name == "openai-compatible"
+
+    def test_implements_run_skill_method(self):
+        assert callable(getattr(OpenAICompatibleRunner, "run_skill", None))
+
+    def test_run_skill_signature_matches_abc(self):
+        """Ensure the runner accepts all parameters defined by the ABC."""
+        import inspect
+        abc_sig = inspect.signature(EvalRunner.run_skill)
+        impl_sig = inspect.signature(OpenAICompatibleRunner.run_skill)
+        abc_params = set(abc_sig.parameters.keys())
+        impl_params = set(impl_sig.parameters.keys())
+        assert abc_params == impl_params, (
+            f"Signature mismatch: ABC has {abc_params - impl_params} extra, "
+            f"impl has {impl_params - abc_params} extra"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PART 5: Edge cases and robustness
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_large_response_handled(self, mock_server, tmp_path):
+        large_content = "x" * 100_000
+        _MockHandler.response_body = _make_completion_response(
+            content=large_content)
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 0
+        assert len(result.stdout) == 100_000
+
+    def test_unicode_response(self, mock_server, tmp_path):
+        _MockHandler.response_body = _make_completion_response(
+            content="你好世界 🌍 مرحبا")
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 0
+        assert "你好世界" in result.stdout
+
+    def test_special_chars_in_prompt(self, mock_server, tmp_path):
+        prompt = 'Review this: `def f(): "quoted" & <html>`'
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args=prompt,
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 0
+        sent = _MockHandler.last_request_body["messages"][-1]["content"]
+        assert sent == prompt
+
+    def test_workspace_created_if_not_exists(self, mock_server, tmp_path):
+        workspace = tmp_path / "deep" / "nested" / "workspace"
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=workspace, model="m",
+        )
+        assert result.exit_code == 0
+        assert (workspace / "artifacts" / "response.md").exists()
+        assert (workspace / "run_result.json").exists()
+
+    def test_multiline_response(self, mock_server, tmp_path):
+        content = "Line 1\nLine 2\nLine 3\n"
+        _MockHandler.response_body = _make_completion_response(content=content)
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 0
+        assert (tmp_path / "artifacts" / "response.md").read_text() == content

--- a/tests/test_openai_compatible.py
+++ b/tests/test_openai_compatible.py
@@ -466,7 +466,7 @@ class TestRunSkillErrors:
         assert data["exit_code"] == 1
         assert data["num_turns"] == 1
 
-    def test_empty_response_text_treated_as_error(self, mock_server, tmp_path):
+    def test_empty_response_text_writes_empty_response_marker(self, mock_server, tmp_path):
         body = _make_completion_response(content="")
         _MockHandler.response_body = body
         runner = OpenAICompatibleRunner(base_url=mock_server)
@@ -474,9 +474,11 @@ class TestRunSkillErrors:
             skill_name="s", args="a",
             workspace=tmp_path, model="m",
         )
-        # Empty content → exit_code 0 but no response.md written
-        # (because the condition is `exit_code == 0 and response_text`)
         assert not (tmp_path / "artifacts" / "response.md").exists()
+        assert not (tmp_path / "artifacts" / "error.txt").exists()
+        empty_marker = tmp_path / "artifacts" / "empty_response.txt"
+        assert empty_marker.exists()
+        assert "empty content" in empty_marker.read_text().lower()
 
     def test_empty_choices_array_returns_error(self, mock_server, tmp_path):
         _MockHandler.response_body = {
@@ -647,3 +649,34 @@ class TestEdgeCases:
         )
         assert result.exit_code == 0
         assert (tmp_path / "artifacts" / "response.md").read_text() == content
+
+    def test_null_content_does_not_crash(self, mock_server, tmp_path):
+        """Endpoints may return content: null (tool-use, content-filter)."""
+        _MockHandler.response_body = {
+            "id": "chatcmpl-abc",
+            "choices": [{"message": {"role": "assistant", "content": None}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 0, "total_tokens": 5},
+        }
+        runner = OpenAICompatibleRunner(base_url=mock_server)
+        result = runner.run_skill(
+            skill_name="s", args="a",
+            workspace=tmp_path, model="m",
+        )
+        assert result.exit_code == 0
+        assert result.stdout == ""
+        assert not (tmp_path / "artifacts" / "response.md").exists()
+
+    def test_accepts_harness_kwargs(self):
+        """Runner must accept kwargs from execute.py without crashing."""
+        runner = OpenAICompatibleRunner(
+            base_url="http://localhost:8000",
+            log_prefix="eval",
+            permissions={"allow": ["*"]},
+            plugin_dirs=["/tmp/plugins"],
+            env_strip=["SECRET"],
+            subagent_model="sonnet",
+            mlflow_experiment="test-exp",
+            mlflow_tracking_uri="http://mlflow:5000",
+            effort="high",
+        )
+        assert runner.name == "openai-compatible"


### PR DESCRIPTION
## Summary
- Adds an `openai-compatible` runner that evaluates models served via standard OpenAI-compatible `/v1/chat/completions` APIs
- Enables the harness to evaluate models deployed on vLLM, KServe, Ollama, LiteLLM, or any OpenAI-compatible endpoint
- No new dependencies -- uses stdlib `urllib.request`
- Registers in `RUNNERS` dict so `runner.type: openai-compatible` works in eval.yaml

## Motivation
The harness currently only supports Claude Code as a runner. This adds support for evaluating any model behind an OpenAI-compatible API, making the harness useful for a much wider range of deployment targets (vLLM, KServe, Ollama, LiteLLM, etc.).

## Usage
```yaml
# eval.yaml
runner:
  type: openai-compatible
```

Set `OPENAI_BASE_URL` and optionally `OPENAI_API_KEY` in the environment, or pass `base_url`/`api_key` directly.

## Test plan
- 58 unit tests covering constructor validation, request format, success/error paths, ABC compliance, harness integration, and edge cases (null content, empty choices, unicode, large responses)
- Tests use a real local HTTP mock server (not mocked at function level)
- All 111 tests in the repo pass (58 new + 53 existing)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced support for OpenAI-compatible evaluation runners, enabling evaluation against custom API endpoints with configurable models and authentication.
  * Added token usage tracking, structured error handling, and comprehensive artifact logging of evaluation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->