### PR TITLE
Add venv bootstrap to all Python scripts

### DIFF
--- a/agent_eval/__init__.py
+++ b/agent_eval/__init__.py
@@ -1,4 +1,3 @@
 """Agent Eval Harness — generic evaluation framework for Claude Code skills."""
-import agent_eval._bootstrap  # noqa: F401 — auto-activate venv before third-party imports
 
 __version__ = "0.1.0"

--- a/skills/eval-mlflow/scripts/attach_feedback.py
+++ b/skills/eval-mlflow/scripts/attach_feedback.py
@@ -25,6 +25,8 @@ Usage:
         --run-id <id> --config eval.yaml --action pull
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import os
 import sys

--- a/skills/eval-mlflow/scripts/from_traces.py
+++ b/skills/eval-mlflow/scripts/from_traces.py
@@ -13,6 +13,8 @@ Usage:
         [--min-duration 5]
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import sys
 

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -11,6 +11,8 @@ Usage:
         --config eval.yaml
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import json
 import os

--- a/skills/eval-mlflow/scripts/sync_dataset.py
+++ b/skills/eval-mlflow/scripts/sync_dataset.py
@@ -27,6 +27,8 @@ Schema mapping format (tmp/schema_mapping.json):
     - "filename:__file__" uses the entire file content
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import json
 import os

--- a/skills/eval-mlflow/scripts/trace_from_stdout.py
+++ b/skills/eval-mlflow/scripts/trace_from_stdout.py
@@ -14,6 +14,8 @@ Usage:
         [--experiment <name>]
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import json
 import os

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -11,6 +11,8 @@ Usage:
         --output eval/runs/test-001
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import json
 import re

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -18,6 +18,8 @@ Usage:
         [--mlflow-experiment my-eval]
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import json
 import shutil

--- a/skills/eval-run/scripts/preflight.py
+++ b/skills/eval-run/scripts/preflight.py
@@ -19,6 +19,8 @@ Usage:
     python3 ${CLAUDE_SKILL_DIR}/scripts/preflight.py --config eval.yaml --run-id 2026-04-11-opus
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import os
 import shutil

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -11,6 +11,8 @@ Usage:
     python3 ${CLAUDE_SKILL_DIR}/scripts/score.py regression --run-id <id> --config eval.yaml
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import importlib
 import json

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -13,6 +13,8 @@ Usage:
         [--symlinks scripts,.claude,CLAUDE.md]
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import os
 import re

--- a/skills/eval-setup/scripts/check_env.py
+++ b/skills/eval-setup/scripts/check_env.py
@@ -8,6 +8,8 @@ Usage:
     python3 ${CLAUDE_SKILL_DIR}/scripts/check_env.py [--config eval.yaml] [--fix]
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import argparse
 import os
 import sys


### PR DESCRIPTION
## Summary
- Adds `import agent_eval._bootstrap` to all 11 Python scripts that were missing it
- Follow-up to #46 which introduced the bootstrap mechanism but only added it to 4 of 15 scripts
- `score.py` was the critical miss: LLM judges failed with `No module named 'anthropic'` because it ran under system Python without the venv activated

## Test plan
- [x] Verified all 15 Python scripts now have the bootstrap import
- [x] Confirmed `score.py` successfully runs LLM judges when invoked via system `python3`
- [ ] Run full eval suite to verify no regressions

Assisted-By: 🤖 Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Evaluation and setup scripts now automatically activate the configured virtual environment at startup, ensuring consistent runtime configuration and more reliable script execution.
  * The package no longer triggers environment activation on import, centralizing startup behavior to the CLI/run-time scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->