### PR TITLE
Add {{ stdout }} template variable for LLM judges

### DIFF
--- a/skills/eval-analyze/prompts/analyze-skill.md
+++ b/skills/eval-analyze/prompts/analyze-skill.md
@@ -94,7 +94,9 @@ suggested_judges:
     # For check type, include a working inline script:
     check: |
       <python snippet that takes outputs dict, returns (bool, str)>
-    # For llm type, include evaluation instructions:
+    # For llm type, include evaluation instructions.
+    # Use {{ outputs }} for file artifacts, {{ stdout }} for conversation text,
+    # or both. For stdout-only skills (no file output), use {{ stdout }}:
     prompt: |
       <what to evaluate and how to score>
 ```

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -322,15 +322,49 @@ Example check judge for in-place edits (skills that edit input files via Edit to
 - Accuracy: is the content correct?
 - Relevance: does it address the input?
 
-**IMPORTANT**: LLM judges only see what's in their prompt text. To include the skill's output files, use the `{{ outputs }}` template variable. The harness replaces it with all collected file contents (from `outputs[*].path` directories), formatted as markdown sections with file paths as headers. Without `{{ outputs }}`, the LLM receives only the raw prompt text and cannot see any output files.
+**IMPORTANT**: LLM judges only see what's in their prompt text. Use template variables to include skill output:
 
-Example:
+- `{{ outputs }}` renders all collected file contents (from `outputs[*].path` directories and `_modified/` in-place edits), formatted as markdown sections with file paths as headers.
+- `{{ stdout }}` renders extracted assistant conversation text from the JSONL stdout log. It filters out subagent messages, tool calls, and non-text events. For stdout-only skills (no file artifacts), this is the primary way to give judges the skill's output.
+- `{{ annotations }}` renders dataset annotations from the case's `annotations.yaml`.
+
+All three can be used in the same prompt. Without any template variables, the LLM receives only the raw prompt text and cannot see any output.
+
+Example with file artifacts:
 ```yaml
   - name: output_quality
     prompt: |
       Review the following outputs:
 
       {{ outputs }}
+
+      Score on a 1-5 scale:
+      ...
+```
+
+Example for stdout-only skills:
+```yaml
+  - name: response_quality
+    prompt: |
+      Evaluate this skill's response:
+
+      {{ stdout }}
+
+      Score on a 1-5 scale:
+      ...
+```
+
+Example with both file artifacts and conversation output:
+```yaml
+  - name: comprehensive_quality
+    prompt: |
+      The skill produced these file artifacts:
+
+      {{ outputs }}
+
+      And this conversation output:
+
+      {{ stdout }}
 
       Score on a 1-5 scale:
       ...

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -170,6 +170,8 @@ Skills that modify input files using the Edit tool (rather than writing to an ou
 
 **Note on `{{ outputs }}` in LLM judges**: The `{{ outputs }}` template variable renders ALL entries in `files`, including `_modified/` entries. Each file appears as a markdown section with its path as the heading. Modified files will appear as `### _modified/source.md` followed by the edited content.
 
+**Note on `{{ stdout }}` in LLM judges**: The `{{ stdout }}` template variable extracts assistant conversation text from the JSONL stdout log. It filters for top-level assistant text blocks (skipping subagent messages, tool calls, system events, and user input), then concatenates the extracted text. For non-JSONL stdout (e.g., from non-Claude runners), the raw content is passed through. If stdout is empty or missing, it renders as `(no stdout captured)`. Use `{{ stdout }}` for skills that produce their primary output via conversation text rather than file artifacts.
+
 **Key naming convention for convenience keys**: for an output with `path: "artifacts/rfe-tasks"`, the convenience key is `rfe-tasks_content` (the last directory component + `_content`). For `path: "."`, the key is `main_content`.
 
 ## 5. Scoring → Judges
@@ -239,4 +241,4 @@ for line in outputs.get("stdout", "").splitlines():
 rewritten_text = "\n".join(texts)
 ```
 
-**For LLM judges**: prefer `{{ outputs }}` (renders file artifacts and modified files as markdown) over `{{ stdout }}` (not a recognized template variable). If the skill edits files in-place, the rewritten content appears in `{{ outputs }}` via the `_modified/` collection.
+**For LLM judges**: use `{{ outputs }}` to render file artifacts and modified files as markdown. Use `{{ stdout }}` to render extracted assistant conversation text from the JSONL stream. Both can be used in the same prompt. If the skill edits files in-place, the rewritten content appears in `{{ outputs }}` via the `_modified/` collection.

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -214,12 +214,18 @@ def _extract_assistant_text(stdout_raw):
             obj = json.loads(line)
         except (json.JSONDecodeError, ValueError):
             continue
+        if not isinstance(obj, dict):
+            continue
         found_jsonl = True
         if obj.get("type") != "assistant" or obj.get("parent_tool_use_id"):
             continue
         for block in (obj.get("message") or {}).get("content", []):
+            if not isinstance(block, dict):
+                continue
             if block.get("type") == "text":
-                texts.append(block["text"])
+                text = block.get("text")
+                if isinstance(text, str):
+                    texts.append(text)
     if texts:
         return "\n".join(texts)
     if found_jsonl:
@@ -491,8 +497,10 @@ def _make_anthropic_llm_judge(name, prompt, judge_model):
         # Render {{ stdout }} template variable
         if outputs and "{{ stdout }}" in rendered_prompt:
             stdout_raw = outputs.get("stdout", "")
-            rendered_prompt = rendered_prompt.replace(
-                "{{ stdout }}", _extract_assistant_text(stdout_raw))
+            stdout_text = _extract_assistant_text(stdout_raw)
+            if len(stdout_text) > 200_000:
+                stdout_text = stdout_text[:200_000] + "\n...[truncated]"
+            rendered_prompt = rendered_prompt.replace("{{ stdout }}", stdout_text)
 
         # Render {{ annotations }} template variable
         if outputs and "{{ annotations }}" in rendered_prompt:

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -200,6 +200,33 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
     return record
 
 
+def _extract_assistant_text(stdout_raw):
+    """Extract top-level assistant conversation text from JSONL stdout."""
+    if not stdout_raw or not stdout_raw.strip():
+        return "(no stdout captured)"
+    texts = []
+    found_jsonl = False
+    for line in stdout_raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        found_jsonl = True
+        if obj.get("type") != "assistant" or obj.get("parent_tool_use_id"):
+            continue
+        for block in (obj.get("message") or {}).get("content", []):
+            if block.get("type") == "text":
+                texts.append(block["text"])
+    if texts:
+        return "\n".join(texts)
+    if found_jsonl:
+        return "(no top-level assistant text)"
+    return stdout_raw
+
+
 def _extract_tool_calls(stdout_text, tool_outputs):
     """Extract tool calls from stream-json stdout matching configured patterns."""
     tool_patterns = [o.tool for o in tool_outputs]
@@ -460,6 +487,12 @@ def _make_anthropic_llm_judge(name, prompt, judge_model):
                 else:
                     output_text += f"\n### {path}\n\n{content}\n"
             rendered_prompt = rendered_prompt.replace("{{ outputs }}", output_text)
+
+        # Render {{ stdout }} template variable
+        if outputs and "{{ stdout }}" in rendered_prompt:
+            stdout_raw = outputs.get("stdout", "")
+            rendered_prompt = rendered_prompt.replace(
+                "{{ stdout }}", _extract_assistant_text(stdout_raw))
 
         # Render {{ annotations }} template variable
         if outputs and "{{ annotations }}" in rendered_prompt:

--- a/tests/test_stdout_template.py
+++ b/tests/test_stdout_template.py
@@ -1,0 +1,188 @@
+"""Tests for {{ stdout }} template variable and _extract_assistant_text() helper."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from conftest import make_assistant, make_result, make_system_init, make_user
+
+from score import _extract_assistant_text, _make_anthropic_llm_judge
+
+
+def _jsonl(*events):
+    return "\n".join(json.dumps(e) for e in events)
+
+
+ASSISTANT_EVENT = make_assistant("msg_001", text="Hello from the skill")
+MULTI_BLOCK_EVENT = {
+    "type": "assistant",
+    "message": {
+        "content": [
+            {"type": "text", "text": "First block"},
+            {"type": "tool_use", "id": "tu_001", "name": "Write", "input": {}},
+            {"type": "text", "text": "Second block"},
+        ]
+    },
+}
+SUBAGENT_EVENT = make_assistant("msg_sub", text="Subagent output",
+                                parent_tool_use_id="toolu_abc123")
+USER_EVENT = make_user(text="user input")
+SYSTEM_EVENT = make_system_init()
+RESULT_EVENT = make_result(cost_usd=0.05, num_turns=1)
+
+
+# --- T002: _extract_assistant_text with valid JSONL ---
+
+class TestExtractAssistantTextJSONL:
+    def test_single_assistant_event(self):
+        stdout = _jsonl(ASSISTANT_EVENT)
+        result = _extract_assistant_text(stdout)
+        assert result == "Hello from the skill"
+
+    def test_multiple_assistant_events(self):
+        event2 = make_assistant("msg_002", text="Second message")
+        stdout = _jsonl(ASSISTANT_EVENT, event2)
+        result = _extract_assistant_text(stdout)
+        assert result == "Hello from the skill\nSecond message"
+
+    def test_multi_block_event(self):
+        stdout = _jsonl(MULTI_BLOCK_EVENT)
+        result = _extract_assistant_text(stdout)
+        assert result == "First block\nSecond block"
+
+    def test_filters_non_assistant_events(self):
+        stdout = _jsonl(USER_EVENT, ASSISTANT_EVENT, SYSTEM_EVENT, RESULT_EVENT)
+        result = _extract_assistant_text(stdout)
+        assert result == "Hello from the skill"
+
+    def test_filters_subagent_events(self):
+        stdout = _jsonl(ASSISTANT_EVENT, SUBAGENT_EVENT)
+        result = _extract_assistant_text(stdout)
+        assert result == "Hello from the skill"
+
+
+# --- T003: {{ stdout }} rendering in _make_anthropic_llm_judge ---
+
+class TestStdoutTemplateRendering:
+    def _make_mock_client(self):
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text='{"score": 4, "rationale": "good"}')]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+        return mock_client
+
+    @patch("score._get_anthropic_client")
+    def test_stdout_variable_renders_extracted_text(self, mock_get_client):
+        mock_client = self._make_mock_client()
+        mock_get_client.return_value = mock_client
+
+        prompt = "Evaluate this output:\n{{ stdout }}\nScore 1-5."
+        scorer = _make_anthropic_llm_judge("test", prompt, "test-model")
+
+        stdout = _jsonl(ASSISTANT_EVENT)
+        scorer(outputs={"stdout": stdout, "files": {}})
+
+        call_args = mock_client.messages.create.call_args
+        rendered = call_args.kwargs["messages"][0]["content"]
+        assert "Hello from the skill" in rendered
+        assert "{{ stdout }}" not in rendered
+
+    @patch("score._get_anthropic_client")
+    def test_stdout_variable_not_present_leaves_prompt_unchanged(self, mock_get_client):
+        mock_client = self._make_mock_client()
+        mock_get_client.return_value = mock_client
+
+        prompt = "Evaluate:\n{{ outputs }}\nScore 1-5."
+        scorer = _make_anthropic_llm_judge("test", prompt, "test-model")
+
+        scorer(outputs={"stdout": "some data", "files": {"f.md": "content"}})
+
+        call_args = mock_client.messages.create.call_args
+        rendered = call_args.kwargs["messages"][0]["content"]
+        assert "{{ stdout }}" not in rendered
+        assert "{{ outputs }}" not in rendered
+        assert "content" in rendered
+        assert "some data" not in rendered
+
+    @patch("score._get_anthropic_client")
+    def test_stdout_with_none_outputs(self, mock_get_client):
+        mock_client = self._make_mock_client()
+        mock_get_client.return_value = mock_client
+
+        prompt = "Evaluate:\n{{ stdout }}\nScore 1-5."
+        scorer = _make_anthropic_llm_judge("test", prompt, "test-model")
+
+        scorer(outputs=None)
+
+        call_args = mock_client.messages.create.call_args
+        rendered = call_args.kwargs["messages"][0]["content"]
+        assert "{{ stdout }}" in rendered
+
+
+# --- T007: Mixed {{ outputs }} and {{ stdout }} ---
+
+class TestMixedTemplateVariables:
+    @patch("score._get_anthropic_client")
+    def test_both_variables_resolve_independently(self, mock_get_client):
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text='{"score": 5, "rationale": "excellent"}')]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+        mock_get_client.return_value = mock_client
+
+        prompt = "Files:\n{{ outputs }}\n\nConversation:\n{{ stdout }}\n\nScore 1-5."
+        scorer = _make_anthropic_llm_judge("test", prompt, "test-model")
+
+        stdout = _jsonl(ASSISTANT_EVENT)
+        outputs = {
+            "stdout": stdout,
+            "files": {"output/result.md": "# Result\nSome content"},
+        }
+        scorer(outputs=outputs)
+
+        call_args = mock_client.messages.create.call_args
+        rendered = call_args.kwargs["messages"][0]["content"]
+        assert "Hello from the skill" in rendered
+        assert "# Result" in rendered
+        assert "{{ stdout }}" not in rendered
+        assert "{{ outputs }}" not in rendered
+
+
+# --- T008: Empty/missing stdout ---
+
+class TestExtractAssistantTextEmpty:
+    def test_empty_string(self):
+        assert _extract_assistant_text("") == "(no stdout captured)"
+
+    def test_none(self):
+        assert _extract_assistant_text(None) == "(no stdout captured)"
+
+    def test_whitespace_only(self):
+        assert _extract_assistant_text("   \n  \n  ") == "(no stdout captured)"
+
+
+# --- T009: Plain text (non-JSONL) stdout ---
+
+class TestExtractAssistantTextPlainText:
+    def test_plain_text_falls_back_to_raw(self):
+        plain = "This is just regular output\nfrom a non-Claude runner"
+        result = _extract_assistant_text(plain)
+        assert result == plain
+
+    def test_mixed_json_and_text(self):
+        mixed = "Some log line\n" + json.dumps(ASSISTANT_EVENT) + "\nAnother log"
+        result = _extract_assistant_text(mixed)
+        assert result == "Hello from the skill"
+
+
+# --- T010: Subagent-only JSONL ---
+
+class TestExtractAssistantTextSubagentOnly:
+    def test_subagent_only_returns_placeholder(self):
+        stdout = _jsonl(SUBAGENT_EVENT, USER_EVENT, RESULT_EVENT)
+        result = _extract_assistant_text(stdout)
+        assert result == "(no top-level assistant text)"
+
+    def test_jsonl_with_no_assistant_events_returns_placeholder(self):
+        stdout = _jsonl(USER_EVENT, SYSTEM_EVENT, RESULT_EVENT)
+        result = _extract_assistant_text(stdout)
+        assert result == "(no top-level assistant text)"

--- a/tests/test_stdout_template.py
+++ b/tests/test_stdout_template.py
@@ -186,3 +186,33 @@ class TestExtractAssistantTextSubagentOnly:
         stdout = _jsonl(USER_EVENT, SYSTEM_EVENT, RESULT_EVENT)
         result = _extract_assistant_text(stdout)
         assert result == "(no top-level assistant text)"
+
+
+# --- Type guard edge cases (CodeRabbit review) ---
+
+class TestExtractAssistantTextTypeGuards:
+    def test_scalar_json_lines_skipped(self):
+        stdout = '"just a string"\n42\ntrue\n' + json.dumps(ASSISTANT_EVENT)
+        result = _extract_assistant_text(stdout)
+        assert result == "Hello from the skill"
+
+    def test_array_json_lines_skipped(self):
+        stdout = '[1, 2, 3]\n' + json.dumps(ASSISTANT_EVENT)
+        result = _extract_assistant_text(stdout)
+        assert result == "Hello from the skill"
+
+    def test_missing_text_field_in_block(self):
+        event = {
+            "type": "assistant",
+            "message": {"content": [{"type": "text"}]},
+        }
+        result = _extract_assistant_text(json.dumps(event))
+        assert result == "(no top-level assistant text)"
+
+    def test_non_string_text_field_skipped(self):
+        event = {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": 123}]},
+        }
+        result = _extract_assistant_text(json.dumps(event))
+        assert result == "(no top-level assistant text)"

--- a/tests/test_stdout_template.py
+++ b/tests/test_stdout_template.py
@@ -104,6 +104,25 @@ class TestStdoutTemplateRendering:
         assert "some data" not in rendered
 
     @patch("score._get_anthropic_client")
+    def test_stdout_truncated_at_200k_chars(self, mock_get_client):
+        mock_client = self._make_mock_client()
+        mock_get_client.return_value = mock_client
+
+        prompt = "Start\n{{ stdout }}\nEnd"
+        scorer = _make_anthropic_llm_judge("test", prompt, "test-model")
+
+        long_text = "A" * 210_000
+        event = {"type": "assistant", "message": {"content": [{"type": "text", "text": long_text}]}}
+        stdout = _jsonl(event)
+        scorer(outputs={"stdout": stdout, "files": {}})
+
+        call_args = mock_client.messages.create.call_args
+        rendered = call_args.kwargs["messages"][0]["content"]
+        assert "{{ stdout }}" not in rendered
+        assert len(rendered) < len(long_text)
+        assert "...[truncated]" in rendered
+
+    @patch("score._get_anthropic_client")
     def test_stdout_with_none_outputs(self, mock_get_client):
         mock_client = self._make_mock_client()
         mock_get_client.return_value = mock_client


### PR DESCRIPTION
## Summary

- Add `{{ stdout }}` as a recognized template variable in LLM judge prompts, enabling meaningful evaluation of stdout-only skills
- New `_extract_assistant_text()` helper parses JSONL stdout, extracts top-level assistant text blocks (filtering subagent messages), falls back to raw content for non-JSONL runners, and returns a placeholder for empty or subagent-only output
- Document `{{ stdout }}` in data-pipeline.md, eval-yaml-template.md, and analyze-skill.md

**Context:** We detected this gap while testing a skill that produces output exclusively via stdout conversation text (no file artifacts). LLM judges configured with `{{ outputs }}` received only infrastructure files (like `tool_handlers.yaml`) instead of the actual skill output, making evaluation scores meaningless. The `{{ stdout }}` variable solves this by giving judges direct access to the extracted conversation text.

## Test plan

- [x] 16 unit tests covering all user stories and edge cases (JSONL extraction, template rendering, mixed variables, empty input, plain text fallback, subagent-only JSONL)
- [x] Verified no regressions in existing test suite (48 tests pass)
- [x] Deep review with 5 specialized agents (correctness, architecture, security, production readiness, test quality) + CodeRabbit: all Critical/Important findings fixed
- [x] Spec compliance: 100% (7/7 functional requirements verified)

Assisted-By: 🤖 Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified what `{{ outputs }}`, `{{ stdout }}`, and `{{ annotations }}` contain; added examples for stdout-only and combined prompts and guidance on using both variables.

* **New Features**
  * Judges can reference extracted assistant conversation via `{{ stdout }}` and use it alongside `{{ outputs }}`; stdout is extracted and truncated when needed.

* **Tests**
  * Added comprehensive tests for stdout extraction and prompt templating covering JSONL, multi-block, plain text, empty, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->