### PR TITLE
Use isolated venv for Python dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 dist/
 build/
 .venv/
+.eval-venv/
 venv/
 
 # Eval runs and state

--- a/agent_eval/__init__.py
+++ b/agent_eval/__init__.py
@@ -1,3 +1,4 @@
 """Agent Eval Harness — generic evaluation framework for Claude Code skills."""
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv before third-party imports
 
 __version__ = "0.1.0"

--- a/agent_eval/_bootstrap.py
+++ b/agent_eval/_bootstrap.py
@@ -1,0 +1,41 @@
+"""Auto-activate the eval harness venv if available.
+
+Imported by __init__.py before any third-party deps. Uses only stdlib.
+
+For script invocations (python3 script.py), replaces the process with
+the venv python via os.execv(). For inline code (python3 -c "..."),
+patches sys.path so third-party imports resolve from the venv.
+"""
+import glob
+import os
+import sys
+
+
+def _activate():
+    pkg_dir = os.path.dirname(os.path.abspath(__file__))
+    plugin_root = os.path.dirname(pkg_dir)
+    venv_dir = os.path.join(plugin_root, '.eval-venv')
+    venv_python = os.path.join(venv_dir, 'bin', 'python3')
+
+    if not os.path.isfile(venv_python):
+        return
+
+    site_dirs = glob.glob(os.path.join(
+        venv_dir, 'lib', 'python*', 'site-packages'))
+
+    # Already activated (venv site-packages on sys.path)
+    if site_dirs and all(d in sys.path for d in site_dirs):
+        return
+
+    # For -c invocations, we can't re-exec (the inline code isn't in
+    # sys.argv). Patch sys.path instead so third-party imports resolve.
+    if sys.argv[:1] == ['-c']:
+        for d in site_dirs:
+            if d not in sys.path:
+                sys.path.insert(0, d)
+        return
+
+    os.execv(venv_python, [venv_python] + sys.argv)
+
+
+_activate()

--- a/scripts/ensure_deps.py
+++ b/scripts/ensure_deps.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Install Python dependencies based on what the project actually needs.
+"""Install Python dependencies into an isolated venv.
+
+Creates .eval-venv/ at the plugin root and installs packages there.
+Prefers uv for speed, falls back to stdlib venv + pip.
 
 Checks eval.yaml (if it exists) to decide which optional deps to install:
 - pyyaml: always required
@@ -11,97 +14,148 @@ Caches a stamp file in CLAUDE_PLUGIN_DATA so installs only run once
 """
 
 import hashlib
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+VENV_DIR_NAME = ".eval-venv"
 
 
 def main():
     plugin_data = Path(sys.argv[1]) if len(sys.argv) > 1 else None
     plugin_root = Path(__file__).parent.parent
+    venv_dir = plugin_root / VENV_DIR_NAME
+    venv_python = venv_dir / "bin" / "python3"
 
-    try:
-        import yaml  # noqa: F401
-    except ImportError:
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-q", "pyyaml>=6.0"],
-            check=False,
-        )
-
-    eval_yaml = _find_eval_yaml(plugin_root)
-
-    deps = [("pyyaml>=6.0", "yaml")]
-    needs_mlflow = False
-    needs_anthropic = False
-
-    if eval_yaml and eval_yaml.exists():
-        content = eval_yaml.read_text()
-        try:
-            import yaml
-            config = yaml.safe_load(content) or {}
-        except Exception as e:
-            print(f"ensure_deps: failed to parse {eval_yaml}: {e}", file=sys.stderr)
-            config = {}
-
-        if not isinstance(config, dict):
-            print(f"ensure_deps: expected mapping in {eval_yaml}, got {type(config).__name__}",
-                  file=sys.stderr)
-            config = {}
-
-        mlflow_block = config.get("mlflow")
-        if mlflow_block is not None:
-            needs_mlflow = True
-
-        judges = config.get("judges", [])
-        if isinstance(judges, list):
-            for j in judges:
-                if not isinstance(j, dict):
-                    continue
-                if j.get("prompt") or j.get("prompt_file") or j.get("pairwise"):
-                    needs_anthropic = True
-                    break
-
-    if needs_mlflow:
-        deps.append(("mlflow[genai]>=3.5", "mlflow"))
-    if needs_anthropic:
-        deps.append(("anthropic[vertex]>=0.40", "anthropic"))
-
-    stamp = _compute_stamp([spec for spec, _ in deps])
+    deps = _resolve_deps(plugin_root)
+    stamp = _compute_stamp(deps)
 
     stamp_file = None
     if plugin_data:
         plugin_data.mkdir(parents=True, exist_ok=True)
         stamp_file = plugin_data / "deps.stamp"
+        if stamp_file.exists() and stamp_file.read_text().strip() == stamp:
+            if venv_python.exists() and _all_importable(venv_python, deps):
+                return
 
-    missing = []
-    for spec, import_name in deps:
-        try:
-            __import__(import_name)
-        except ImportError:
-            missing.append(spec)
-
-    if not missing and stamp_file:
-        stamp_file.write_text(stamp)
-
-    if not missing:
-        return
-
-    if not missing:
-        if plugin_data:
-            stamp_file.write_text(stamp)
-        return
-
-    print(f"Installing: {', '.join(missing)}")
-    result = subprocess.run(
-        [sys.executable, "-m", "pip", "install", "-q", *missing],
-        capture_output=True, text=True
-    )
-    if result.returncode != 0:
-        print(f"pip install failed: {result.stderr}", file=sys.stderr)
-        return
+    _ensure_venv(venv_dir)
+    _install_deps(venv_dir, [spec for spec, _ in deps])
 
     if stamp_file:
         stamp_file.write_text(stamp)
+
+
+def _resolve_deps(plugin_root):
+    """Determine which deps are needed based on eval.yaml."""
+    deps = [("pyyaml>=6.0", "yaml")]
+
+    eval_yaml = _find_eval_yaml(plugin_root)
+    if not eval_yaml or not eval_yaml.exists():
+        return deps
+
+    try:
+        import yaml
+        config = yaml.safe_load(eval_yaml.read_text()) or {}
+    except Exception:
+        try:
+            config = _parse_yaml_minimal(eval_yaml.read_text())
+        except Exception:
+            return deps
+
+    if not isinstance(config, dict):
+        return deps
+
+    if config.get("mlflow") is not None:
+        deps.append(("mlflow[genai]>=3.5", "mlflow"))
+
+    judges = config.get("judges", [])
+    if isinstance(judges, list):
+        for j in judges:
+            if not isinstance(j, dict):
+                continue
+            if j.get("prompt") or j.get("prompt_file") or j.get("pairwise"):
+                deps.append(("anthropic[vertex]>=0.40", "anthropic"))
+                break
+
+    return deps
+
+
+def _parse_yaml_minimal(text):
+    """Minimal YAML-like extraction when pyyaml isn't available yet."""
+    result = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped:
+            continue
+        if ":" in stripped and not stripped.startswith("-"):
+            key, _, val = stripped.partition(":")
+            key = key.strip()
+            val = val.strip()
+            if val:
+                result[key] = val
+            else:
+                result[key] = {}
+    return result
+
+
+def _ensure_venv(venv_dir):
+    """Create the venv if it doesn't exist."""
+    if (venv_dir / "bin" / "python3").exists():
+        return
+
+    uv = shutil.which("uv")
+    if uv:
+        print(f"Creating venv with uv: {venv_dir}")
+        subprocess.run([uv, "venv", str(venv_dir), "--seed",
+                        "--python", sys.executable],
+                       check=True, capture_output=True, text=True)
+    else:
+        print(f"Creating venv: {venv_dir}")
+        subprocess.run([sys.executable, "-m", "venv", str(venv_dir)],
+                       check=True, capture_output=True, text=True)
+
+
+def _install_deps(venv_dir, specs):
+    """Install packages into the venv."""
+    if not specs:
+        return
+
+    uv = shutil.which("uv")
+    venv_pip = venv_dir / "bin" / "pip"
+    venv_python = venv_dir / "bin" / "python3"
+
+    print(f"Installing: {', '.join(specs)}")
+
+    if uv:
+        result = subprocess.run(
+            [uv, "pip", "install", "-q", "--python", str(venv_python), *specs],
+            capture_output=True, text=True,
+        )
+    elif venv_pip.exists():
+        result = subprocess.run(
+            [str(venv_pip), "install", "-q", *specs],
+            capture_output=True, text=True,
+        )
+    else:
+        result = subprocess.run(
+            [str(venv_python), "-m", "pip", "install", "-q", *specs],
+            capture_output=True, text=True,
+        )
+
+    if result.returncode != 0:
+        print(f"Install failed: {result.stderr}", file=sys.stderr)
+
+
+def _all_importable(venv_python, deps):
+    """Check all deps are importable in the venv python."""
+    imports = ";".join(f"__import__('{mod}')" for _, mod in deps)
+    result = subprocess.run(
+        [str(venv_python), "-c", imports],
+        capture_output=True, text=True,
+    )
+    return result.returncode == 0
 
 
 def _find_eval_yaml(plugin_root):
@@ -113,7 +167,7 @@ def _find_eval_yaml(plugin_root):
 
 
 def _compute_stamp(deps):
-    return hashlib.sha256("|".join(sorted(deps)).encode()).hexdigest()[:12]
+    return hashlib.sha256("|".join(sorted(s for s, _ in deps)).encode()).hexdigest()[:12]
 
 
 if __name__ == "__main__":

--- a/scripts/ensure_deps.py
+++ b/scripts/ensure_deps.py
@@ -78,6 +78,11 @@ def _resolve_deps(plugin_root):
             if j.get("prompt") or j.get("prompt_file") or j.get("pairwise"):
                 deps.append(("anthropic[vertex]>=0.40", "anthropic"))
                 break
+    elif isinstance(judges, dict):
+        # _parse_yaml_minimal can't parse YAML lists, so judges may be
+        # a dict or empty. Install anthropic as a safe default since we
+        # can't tell whether LLM judges are configured.
+        deps.append(("anthropic[vertex]>=0.40", "anthropic"))
 
     return deps
 

--- a/scripts/ensure_deps.py
+++ b/scripts/ensure_deps.py
@@ -146,6 +146,7 @@ def _install_deps(venv_dir, specs):
 
     if result.returncode != 0:
         print(f"Install failed: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _all_importable(venv_python, deps):

--- a/skills/eval-analyze/scripts/find_skills.py
+++ b/skills/eval-analyze/scripts/find_skills.py
@@ -8,6 +8,8 @@ Usage:
     python3 ${CLAUDE_SKILL_DIR}/scripts/find_skills.py [--name <skill>]
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import json
 import sys

--- a/skills/eval-analyze/scripts/validate_eval.py
+++ b/skills/eval-analyze/scripts/validate_eval.py
@@ -6,6 +6,8 @@ Usage:
     python3 ${CLAUDE_SKILL_DIR}/scripts/validate_eval.py memory [eval.md]
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import hashlib
 import sys
 from pathlib import Path

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -13,6 +13,8 @@ Usage:
         [--open]
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import base64
 import difflib

--- a/skills/eval-run/scripts/tools.py
+++ b/skills/eval-run/scripts/tools.py
@@ -11,6 +11,8 @@ Supports:
 - Filtering Bash commands by content patterns
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import json
 import os
 import re

--- a/skills/eval-setup/SKILL.md
+++ b/skills/eval-setup/SKILL.md
@@ -23,30 +23,32 @@ Parse `$ARGUMENTS` for:
 
 ## Step 1: Install Dependencies (if needed)
 
-Dependencies are normally auto-installed by the plugin's SessionStart hook. This step is a fallback for mid-session installs or troubleshooting.
+Dependencies are managed in an isolated venv at `<plugin_root>/.eval-venv/`. The SessionStart hook creates this venv automatically. Scripts auto-activate it via `agent_eval._bootstrap` on import.
 
-Check what's missing:
+This step is a fallback for mid-session installs or troubleshooting. Re-run the hook's install script:
 
 ```bash
-python3 -c "import yaml; print('pyyaml: OK')" 2>&1 || echo "pyyaml: MISSING"
+python3 ${CLAUDE_SKILL_DIR}/../../scripts/ensure_deps.py "${CLAUDE_PLUGIN_DATA:-/tmp/agent-eval-data}"
 ```
 
-Install pyyaml if missing:
+To check the venv status:
 
 ```bash
-pip install 'pyyaml>=6.0'
+VENV_PYTHON="${CLAUDE_SKILL_DIR}/../../.eval-venv/bin/python3"
+test -x "$VENV_PYTHON" && echo "venv: OK" || echo "venv: MISSING"
+$VENV_PYTHON -c "import yaml; print('pyyaml: OK')" 2>&1 || echo "pyyaml: MISSING"
 ```
 
-If `--skip-mlflow` was NOT passed, also install mlflow:
+To install additional packages manually into the venv:
 
 ```bash
-pip install 'mlflow[genai]>=3.5'
-```
-
-For LLM judges, pairwise comparison, and LLM-based AskUserQuestion answering in hooks:
-
-```bash
-pip install 'anthropic[vertex]>=0.40'
+VENV_DIR="${CLAUDE_SKILL_DIR}/../../.eval-venv"
+# Use uv if available, otherwise venv pip
+if command -v uv &>/dev/null; then
+  uv pip install --python "$VENV_DIR/bin/python3" 'mlflow[genai]>=3.5' 'anthropic[vertex]>=0.40'
+else
+  "$VENV_DIR/bin/pip" install 'mlflow[genai]>=3.5' 'anthropic[vertex]>=0.40'
+fi
 ```
 
 ## Step 2: Run Preflight Checks

--- a/skills/eval-setup/SKILL.md
+++ b/skills/eval-setup/SKILL.md
@@ -28,7 +28,7 @@ Dependencies are managed in an isolated venv at `<plugin_root>/.eval-venv/`. The
 This step is a fallback for mid-session installs or troubleshooting. Re-run the hook's install script:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/../../scripts/ensure_deps.py "${CLAUDE_PLUGIN_DATA:-/tmp/agent-eval-data}"
+python3 "${CLAUDE_SKILL_DIR}/../../scripts/ensure_deps.py" "${CLAUDE_PLUGIN_DATA:-${XDG_STATE_HOME:-$HOME/.local/state}/agent-eval-data}"
 ```
 
 To check the venv status:
@@ -36,7 +36,7 @@ To check the venv status:
 ```bash
 VENV_PYTHON="${CLAUDE_SKILL_DIR}/../../.eval-venv/bin/python3"
 test -x "$VENV_PYTHON" && echo "venv: OK" || echo "venv: MISSING"
-$VENV_PYTHON -c "import yaml; print('pyyaml: OK')" 2>&1 || echo "pyyaml: MISSING"
+"$VENV_PYTHON" -c "import yaml; print('pyyaml: OK')" 2>&1 || echo "pyyaml: MISSING"
 ```
 
 To install additional packages manually into the venv:


### PR DESCRIPTION
## Summary

- `ensure_deps.py` now creates `.eval-venv/` at the plugin root (using `uv` or stdlib `venv`) instead of running `pip install` into the system python
- New `agent_eval/_bootstrap.py` auto-activates the venv on import, before any third-party deps load
- Scripts that import `agent_eval` get the bootstrap for free via `__init__.py`; yaml-only scripts get an explicit import
- No changes to SKILL.md invocation patterns (`python3 ${CLAUDE_SKILL_DIR}/scripts/...` stays the same)

## Problem

On macOS with Homebrew Python 3.14 (externally-managed environment), `pip install` silently fails. The SessionStart hook reported success, but scripts crashed at runtime:

```
ModuleNotFoundError: No module named 'yaml'
ModuleNotFoundError: No module named 'anthropic'
```

## How the bootstrap works

- **Script invocations** (`python3 script.py`): `_bootstrap` re-execs the process with the venv python via `os.execv()`
- **Inline code** (`python3 -c "from agent_eval..."`): `_bootstrap` patches `sys.path` with the venv's site-packages (can't re-exec since `-c` code isn't in `sys.argv`)
- **Already in venv**: no-op (detected by checking if venv site-packages are on `sys.path`)

## Test plan

- [x] `ensure_deps.py` creates `.eval-venv/` with correct python version
- [x] Second run skips install (stamp caching works)
- [x] `score.py` auto-bootstraps when invoked with system python
- [x] `python3 -c "from agent_eval... import anthropic"` works via sys.path patching
- [x] `find_skills.py` (yaml-only script) bootstraps correctly
- [x] `validate_eval.py` works from cc-prose project directory

Assisted-By: 🤖 Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic activation of an isolated evaluation virtual environment for CLI tools and runtime imports; dependency installation now targets that venv and uses a stamp to avoid unnecessary reinstalls.

* **Documentation**
  * Updated setup and health-check guidance to use the isolated venv and clarified manual install fallback steps.

* **Chores**
  * Added the evaluation environment directory to version control exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->