### PR TITLE
Collect in-place file edits from skill execution

### DIFF
--- a/skills/eval-analyze/prompts/analyze-skill.md
+++ b/skills/eval-analyze/prompts/analyze-skill.md
@@ -45,6 +45,11 @@ outputs:
   # - tool: "<tool name pattern, e.g. mcp__atlassian__create_issue>"
   #   schema: |
   #     <what this tool call does and what fields in its input/output matter>
+  edits_in_place: <true|false>
+  # Set to true if the skill modifies input files (e.g., using the Edit tool
+  # on source.md) rather than writing to an output directory. The harness
+  # automatically collects these changes into outputs["modified_files"].
+  # Judges access them as: outputs.get("modified_files", {}).get("filename")
 
 sub_skills:
   - name: "<sub-skill name>"

--- a/skills/eval-analyze/prompts/analyze-skill.md
+++ b/skills/eval-analyze/prompts/analyze-skill.md
@@ -45,11 +45,6 @@ outputs:
   # - tool: "<tool name pattern, e.g. mcp__atlassian__create_issue>"
   #   schema: |
   #     <what this tool call does and what fields in its input/output matter>
-  edits_in_place: <true|false>
-  # Set to true if the skill modifies input files (e.g., using the Edit tool
-  # on source.md) rather than writing to an output directory. The harness
-  # automatically collects these changes into outputs["modified_files"].
-  # Judges access them as: outputs.get("modified_files", {}).get("filename")
 
 sub_skills:
   - name: "<sub-skill name>"
@@ -112,6 +107,7 @@ After the YAML block, explain:
 3. Any edge cases or failure modes you noticed
 4. What evaluation criteria would be most valuable
 5. Which sub-skill's outputs are the ones that matter for scoring
-6. Which tools and scripts interact with external services — look for AskUserQuestion (needs auto-answers), MCP tools calling external APIs (Jira, Slack, etc.), AND Python scripts that import API clients or call external URLs. These all need `inputs.tools` entries in eval.yaml so headless eval can intercept them. Also identify which **input fields** reference real external state (e.g., a Jira project key that must exist on the target instance, a GitHub repo URL that must be accessible, a Slack channel ID). These fields cannot be synthesized by eval-dataset — list them so eval-analyze can mark them with `[EXTERNAL: System]` in the dataset schema.
+6. Whether the skill edits input files in-place (e.g., uses the Edit tool on `source.md`) rather than writing to an output directory. If so, note this explicitly. The harness automatically collects in-place edits into `outputs["modified_files"]`, so judges should be written against that dict (e.g., `outputs.get("modified_files", {}).get("source.md")`) rather than expecting files in an output directory.
+7. Which tools and scripts interact with external services — look for AskUserQuestion (needs auto-answers), MCP tools calling external APIs (Jira, Slack, etc.), AND Python scripts that import API clients or call external URLs. These all need `inputs.tools` entries in eval.yaml so headless eval can intercept them. Also identify which **input fields** reference real external state (e.g., a Jira project key that must exist on the target instance, a GitHub repo URL that must be accessible, a Slack channel ID). These fields cannot be synthesized by eval-dataset — list them so eval-analyze can mark them with `[EXTERNAL: System]` in the dataset schema.
 
 Be thorough but concise. Reference actual file paths and field names you observed — don't invent generic examples.

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -138,6 +138,13 @@ outputs:
   #   schema: |
   #     <what this tool call represents and what fields matter>
 
+# In-place edits: if the skill modifies input files (e.g., editing source.md
+# via the Edit tool), those changes are automatically collected into
+# outputs["modified_files"] and outputs["files"]["_modified/filename"].
+# No extra config needed — the harness diffs the workspace against its
+# initial state after execution. Judges can access modified file content
+# directly: outputs.get("modified_files", {}).get("source.md", "")
+
 # Traces — execution data to capture for judges
 traces:
   stdout: true     # Capture stdout.log
@@ -247,6 +254,7 @@ Keep check scripts short (under 15 lines). They receive an `outputs` dict — **
 
 Key fields in `outputs`:
 - `outputs["files"]` — dict of `{relative_path: file_content}`, e.g. `{"artifacts/rfe-tasks/RFE-001.md": "# Summary\n..."}`
+- `outputs["modified_files"]` — dict of `{filename: content}` for files modified in-place during execution (e.g., `{"source.md": "edited content..."}`)
 - `outputs["case_dir"]` — absolute path to the per-case output directory
 - `outputs["exit_code"]`, `outputs["duration_s"]`, `outputs["cost_usd"]`, `outputs["num_turns"]` — execution metadata
 - `outputs["tool_calls"]` — list of captured tool calls

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -144,6 +144,11 @@ outputs:
 # No extra config needed — the harness diffs the workspace against its
 # initial state after execution. Judges can access modified file content
 # directly: outputs.get("modified_files", {}).get("source.md", "")
+#
+# For skills that ONLY edit in-place (no output directory), you still need
+# at least one outputs entry with a path. Use a placeholder directory name
+# (e.g., "output") — the directory may be empty, but judges will receive
+# modified files via outputs["modified_files"] and {{ outputs }} regardless.
 
 # Traces — execution data to capture for judges
 traces:
@@ -283,6 +288,21 @@ Example check judge — find files by path prefix and read their content:
               return (False, f"{fname}: missing score")
       return (True, f"{len(reviews)} reviews valid")
 ```
+
+Example check judge for in-place edits (skills that edit input files via Edit tool):
+```yaml
+  - name: source_modified
+    check: |
+      modified = outputs.get("modified_files", {})
+      text = modified.get("source.md", "")
+      if not text.strip():
+          return (False, "source.md was not modified")
+      if len(text.strip()) < 50:
+          return (False, f"Modified source.md too short ({len(text.strip())} chars)")
+      return (True, f"source.md modified ({len(text)} chars)")
+```
+
+**Note on `{{ outputs }}` and modified files**: Modified files appear in `outputs["files"]` with a `_modified/` prefix (e.g., `_modified/source.md`). The `{{ outputs }}` template variable in LLM judge prompts renders ALL entries from `outputs["files"]`, so modified files are automatically included. LLM judges see them as `### _modified/source.md` sections.
 
 **Error handling in check judges:** Use `.get()` with defaults for all dict lookups — if the skill produced no output or failed, keys may be missing. Return `(False, "reason")` for missing data rather than letting exceptions propagate:
 ```yaml

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -104,10 +104,18 @@ $AGENT_EVAL_RUNS_DIR/{id}/
         RFE-001-slug.md
       artifacts/reviews/  # Files from outputs[1].path
         RFE-001-review.md
+      _modified/          # In-place edits (auto-detected via git diff)
+        source.md
     case-002-name/
       artifacts/
         RFE-002-slug.md
+      _modified/
+        source.md
 ```
+
+### In-place file edits
+
+Skills that modify input files using the Edit tool (rather than writing to an output directory) are handled automatically. `workspace.py` creates a git commit of the initial workspace state before execution. After execution, `collect.py` runs `git diff HEAD` to detect modified files and copies them to a `_modified/` directory under each case's run output. No extra `outputs` config is needed.
 
 ## 4. Collection → Scoring
 
@@ -119,10 +127,19 @@ $AGENT_EVAL_RUNS_DIR/{id}/
     "files": {
         "artifacts/RFE-001-slug.md": "<full file content>",
         "artifacts/reviews/RFE-001-review.md": "<full file content>",
+        # In-place edits (auto-collected via git diff)
+        "_modified/source.md": "<edited file content>",
     },
     "artifacts_content": "<content of first file in artifacts/>",
     "artifacts_file": "/path/to/artifacts/RFE-001-slug.md",
     "reviews_content": "<content of first file in reviews/>",
+
+    # --- In-place edits (convenience access) ---
+    # Same content as files["_modified/..."] but keyed by filename only.
+    # Use this for direct access: outputs.get("modified_files", {}).get("source.md")
+    "modified_files": {
+        "source.md": "<edited file content>",
+    },
 
     # --- Tool calls (from outputs with tool) ---
     "tool_calls": [
@@ -143,10 +160,15 @@ $AGENT_EVAL_RUNS_DIR/{id}/
     "stdout": "<full stdout.log content>",
     "stderr": "<full stderr.log content>",
 
+    # --- Annotations (from dataset case directory) ---
+    "annotations": {"expected_voice": "technical", "difficulty": "easy"},
+
     # --- Context ---
     "case_dir": "/absolute/path/to/case"
 }
 ```
+
+**Note on `{{ outputs }}` in LLM judges**: The `{{ outputs }}` template variable renders ALL entries in `files`, including `_modified/` entries. Each file appears as a markdown section with its path as the heading. Modified files will appear as `### _modified/source.md` followed by the edited content.
 
 **Key naming convention for convenience keys**: for an output with `path: "artifacts/rfe-tasks"`, the convenience key is `rfe-tasks_content` (the last directory component + `_content`). For `path: "."`, the key is `main_content`.
 
@@ -190,3 +212,31 @@ For each judge across all cases:
 | `metrics: true` | Capture execution metadata | `$AGENT_EVAL_RUNS_DIR/{id}/run_result.json` | `outputs["exit_code"]`, `["duration_s"]`, `["cost_usd"]`, `["num_turns"]`, `["token_usage"]` |
 
 Note: `events` being false doesn't prevent tool call extraction — tool calls are extracted from stdout regardless if `outputs` has `tool:` entries. The `events` flag controls whether the full event stream is stored.
+
+### Important: stdout format for Claude Code runner
+
+When `runner.type: claude-code`, `outputs["stdout"]` contains the **raw JSONL event stream** from `claude --print`, not plain text. Each line is a JSON object with `type` (`user`, `assistant`, `system`, `result`). Assistant text is in objects like:
+
+```json
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "..."}]}}
+```
+
+**For check judges**: if you need to scan the skill's text output, extract it from the JSONL rather than regex-matching the raw stream (which also contains the original input, tool calls, and tool results). Example:
+
+```python
+import json
+texts = []
+for line in outputs.get("stdout", "").splitlines():
+    try:
+        evt = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        continue
+    if evt.get("type") != "assistant" or evt.get("parent_tool_use_id"):
+        continue
+    for block in evt.get("message", {}).get("content", []):
+        if block.get("type") == "text":
+            texts.append(block["text"])
+rewritten_text = "\n".join(texts)
+```
+
+**For LLM judges**: prefer `{{ outputs }}` (renders file artifacts and modified files as markdown) over `{{ stdout }}` (not a recognized template variable). If the skill edits files in-place, the rewritten content appears in `{{ outputs }}` via the `_modified/` collection.

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -233,7 +233,9 @@ def _collect_modified_files(case_dir, config):
              "--others", "--exclude-standard"],
             capture_output=True, text=True, check=True,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"  {case_dir.name}: no modified files (git diff failed: {e})",
+              file=sys.stderr)
         return []
 
     all_changed = set()

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -15,12 +15,19 @@ import argparse
 import json
 import re
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
 import yaml
 
 from agent_eval.config import EvalConfig
+
+# Files/dirs created by the harness infrastructure, not by the skill
+_HARNESS_PATHS = {
+    ".claude", ".git", "stdout.log", "stderr.log",
+    "run_result.json", "batch.yaml", "case_order.yaml",
+}
 
 
 def _safe_path_component(value, field):
@@ -178,6 +185,17 @@ def _collect_per_case(workspace, output_dir, config):
 
             results.setdefault(case_id, {})[out_path] = len(files)
 
+        # Collect files modified in-place during execution
+        modified = _collect_modified_files(case_dir, config)
+        if modified:
+            mod_output = output_dir / "cases" / case_id / "_modified"
+            mod_output.mkdir(parents=True, exist_ok=True)
+            for rel_path, abs_path in modified:
+                dest = mod_output / rel_path
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(abs_path, dest)
+            results.setdefault(case_id, {})["_modified"] = len(modified)
+
     # Save collection summary
     with open(output_dir / "collection.json", "w") as f:
         json.dump(results, f, indent=2)
@@ -188,6 +206,56 @@ def _collect_per_case(workspace, output_dir, config):
 
     if not results:
         print("WARNING: no artifacts collected", file=sys.stderr)
+
+
+def _collect_modified_files(case_dir, config):
+    """Find files modified or created during skill execution.
+
+    Uses git diff against the initial commit (created by workspace.py)
+    to detect in-place edits. Filters out harness infrastructure and
+    configured output directories.
+    """
+    git_dir = case_dir / ".git"
+    if not git_dir.exists():
+        return []
+
+    output_dirs = {o.path for o in config.outputs if o.path}
+
+    try:
+        # Modified tracked files
+        diff = subprocess.run(
+            ["git", "-C", str(case_dir), "diff", "--name-only", "HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+        # New untracked files (excluding harness paths)
+        untracked = subprocess.run(
+            ["git", "-C", str(case_dir), "ls-files",
+             "--others", "--exclude-standard"],
+            capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+    all_changed = set()
+    for line in (diff.stdout + untracked.stdout).splitlines():
+        line = line.strip()
+        if line:
+            all_changed.add(line)
+
+    result = []
+    for rel in sorted(all_changed):
+        parts = Path(rel).parts
+        if not parts:
+            continue
+        if parts[0] in _HARNESS_PATHS:
+            continue
+        if parts[0] in output_dirs:
+            continue
+        abs_path = case_dir / rel
+        if abs_path.is_file() and not abs_path.is_symlink():
+            result.append((rel, abs_path))
+
+    return result
 
 
 def _collect_batch(files, case_order, batch_pattern):

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -219,7 +219,10 @@ def _collect_modified_files(case_dir, config):
     if not git_dir.exists():
         return []
 
-    output_dirs = {o.path for o in config.outputs if o.path}
+    output_prefixes = {
+        tuple(Path(o.path).parts)
+        for o in config.outputs if o.path
+    }
 
     try:
         # Modified tracked files
@@ -253,12 +256,16 @@ def _collect_modified_files(case_dir, config):
             continue
         if parts[0] in _HARNESS_PATHS:
             continue
-        if parts[0] in output_dirs:
+        if any(parts[:len(op)] == op for op in output_prefixes):
             continue
-        abs_path = (case_dir / rel).resolve()
+        candidate = case_dir / rel
+        if candidate.is_symlink() or any(p.is_symlink() for p in candidate.parents
+                                         if p != case_dir):
+            continue
+        abs_path = candidate.resolve()
         if not abs_path.is_relative_to(case_dir.resolve()):
             continue
-        if abs_path.is_file() and not abs_path.is_symlink():
+        if abs_path.is_file():
             result.append((rel, abs_path))
 
     return result

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -247,11 +247,15 @@ def _collect_modified_files(case_dir, config):
         parts = Path(rel).parts
         if not parts:
             continue
+        if ".." in parts:
+            continue
         if parts[0] in _HARNESS_PATHS:
             continue
         if parts[0] in output_dirs:
             continue
-        abs_path = case_dir / rel
+        abs_path = (case_dir / rel).resolve()
+        if not abs_path.is_relative_to(case_dir.resolve()):
+            continue
         if abs_path.is_file() and not abs_path.is_symlink():
             result.append((rel, abs_path))
 

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -259,8 +259,16 @@ def _collect_modified_files(case_dir, config):
         if any(parts[:len(op)] == op for op in output_prefixes):
             continue
         candidate = case_dir / rel
-        if candidate.is_symlink() or any(p.is_symlink() for p in candidate.parents
-                                         if p != case_dir):
+        if candidate.is_symlink():
+            continue
+        has_symlink_ancestor = False
+        for p in candidate.parents:
+            if p == case_dir:
+                break
+            if p.is_symlink():
+                has_symlink_ancestor = True
+                break
+        if has_symlink_ancestor:
             continue
         abs_path = candidate.resolve()
         if not abs_path.is_relative_to(case_dir.resolve()):

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -120,6 +120,25 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
                     pass
                 break
 
+    # --- Modified files (in-place edits collected by collect.py) ---
+    modified_dir = case_dir / "_modified"
+    if modified_dir.exists():
+        modified = {}
+        for f in sorted(modified_dir.rglob("*")):
+            if not f.is_file() or f.is_symlink():
+                continue
+            _resolve_under(case_dir, f)
+            rel = str(f.relative_to(modified_dir))
+            try:
+                content = f.read_text()
+                record["files"][f"_modified/{rel}"] = content
+                modified[rel] = content
+            except UnicodeDecodeError:
+                record["files"][f"_modified/{rel}"] = {
+                    "_binary": True, "path": str(f), "name": f.name}
+        if modified:
+            record["modified_files"] = modified
+
     # --- Execution metadata (from run_result.json) ---
     if run_id and config.traces.metrics:
         run_result_path = runs_dir / run_id / "run_result.json"

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -210,6 +210,18 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
                 else:
                     out.mkdir(parents=True, exist_ok=True)
 
+        # Snapshot initial state so collect.py can diff for in-place edits
+        _git_env = {**os.environ,
+                    "GIT_AUTHOR_NAME": "eval-harness",
+                    "GIT_AUTHOR_EMAIL": "eval@harness",
+                    "GIT_COMMITTER_NAME": "eval-harness",
+                    "GIT_COMMITTER_EMAIL": "eval@harness"}
+        subprocess.run(["git", "-C", str(case_ws), "add", "-A"],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(case_ws), "commit", "-q",
+                        "-m", "initial", "--allow-empty"],
+                       check=True, capture_output=True, env=_git_env)
+
         # Symlink project resources (skip .claude — we create our own)
         for name in symlink_names:
             if name == ".claude":


### PR DESCRIPTION
## Summary

- `workspace.py`: Commits initial workspace state after setup (`git add -A && git commit`)
- `collect.py`: After execution, diffs workspace against initial commit to find modified/new files. Collects them into `_modified/` directory, filtering out harness infrastructure
- `score.py`: Loads `_modified/` files into `outputs["modified_files"]` dict for easy judge access
- Template/prompt updates: Documents `modified_files` in outputs reference and guides eval-analyze to note in-place edit patterns

## Problem

Skills like the [cc-prose](https://github.com/rhuss/cc-prose) humanizer edit input files in-place (e.g., `source.md` via the Edit tool) rather than writing to a configured output directory. The collect step found zero artifacts, `collection.json` was empty, and judges received an empty `outputs["files"]` dict.

## How it works

```
workspace.py: git init + git commit (snapshot initial state)
    |
skill executes: edits source.md in-place
    |
collect.py: git diff --name-only HEAD → finds source.md changed
    |
copies to: run_dir/cases/{case_id}/_modified/source.md
    |
score.py: loads into outputs["modified_files"]["source.md"]
```

Harness infrastructure (`stdout.log`, `stderr.log`, `.claude/`, configured output dirs) is filtered out.

## Test plan

- [x] Simulated workspace: `source.md` modified in-place is detected and collected
- [x] Harness files (`stdout.log`, `stderr.log`, `run_result.json`) are filtered out
- [x] Files in configured output dirs are still collected normally (not duplicated)
- [x] `collection.json` shows both `output` and `_modified` counts
- [ ] End-to-end with cc-prose humanizer eval run

Assisted-By: 🤖 Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runs now detect files created or edited during execution and collect them into each case’s outputs under a dedicated per-case "modified" area; case summaries include counts and a modified-files map. Workspaces are snapshotted to enable reliable in-place edit detection.

* **Documentation**
  * Prompts and evaluation docs clarify how to access collected modified files, document stdout-based outputs (including raw event streams for some runners), and recommend using the unified outputs view in judges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->