### PR TITLE
feat: add opaque CLI runner for arbitrary agent commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ agent_eval/              # Python package (config, runner, state)
   agent/
     base.py              # EvalRunner ABC + RunResult
     claude_code.py       # Claude Code CLI runner (claude --print)
+    cli_runner.py        # Opaque CLI runner (arbitrary command templates)
     stream_capture.py    # Stream-json processing (events, timestamps, usage, hooks)
   mlflow/
     experiment.py        # MLflow experiment setup, server check, feedback logging

--- a/README.md
+++ b/README.md
@@ -525,12 +525,18 @@ skills/
 
 ## Agent Support
 
-The harness is agent-agnostic via the `EvalRunner` abstraction. Set `runner` in eval.yaml:
+The harness is agent-agnostic via the `EvalRunner` abstraction. Set `runner.type` in eval.yaml:
 
 ```yaml
-runner: claude-code    # default
-runner: opencode       # when implemented
+runner:
+  type: claude-code    # default — uses claude --print
+
+runner:
+  type: cli            # opaque CLI runner — delegates to an arbitrary command
+  command: "my-runner run {agent} --model {model} --workspace {workspace}"
 ```
+
+The `cli` runner executes a configurable command template with placeholder substitution. See **[docs/opaque-cli-runner-contract.md](docs/opaque-cli-runner-contract.md)** for the full contract (placeholders, metrics.json format, what the command MUST and SHOULD do).
 
 Add new runners by subclassing `EvalRunner` in `agent_eval/agent/` and registering in `RUNNERS`.
 

--- a/agent_eval/agent/__init__.py
+++ b/agent_eval/agent/__init__.py
@@ -2,9 +2,11 @@
 
 from .base import EvalRunner, RunResult
 from .claude_code import ClaudeCodeRunner
+from .cli_runner import CliRunner
 
 RUNNERS = {
     "claude-code": ClaudeCodeRunner,
+    "cli": CliRunner,
 }
 
-__all__ = ["EvalRunner", "RunResult", "ClaudeCodeRunner", "RUNNERS"]
+__all__ = ["EvalRunner", "RunResult", "ClaudeCodeRunner", "CliRunner", "RUNNERS"]

--- a/agent_eval/agent/base.py
+++ b/agent_eval/agent/base.py
@@ -33,6 +33,7 @@ class EvalRunner(ABC):
     """Abstract runner -- one implementation per agent platform."""
 
     @classmethod
+    @abstractmethod
     def from_config(cls, config, *, log_prefix=None, **overrides):
         """Construct a runner from an EvalConfig.
 
@@ -44,8 +45,6 @@ class EvalRunner(ABC):
             log_prefix: Progress logging prefix (e.g. "eval", "eval:case-01").
             **overrides: Runner-specific overrides from CLI flags.
         """
-        raise NotImplementedError(
-            f"{cls.__name__} must implement from_config()")
 
     @property
     @abstractmethod

--- a/agent_eval/agent/base.py
+++ b/agent_eval/agent/base.py
@@ -32,6 +32,21 @@ class RunResult:
 class EvalRunner(ABC):
     """Abstract runner -- one implementation per agent platform."""
 
+    @classmethod
+    def from_config(cls, config, *, log_prefix=None, **overrides):
+        """Construct a runner from an EvalConfig.
+
+        Each runner subclass extracts the config fields it needs.
+        Overrides (e.g. resolved models, experiments) take precedence.
+
+        Args:
+            config: EvalConfig instance.
+            log_prefix: Progress logging prefix (e.g. "eval", "eval:case-01").
+            **overrides: Runner-specific overrides from CLI flags.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__} must implement from_config()")
+
     @property
     @abstractmethod
     def name(self) -> str:

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -50,7 +50,7 @@ class ClaudeCodeRunner(EvalRunner):
             subagent_model=overrides.get("subagent_model"),
             mlflow_experiment=overrides.get("mlflow_experiment"),
             mlflow_tracking_uri=overrides.get("mlflow_tracking_uri"),
-            effort=overrides.get("effort"),
+            effort=overrides.get("effort", config.runner.effort),
             log_prefix=log_prefix,
         )
 

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -37,6 +37,23 @@ class ClaudeCodeRunner(EvalRunner):
 
     _VALID_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
 
+    @classmethod
+    def from_config(cls, config, *, log_prefix=None, **overrides):
+        plugin_dirs = config.runner.plugin_dirs or []
+        resolved_plugin_dirs = [
+            str(Path(d).resolve()) for d in plugin_dirs]
+        return cls(
+            permissions=config.permissions,
+            plugin_dirs=resolved_plugin_dirs,
+            env_strip=config.runner.env_strip,
+            system_prompt=config.runner.system_prompt,
+            subagent_model=overrides.get("subagent_model"),
+            mlflow_experiment=overrides.get("mlflow_experiment"),
+            mlflow_tracking_uri=overrides.get("mlflow_tracking_uri"),
+            effort=overrides.get("effort"),
+            log_prefix=log_prefix,
+        )
+
     def __init__(
         self,
         permissions: Optional[dict] = None,

--- a/agent_eval/agent/cli_runner.py
+++ b/agent_eval/agent/cli_runner.py
@@ -4,8 +4,8 @@ import json
 import os
 import re
 import shlex
-import signal
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -138,20 +138,25 @@ class CliRunner(EvalRunner):
         start = time.monotonic()
 
         try:
-            proc = subprocess.Popen(
-                cmd,
+            popen_kwargs = dict(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
                 cwd=str(workspace),
                 env=env,
-                start_new_session=True,
             )
+            if sys.platform != "win32":
+                popen_kwargs["start_new_session"] = True
+            proc = subprocess.Popen(cmd, **popen_kwargs)
             try:
                 stdout, stderr = proc.communicate(timeout=timeout_s)
             except subprocess.TimeoutExpired:
                 # Kill the entire process group so child processes don't linger
-                os.killpg(proc.pid, signal.SIGKILL)
+                if sys.platform != "win32":
+                    import signal
+                    os.killpg(proc.pid, signal.SIGKILL)
+                else:
+                    proc.kill()
                 try:
                     stdout, stderr = proc.communicate(timeout=5)
                 except subprocess.TimeoutExpired:
@@ -257,5 +262,8 @@ class CliRunner(EvalRunner):
             if not isinstance(data, dict):
                 return {}
             return data
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError) as exc:
+            with _print_lock:
+                print(f"  WARNING: failed to parse {metrics_path}: {exc}",
+                      flush=True)
             return {}

--- a/agent_eval/agent/cli_runner.py
+++ b/agent_eval/agent/cli_runner.py
@@ -43,9 +43,10 @@ class CliRunner(EvalRunner):
         return cls(
             command=config.runner.command,
             env=config.execution.env,
+            env_strip=config.runner.env_strip,
             log_prefix=log_prefix,
             subagent_model=overrides.get("subagent_model"),
-            effort=overrides.get("effort"),
+            effort=overrides.get("effort", config.runner.effort),
             system_prompt=config.runner.system_prompt,
         )
 
@@ -53,6 +54,7 @@ class CliRunner(EvalRunner):
         self,
         command: Union[str, list],
         env: Optional[dict] = None,
+        env_strip: Optional[list] = None,
         log_prefix: Optional[str] = None,
         subagent_model: Optional[str] = None,
         effort: Optional[str] = None,
@@ -68,6 +70,7 @@ class CliRunner(EvalRunner):
                 f"runner.command must be a string or list, got {type(command).__name__}")
         self._command = command
         self._extra_env = env or {}
+        self._env_strip = env_strip or []
         self._log_prefix = log_prefix
         self._subagent_model = subagent_model or ""
         self._effort = effort or ""
@@ -115,15 +118,19 @@ class CliRunner(EvalRunner):
                     for k, v in input_data.items():
                         if k not in placeholders:
                             placeholders[k] = str(v) if v is not None else ""
-            except Exception as exc:
+            except (yaml.YAMLError, OSError, ValueError) as exc:
                 with _print_lock:
                     print(f"  WARNING: failed to parse {input_path}: {exc}",
                           flush=True)
 
         cmd = self._resolve_command(placeholders)
 
+        # Always use list form to avoid shell=True (CWE-78)
+        if isinstance(cmd, str):
+            cmd = shlex.split(cmd)
+
         if self._log_prefix:
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+            cmd_str = " ".join(cmd)
             with _print_lock:
                 print(f"  {self._log_prefix} | Running: {cmd_str[:120]}", flush=True)
 
@@ -138,7 +145,6 @@ class CliRunner(EvalRunner):
                 text=True,
                 cwd=str(workspace),
                 env=env,
-                shell=isinstance(cmd, str),
                 start_new_session=True,
             )
             try:
@@ -146,10 +152,11 @@ class CliRunner(EvalRunner):
             except subprocess.TimeoutExpired:
                 # Kill the entire process group so child processes don't linger
                 os.killpg(proc.pid, signal.SIGKILL)
-                stdout, stderr = proc.communicate()
+                try:
+                    stdout, stderr = proc.communicate(timeout=5)
+                except subprocess.TimeoutExpired:
+                    stdout, stderr = "", "Process group termination hung"
                 duration = time.monotonic() - start
-                if isinstance(stdout, bytes):
-                    stdout = stdout.decode(errors="replace")
                 return RunResult(
                     exit_code=-1,
                     stdout=stdout or "",
@@ -157,7 +164,7 @@ class CliRunner(EvalRunner):
                     duration_s=duration,
                 )
             duration = time.monotonic() - start
-        except Exception as e:
+        except (OSError, subprocess.SubprocessError) as e:
             duration = time.monotonic() - start
             return RunResult(
                 exit_code=-1,
@@ -191,14 +198,17 @@ class CliRunner(EvalRunner):
 
     def _resolve_command(self, placeholders: dict):
         """Resolve placeholders in the command template."""
-        is_shell = isinstance(self._command, str)
+        # String commands are shlex.split() after resolution, so quote
+        # placeholder values to preserve tokens with spaces/special chars.
+        # List commands don't need quoting — each element is already a token.
+        needs_quoting = isinstance(self._command, str)
 
         def _sub(template: str) -> str:
             def _replace(m):
                 key = m.group(1)
                 if key in placeholders:
                     value = placeholders[key]
-                    return shlex.quote(value) if is_shell else value
+                    return shlex.quote(value) if needs_quoting else value
                 return m.group(0)  # leave unresolved placeholders as-is
             return re.sub(r'\{([\w-]+)\}', _replace, template)
 
@@ -207,8 +217,10 @@ class CliRunner(EvalRunner):
         return _sub(self._command)
 
     def _build_env(self) -> dict:
-        """Build subprocess environment: inherit full env + extra vars."""
+        """Build subprocess environment: inherit env, apply strip list, add extras."""
         env = os.environ.copy()
+        for key in self._env_strip:
+            env.pop(key, None)
         for k, v in self._extra_env.items():
             if isinstance(v, str) and v.startswith("$"):
                 resolved = os.environ.get(v[1:])

--- a/agent_eval/agent/cli_runner.py
+++ b/agent_eval/agent/cli_runner.py
@@ -1,0 +1,249 @@
+"""Opaque CLI runner — delegates execution to an arbitrary command."""
+
+import json
+import os
+import re
+import shlex
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Optional, Union
+
+import yaml
+
+from .base import EvalRunner, RunResult
+
+_print_lock = threading.Lock()
+
+
+class CliRunner(EvalRunner):
+    """Runs skills by executing a user-provided command template.
+
+    The command template can use placeholders that are resolved at runtime:
+    - {agent}          — skill name or agent definition path
+    - {workspace}      — workspace directory path (absolute)
+    - {output_dir}     — output directory for artifacts (absolute, {workspace}/output)
+    - {model}          — model identifier (from --model or models.skill)
+    - {subagent_model} — subagent model (from models.subagent; empty if unset)
+    - {timeout}        — timeout in seconds
+    - {max_budget_usd} — budget cap (advisory — not enforced by harness)
+    - {effort}         — reasoning effort level (from runner.effort; empty if unset)
+    - {system_prompt}  — system prompt text (from runner.system_prompt; empty if unset)
+    - {args}           — resolved skill arguments string
+    - {field}          — any field from the case's input.yaml
+
+    The command can be a string (shell-parsed) or a list of arguments.
+    See docs/opaque-cli-runner-contract.md for the full contract.
+    """
+
+    @classmethod
+    def from_config(cls, config, *, log_prefix=None, **overrides):
+        return cls(
+            command=config.runner.command,
+            env=config.execution.env,
+            log_prefix=log_prefix,
+            subagent_model=overrides.get("subagent_model"),
+            effort=overrides.get("effort"),
+            system_prompt=config.runner.system_prompt,
+        )
+
+    def __init__(
+        self,
+        command: Union[str, list],
+        env: Optional[dict] = None,
+        log_prefix: Optional[str] = None,
+        subagent_model: Optional[str] = None,
+        effort: Optional[str] = None,
+        system_prompt: Optional[str] = None,
+        **_kwargs,
+    ):
+        if not command:
+            raise ValueError(
+                "CLI runner requires a 'command' in the runner config. "
+                "Example: runner:\n  type: cli\n  command: \"my-runner run {agent}\"")
+        if not isinstance(command, (str, list)):
+            raise TypeError(
+                f"runner.command must be a string or list, got {type(command).__name__}")
+        self._command = command
+        self._extra_env = env or {}
+        self._log_prefix = log_prefix
+        self._subagent_model = subagent_model or ""
+        self._effort = effort or ""
+        self._system_prompt = system_prompt or ""
+
+    @property
+    def name(self) -> str:
+        return "cli"
+
+    def run_skill(
+        self,
+        skill_name: str,
+        args: str,
+        workspace: Path,
+        model: str,
+        settings_path: Optional[Path] = None,
+        system_prompt: Optional[str] = None,
+        max_budget_usd: float = 5.0,
+        timeout_s: int = 600,
+    ) -> RunResult:
+        workspace = workspace.resolve()
+        output_dir = workspace / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Build placeholder values (all paths absolute to avoid cwd issues)
+        placeholders = {
+            "agent": skill_name or "",
+            "workspace": str(workspace),
+            "output_dir": str(output_dir),
+            "model": model or "",
+            "timeout": str(timeout_s),
+            "max_budget_usd": str(max_budget_usd),
+            "args": args or "",
+            "subagent_model": self._subagent_model,
+            "effort": self._effort,
+            "system_prompt": system_prompt or self._system_prompt,
+        }
+
+        # Load input.yaml fields if present
+        input_path = workspace / "input.yaml"
+        if input_path.exists():
+            try:
+                input_data = yaml.safe_load(input_path.read_text()) or {}
+                if isinstance(input_data, dict):
+                    for k, v in input_data.items():
+                        if k not in placeholders:
+                            placeholders[k] = str(v) if v is not None else ""
+            except Exception as exc:
+                with _print_lock:
+                    print(f"  WARNING: failed to parse {input_path}: {exc}",
+                          flush=True)
+
+        cmd = self._resolve_command(placeholders)
+
+        if self._log_prefix:
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+            with _print_lock:
+                print(f"  {self._log_prefix} | Running: {cmd_str[:120]}", flush=True)
+
+        env = self._build_env()
+        start = time.monotonic()
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=str(workspace),
+                env=env,
+                shell=isinstance(cmd, str),
+                start_new_session=True,
+            )
+            try:
+                stdout, stderr = proc.communicate(timeout=timeout_s)
+            except subprocess.TimeoutExpired:
+                # Kill the entire process group so child processes don't linger
+                os.killpg(proc.pid, signal.SIGKILL)
+                stdout, stderr = proc.communicate()
+                duration = time.monotonic() - start
+                if isinstance(stdout, bytes):
+                    stdout = stdout.decode(errors="replace")
+                return RunResult(
+                    exit_code=-1,
+                    stdout=stdout or "",
+                    stderr=f"Timed out after {timeout_s}s",
+                    duration_s=duration,
+                )
+            duration = time.monotonic() - start
+        except Exception as e:
+            duration = time.monotonic() - start
+            return RunResult(
+                exit_code=-1,
+                stdout="",
+                stderr=str(e),
+                duration_s=duration,
+            )
+
+        if self._log_prefix:
+            status = "OK" if proc.returncode == 0 else f"FAIL (exit {proc.returncode})"
+
+            with _print_lock:
+                print(f"  {self._log_prefix} | {status} ({duration:.0f}s)", flush=True)
+
+        # Parse optional metrics.json for token/cost data
+        metrics = self._parse_metrics(output_dir)
+
+        return RunResult(
+            exit_code=proc.returncode,
+            stdout=stdout,
+            stderr=stderr,
+            duration_s=duration,
+            token_usage=metrics.get("token_usage"),
+            cost_usd=metrics.get("cost_usd"),
+            num_turns=metrics.get("num_turns"),
+            resolved_model=metrics.get("model"),
+            models_used=metrics.get("models_used"),
+            per_model_usage=metrics.get("per_model_usage"),
+            per_model_turns=metrics.get("per_model_turns"),
+        )
+
+    def _resolve_command(self, placeholders: dict):
+        """Resolve placeholders in the command template."""
+        is_shell = isinstance(self._command, str)
+
+        def _sub(template: str) -> str:
+            def _replace(m):
+                key = m.group(1)
+                if key in placeholders:
+                    value = placeholders[key]
+                    return shlex.quote(value) if is_shell else value
+                return m.group(0)  # leave unresolved placeholders as-is
+            return re.sub(r'\{([\w-]+)\}', _replace, template)
+
+        if isinstance(self._command, list):
+            return [_sub(part) for part in self._command]
+        return _sub(self._command)
+
+    def _build_env(self) -> dict:
+        """Build subprocess environment: inherit full env + extra vars."""
+        env = os.environ.copy()
+        for k, v in self._extra_env.items():
+            if isinstance(v, str) and v.startswith("$"):
+                resolved = os.environ.get(v[1:])
+                if resolved is not None:
+                    env[k] = resolved
+            else:
+                env[k] = str(v)
+        return env
+
+    @staticmethod
+    def _parse_metrics(output_dir: Path) -> dict:
+        """Parse optional metrics.json from the output directory.
+
+        Expected format:
+        {
+            "token_usage": {"input": N, "output": N},
+            "cost_usd": 0.05,
+            "num_turns": 3,
+            "model": "gpt-4",
+            "models_used": ["gpt-4", "gpt-3.5-turbo"],
+            "per_model_usage": {"gpt-4": {"input": N, "output": N, "cost_usd": 0.04}},
+            "per_model_turns": {"gpt-4": 2, "gpt-3.5-turbo": 1}
+        }
+
+        All fields are optional. Returns empty dict if file doesn't exist
+        or can't be parsed.
+        """
+        metrics_path = output_dir / "metrics.json"
+        if not metrics_path.exists():
+            return {}
+        try:
+            with open(metrics_path) as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                return {}
+            return data
+        except (json.JSONDecodeError, OSError):
+            return {}

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 import yaml
 
@@ -120,7 +120,7 @@ class RunnerConfig:
     that don't read them.
     """
     type: str = "claude-code"
-    command: object = None  # CLI runner: command template (str or list)
+    command: Optional[Union[str, list]] = None  # CLI runner: command template
     settings: dict = field(default_factory=dict)
     plugin_dirs: list = field(default_factory=list)
     env_strip: list = field(default_factory=list)
@@ -265,9 +265,16 @@ class EvalConfig:
 
         # Runner config (block form)
         runner_raw = raw.get("runner") or {}
+        command = runner_raw.get("command")
+        if command is not None:
+            valid_list = isinstance(command, list) and all(
+                isinstance(x, str) for x in command)
+            if not (isinstance(command, str) or valid_list):
+                raise ValueError(
+                    "runner.command must be a string or list of strings")
         runner = RunnerConfig(
             type=runner_raw.get("type", "claude-code"),
-            command=runner_raw.get("command"),
+            command=command,
             settings=runner_raw.get("settings", {}) or {},
             plugin_dirs=runner_raw.get("plugin_dirs", []) or [],
             env_strip=runner_raw.get("env_strip", []) or [],

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -120,6 +120,7 @@ class RunnerConfig:
     that don't read them.
     """
     type: str = "claude-code"
+    command: object = None  # CLI runner: command template (str or list)
     settings: dict = field(default_factory=dict)
     plugin_dirs: list = field(default_factory=list)
     env_strip: list = field(default_factory=list)
@@ -266,6 +267,7 @@ class EvalConfig:
         runner_raw = raw.get("runner") or {}
         runner = RunnerConfig(
             type=runner_raw.get("type", "claude-code"),
+            command=runner_raw.get("command"),
             settings=runner_raw.get("settings", {}) or {},
             plugin_dirs=runner_raw.get("plugin_dirs", []) or [],
             env_strip=runner_raw.get("env_strip", []) or [],

--- a/docs/opaque-cli-runner-contract.md
+++ b/docs/opaque-cli-runner-contract.md
@@ -127,9 +127,16 @@ Judges get an `outputs` dict with these keys (all populated from the above sourc
 
 | Behavior | Opaque CLI runner | Claude Code runner |
 |---|---|---|
-| Inherits caller's env | Full `os.environ` (command is user-provided and trusted) | Filtered to safe allowlist |
+| Inherits caller's env | Full `os.environ` (see security note below) | Filtered to safe allowlist |
 | `execution.env` vars | Injected via `_build_env()` with `$VAR` resolution | Injected into `.claude/settings.json` env block |
 | `runner.env_strip` | Strips named keys from subprocess env | Strips named keys from subprocess env |
+
+**Security note on environment inheritance:** The opaque CLI runner inherits the
+full caller environment because commands are provided by the eval author (not
+untrusted input). Use `runner.env_strip` to remove sensitive keys (e.g.,
+`ANTHROPIC_API_KEY`) when the external command doesn't need them. The Claude Code
+runner uses a strict allowlist because it executes arbitrary agent-generated tool
+calls.
 
 ## Features that don't work with the opaque CLI runner
 

--- a/docs/opaque-cli-runner-contract.md
+++ b/docs/opaque-cli-runner-contract.md
@@ -127,9 +127,9 @@ Judges get an `outputs` dict with these keys (all populated from the above sourc
 
 | Behavior | Opaque CLI runner | Claude Code runner |
 |---|---|---|
-| Inherits caller's env | Full `os.environ` | Filtered to safe allowlist |
+| Inherits caller's env | Full `os.environ` (command is user-provided and trusted) | Filtered to safe allowlist |
 | `execution.env` vars | Injected via `_build_env()` with `$VAR` resolution | Injected into `.claude/settings.json` env block |
-| `runner.env_strip` | Not applied (ignored) | Strips named keys from subprocess env |
+| `runner.env_strip` | Strips named keys from subprocess env | Strips named keys from subprocess env |
 
 ## Features that don't work with the opaque CLI runner
 

--- a/docs/opaque-cli-runner-contract.md
+++ b/docs/opaque-cli-runner-contract.md
@@ -1,0 +1,143 @@
+# Opaque CLI Runner Contract
+
+The opaque CLI runner (`runner.type: cli`) delegates execution to an arbitrary
+command. This document defines the contract between the harness and the external
+command so that downstream features (judges, scoring, reporting, regression
+detection, MLflow) work correctly.
+
+## Placeholders
+
+The command template receives these placeholders, resolved before execution:
+
+| Placeholder | Value | Source |
+|---|---|---|
+| `{agent}` | Skill name or agent definition path | `run_skill(skill_name=...)` |
+| `{workspace}` | Absolute path to the case workspace | Created by `workspace.py` |
+| `{output_dir}` | Absolute path to `{workspace}/output` | Created by the opaque CLI runner |
+| `{model}` | Model identifier (e.g. `sonnet`, `gpt-4`) | `--model` CLI flag or `models.skill` |
+| `{subagent_model}` | Subagent model identifier (empty if unset) | `models.subagent` or `--subagent-model` |
+| `{timeout}` | Timeout in seconds (string) | `execution.timeout` or harness default |
+| `{max_budget_usd}` | Budget cap (string) | `execution.max_budget_usd` or harness default |
+| `{effort}` | Reasoning effort level (empty if unset) | `runner.effort` or `--effort` |
+| `{system_prompt}` | System prompt text (empty if unset) | `runner.system_prompt` |
+| `{args}` | Resolved skill arguments | `execution.arguments` with `{field}` substitution |
+| `{field}` | Any field from `input.yaml` | Case-specific; does not override builtins above |
+
+## Contract: what the command MUST do
+
+| Requirement | Why | What breaks without it |
+|---|---|---|
+| Exit 0 on success, non-zero on failure | Exit code drives pass/fail status in scoring and reporting. `-1` means timeout. | Cases always show as FAIL; worst-exit-code aggregation inflates failure counts |
+| Write artifact files to `{output_dir}` or to the paths declared in `outputs[*].path` | `collect.py` scans these paths to gather artifacts for judges | Judges receive an empty `files` dict; all file-based checks fail |
+| Finish before `{timeout}` seconds | The harness kills the process at the deadline via `subprocess.run(timeout=...)` | Process is killed; result recorded as exit `-1` with "Timed out" stderr |
+
+## Contract: what the command SHOULD do
+
+| Recommendation | Why | What degrades without it |
+|---|---|---|
+| Use `{model}` for model selection | The harness resolves `--model` / `models.skill` into this placeholder; it's the user's chosen model for this eval | Command uses its own default; eval results don't reflect the model the user asked for |
+| Use `{subagent_model}` for subagents | Resolved from `models.subagent`; controls delegation model in multi-agent setups | Subagents use wrong model; cost/quality mismatch vs what user configured |
+| Honor `{max_budget_usd}` | The harness passes this as a hint but **cannot enforce it** for opaque CLI runners | Command may overspend; no server-side guardrail like Claude Code's `--max-budget-usd` |
+| Use `{effort}` for reasoning effort | Resolved from `runner.effort` / `--effort`; controls quality-vs-speed tradeoff | Command ignores effort setting; eval doesn't test the intended effort level |
+| Use `{system_prompt}` if applicable | Resolved from `runner.system_prompt`; provides behavioral context to the agent | Agent runs without the system prompt the eval was designed to test |
+| Write `{output_dir}/metrics.json` | Only way the harness gets token/cost data from an opaque CLI runner | `token_usage`, `cost_usd`, `num_turns` all report as `None`; cost tables empty in reports; no budget tracking |
+| Write output to stdout | `execute.py` captures stdout to `stdout.log`; judges can access it via `outputs["stdout"]` | Judges that inspect stdout (e.g. checking for specific output text) see empty string |
+| Write errors to stderr | Captured to `stderr.log`; shown in HTML report for failed cases | Failures lack diagnostic context in reports |
+| Run in `{workspace}` as cwd | The harness sets `cwd` to workspace, but the command can change it; input.yaml and symlinked resources are there | Command can't find input files or project resources |
+
+## metrics.json format
+
+Write to `{output_dir}/metrics.json`. All fields are optional:
+
+```json
+{
+  "token_usage": {"input": 1500, "output": 800},
+  "cost_usd": 0.03,
+  "num_turns": 4,
+  "model": "claude-sonnet-4-20250514",
+  "models_used": ["claude-sonnet-4-20250514", "claude-haiku-4-5-20251001"],
+  "per_model_usage": {
+    "claude-sonnet-4-20250514": {"input": 1200, "output": 600, "cost_usd": 0.025},
+    "claude-haiku-4-5-20251001": {"input": 300, "output": 200, "cost_usd": 0.005}
+  },
+  "per_model_turns": {
+    "claude-sonnet-4-20250514": 3,
+    "claude-haiku-4-5-20251001": 1
+  }
+}
+```
+
+| Field | Type | Used by |
+|---|---|---|
+| `token_usage` | `{input: int, output: int}` | Report token breakdown; MLflow metrics; cost-per-turn calculation |
+| `cost_usd` | `float` | Report cost column; MLflow run metric; regression cost comparison |
+| `num_turns` | `int` | Report turn count; cost-per-turn ratio |
+| `model` | `str` | Report model column; MLflow run parameter; `resolved_model` in RunResult |
+| `models_used` | `list[str]` | Subagent model detection in reports |
+| `per_model_usage` | `{model: {input, output, cost_usd}}` | Per-model cost breakdown in reports and MLflow |
+| `per_model_turns` | `{model: int}` | Per-model turn breakdown in reports |
+
+## What the harness provides in the workspace
+
+Before the command runs, the workspace contains:
+
+| Path | Description | Relevant to opaque CLI runner? |
+|---|---|---|
+| `input.yaml` | Case input data (fields available as `{field}` placeholders) | Yes — primary input |
+| `output/` | Pre-created output directory (`{output_dir}`) | Yes — write artifacts here |
+| Output dirs from `outputs[*].path` | Pre-created directories matching eval.yaml | Yes — alternative artifact locations |
+| `.claude/settings.json` | Permissions, hooks, env vars | No — Claude Code specific |
+| `.claude/hooks/tools.py` | Tool interception script | No — Claude Code specific |
+| `subagents/` | Subagent transcript capture dir | No — Claude Code specific |
+| Symlinks to `scripts/`, `skills/`, `CLAUDE.md`, `.context/` | Project resources | Maybe — depends on the external command |
+
+## What the harness reads after execution
+
+| Source | Collected by | Consumed by |
+|---|---|---|
+| Process stdout | `execute.py` → `stdout.log` | Judges (via `outputs["stdout"]`); tool call extraction; MLflow trace builder |
+| Process stderr | `execute.py` → `stderr.log` | Judges (via `outputs["stderr"]`); HTML report error display |
+| Process exit code | `execute.py` → `run_result.json` | Report pass/fail; worst-exit aggregation; MLflow metric |
+| Files in `outputs[*].path` dirs | `collect.py` → `cases/{id}/{path}/` | Judges (via `outputs["files"]`); convenience keys like `outputs["{dirname}_content"]` |
+| Files modified in-place in workspace | `collect.py` via `git diff` | Judges (via `outputs["modified_files"]`) |
+| `{output_dir}/metrics.json` | `cli_runner.py` → RunResult fields | Report metrics; MLflow logging; regression comparison |
+
+## What judges receive
+
+Judges get an `outputs` dict with these keys (all populated from the above sources):
+
+| Key | Type | Source |
+|---|---|---|
+| `files` | `{relative_path: content_str}` | Collected artifacts from output dirs |
+| `modified_files` | `{relative_path: content_str}` | In-place edits detected by git diff |
+| `{dirname}_content` | `str` | First file's content from each output dir (convenience) |
+| `{dirname}_file` | `str` | Absolute path to that file |
+| `stdout` | `str` | stdout.log (if `traces.stdout` enabled) |
+| `stderr` | `str` | stderr.log (if `traces.stderr` enabled) |
+| `exit_code` | `int` | From run_result.json (if `traces.metrics` enabled) |
+| `duration_s` | `float` | From run_result.json |
+| `token_usage` | `dict` | From run_result.json (originally from metrics.json) |
+| `cost_usd` | `float` | From run_result.json |
+| `num_turns` | `int` | From run_result.json |
+| `annotations` | `dict` | From dataset `annotations.yaml` (not runner-produced) |
+| `case_dir` | `str` | Absolute path to collected case output |
+| `input_path` | `str` | Path to input.yaml in case output dir |
+
+## Environment
+
+| Behavior | Opaque CLI runner | Claude Code runner |
+|---|---|---|
+| Inherits caller's env | Full `os.environ` | Filtered to safe allowlist |
+| `execution.env` vars | Injected via `_build_env()` with `$VAR` resolution | Injected into `.claude/settings.json` env block |
+| `runner.env_strip` | Not applied (ignored) | Strips named keys from subprocess env |
+
+## Features that don't work with the opaque CLI runner
+
+| Feature | Why |
+|---|---|
+| Budget enforcement | Harness can't throttle an opaque process; `{max_budget_usd}` is advisory |
+| Tool interception / AskUserQuestion answering | Requires Claude Code PreToolUse hooks |
+| Stream-json trace building | Requires Claude Code `--output-format stream-json` |
+| Subagent transcript capture | Requires Claude Code SubagentStop hook |
+| Permission denial detection | Requires Claude Code stream-json events |
+| Real-time progress logging | Requires stream-json event parsing |

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -106,21 +106,14 @@ def main():
     mlflow_experiment = args.mlflow_experiment or config.mlflow.experiment
     effort = args.effort or config.runner.effort
 
-    # Resolve plugin_dirs relative to project root (CWD) so they survive
-    # the workspace CWD change — keeps plugin names stable.
-    resolved_plugin_dirs = [str(Path(d).resolve()) for d in config.runner.plugin_dirs] if config.runner.plugin_dirs else []
-
-    runner_kwargs = dict(
-        permissions=config.permissions,
-        plugin_dirs=resolved_plugin_dirs,
-        env_strip=config.runner.env_strip,
-        system_prompt=config.runner.system_prompt,
+    runner = runner_cls.from_config(
+        config,
+        log_prefix="eval",
         subagent_model=subagent_model,
         mlflow_experiment=mlflow_experiment,
         mlflow_tracking_uri=config.mlflow.tracking_uri,
         effort=effort,
     )
-    runner = runner_cls(log_prefix="eval", **runner_kwargs)
 
     # Resolve timeout and budget: CLI override > config > defaults.
     # Use explicit None checks so that 0 is preserved (an operator who
@@ -134,8 +127,13 @@ def main():
                   else 100.0)
 
     # Compose system prompt: runner.system_prompt (if any) + harness prompt.
+    # Skip the harness safety prompt for the opaque CLI runner — it references
+    # tool interception hooks and permission controls that don't exist there.
     existing_prompt = (config.runner.system_prompt or "").strip()
-    system_prompt = "\n\n".join(p for p in [existing_prompt, _HARNESS_SYSTEM_PROMPT] if p)
+    if agent == "cli":
+        system_prompt = existing_prompt or None
+    else:
+        system_prompt = "\n\n".join(p for p in [existing_prompt, _HARNESS_SYSTEM_PROMPT] if p)
 
     # Capture user-facing eval parameters that defined this run, for the report.
     eval_params = _build_eval_params(args, config, skill_args, max_budget, timeout_s, effort)
@@ -144,12 +142,14 @@ def main():
     if config.execution.mode == "case":
         parallelism = (args.parallelism if args.parallelism is not None
                        else config.execution.parallelism)
-        _execute_per_case(args, config, runner, runner_cls, runner_kwargs,
+        _execute_per_case(args, config, runner, runner_cls,
                           output_dir, max_budget, timeout_s,
                           model, mlflow_experiment, system_prompt,
                           skill_args_template=skill_args,
                           eval_params=eval_params,
-                          parallelism=parallelism)
+                          parallelism=parallelism,
+                          effort=effort,
+                          subagent_model=subagent_model)
         return
 
     # ── Batch execution (below) ──────────────────────────────────
@@ -211,7 +211,7 @@ def _resolve_arguments(template, case_data):
             return ""
         return str(value).strip()
 
-    result = re.sub(r'\{(\w+\??)\}', _replace, template).strip()
+    result = re.sub(r'\{([\w-]+\??)\}', _replace, template).strip()
     if missing:
         raise ValueError(
             f"Missing required fields in input.yaml: {', '.join(missing)}. "
@@ -327,11 +327,11 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
     return case_id, case_result
 
 
-def _execute_per_case(args, config, runner, runner_cls, runner_kwargs,
+def _execute_per_case(args, config, runner, runner_cls,
                       output_dir, max_budget, timeout_s,
                       model, mlflow_experiment, system_prompt="",
                       skill_args_template=None, eval_params=None,
-                      parallelism=None):
+                      parallelism=None, effort=None, subagent_model=None):
     """Execute the skill once per case with case-specific arguments."""
     import yaml as _yaml
 
@@ -364,8 +364,14 @@ def _execute_per_case(args, config, runner, runner_cls, runner_kwargs,
             for i, entry in enumerate(case_order, 1):
                 case_id = entry["case_id"] if isinstance(entry, dict) else entry
                 case_ws = workspace / "cases" / case_id
-                case_runner = runner_cls(
-                    log_prefix=f"eval:{case_id}", **runner_kwargs)
+                case_runner = runner_cls.from_config(
+                    config,
+                    log_prefix=f"eval:{case_id}",
+                    subagent_model=subagent_model,
+                    mlflow_experiment=mlflow_experiment,
+                    mlflow_tracking_uri=config.mlflow.tracking_uri,
+                    effort=effort,
+                )
                 fut = pool.submit(
                     _run_single_case, case_runner, args.skill, case_id,
                     case_ws, output_dir, skill_args_template, model,

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -74,11 +74,11 @@ class TestCliRunnerInit:
         with pytest.raises(TypeError, match="must be a string or list"):
             CliRunner(command=42)
 
-    def test_ignores_extra_kwargs(self):
+    def test_ignores_extra_kwargs(self, tmp_path):
         runner = CliRunner(
             command="echo hello",
             permissions={"allow": ["*"]},
-            plugin_dirs=["/tmp"],
+            plugin_dirs=[str(tmp_path)],
             subagent_model="sonnet",
         )
         assert runner.name == "cli"
@@ -114,38 +114,38 @@ class TestPlaceholderResolution:
         })
         assert result == "sk /ws /ws/output m 600 5.0 --flag"
 
-    def test_subagent_model_and_effort_placeholders(self):
+    def test_subagent_model_and_effort_placeholders(self, tmp_path):
         runner = CliRunner(
             command="run --model {model} --subagent {subagent_model} --effort {effort}",
             subagent_model="haiku",
             effort="high",
         )
         result = runner.run_skill(
-            skill_name="test", args="", workspace=Path("/tmp"),
+            skill_name="test", args="", workspace=tmp_path,
             model="opus", timeout_s=10,
         )
         # Can't easily check the resolved command, but verify it ran
         # (the command will fail, but that's fine — we care about resolution)
         assert isinstance(result.exit_code, int)
 
-    def test_system_prompt_placeholder(self):
+    def test_system_prompt_placeholder(self, tmp_path):
         runner = CliRunner(
             command=["echo", "{system_prompt}"],
             system_prompt="Be careful",
         )
         result = runner.run_skill(
-            skill_name="test", args="", workspace=Path("/tmp"),
+            skill_name="test", args="", workspace=tmp_path,
             model="m", timeout_s=10,
         )
         assert "Be careful" in result.stdout
 
-    def test_run_skill_system_prompt_overrides_constructor(self):
+    def test_run_skill_system_prompt_overrides_constructor(self, tmp_path):
         runner = CliRunner(
             command=["echo", "{system_prompt}"],
             system_prompt="from constructor",
         )
         result = runner.run_skill(
-            skill_name="test", args="", workspace=Path("/tmp"),
+            skill_name="test", args="", workspace=tmp_path,
             model="m", timeout_s=10,
             system_prompt="from caller",
         )
@@ -170,7 +170,8 @@ class TestCliRunnerExecution:
         assert result.duration_s > 0
 
     def test_failing_command(self, tmp_path):
-        runner = CliRunner(command="exit 42", log_prefix="test")
+        runner = CliRunner(command=["python3", "-c", "import sys; sys.exit(42)"],
+                           log_prefix="test")
         result = runner.run_skill(
             skill_name="test",
             args="",
@@ -273,7 +274,7 @@ class TestCliRunnerExecution:
     def test_extra_env_vars(self, tmp_path, monkeypatch):
         monkeypatch.setenv("MY_SECRET", "s3cret")
         runner = CliRunner(
-            command="echo $MY_VAR $RESOLVED",
+            command=["python3", "-c", "import os; print(os.environ['MY_VAR'], os.environ['RESOLVED'])"],
             env={"MY_VAR": "hello", "RESOLVED": "$MY_SECRET"})
         result = runner.run_skill(
             skill_name="test", args="", workspace=tmp_path, model="m")

--- a/tests/test_cli_runner.py
+++ b/tests/test_cli_runner.py
@@ -1,0 +1,355 @@
+"""Tests for the opaque CLI runner."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.agent.cli_runner import CliRunner
+from agent_eval.config import EvalConfig
+
+
+class TestCliRunnerConfig:
+    """Config parsing for CLI runner."""
+
+    def _write(self, tmp_path, body):
+        p = tmp_path / "eval.yaml"
+        p.write_text(body)
+        return p
+
+    def test_command_string_parses(self, tmp_path):
+        cfg = EvalConfig.from_yaml(self._write(tmp_path, """
+name: t
+skill: s
+runner:
+  type: cli
+  command: "my-runner run {agent} --workspace {workspace}"
+"""))
+        assert cfg.runner.type == "cli"
+        assert cfg.runner.command == "my-runner run {agent} --workspace {workspace}"
+
+    def test_command_list_parses(self, tmp_path):
+        cfg = EvalConfig.from_yaml(self._write(tmp_path, """
+name: t
+skill: s
+runner:
+  type: cli
+  command:
+    - my-runner
+    - run
+    - "{agent}"
+    - "--workspace"
+    - "{workspace}"
+"""))
+        assert cfg.runner.type == "cli"
+        assert cfg.runner.command == [
+            "my-runner", "run", "{agent}", "--workspace", "{workspace}"]
+
+    def test_command_default_is_none(self, tmp_path):
+        cfg = EvalConfig.from_yaml(self._write(tmp_path, """
+name: t
+skill: s
+runner:
+  type: claude-code
+"""))
+        assert cfg.runner.command is None
+
+
+class TestCliRunnerInit:
+    """Constructor validation."""
+
+    def test_requires_command(self):
+        with pytest.raises(ValueError, match="requires a 'command'"):
+            CliRunner(command=None)
+
+    def test_requires_nonempty_command(self):
+        with pytest.raises(ValueError, match="requires a 'command'"):
+            CliRunner(command="")
+
+    def test_rejects_non_str_or_list_command(self):
+        with pytest.raises(TypeError, match="must be a string or list"):
+            CliRunner(command=42)
+
+    def test_ignores_extra_kwargs(self):
+        runner = CliRunner(
+            command="echo hello",
+            permissions={"allow": ["*"]},
+            plugin_dirs=["/tmp"],
+            subagent_model="sonnet",
+        )
+        assert runner.name == "cli"
+
+
+class TestPlaceholderResolution:
+    """Command template placeholder substitution."""
+
+    def test_string_command(self):
+        runner = CliRunner(command="run {agent} --model {model}")
+        result = runner._resolve_command({
+            "agent": "my-skill", "model": "opus"})
+        assert result == "run my-skill --model opus"
+
+    def test_list_command(self):
+        runner = CliRunner(command=["run", "{agent}", "--model", "{model}"])
+        result = runner._resolve_command({
+            "agent": "my-skill", "model": "opus"})
+        assert result == ["run", "my-skill", "--model", "opus"]
+
+    def test_unknown_placeholders_preserved(self):
+        runner = CliRunner(command="run {agent} {unknown}")
+        result = runner._resolve_command({"agent": "s"})
+        assert result == "run s {unknown}"
+
+    def test_all_builtin_placeholders(self):
+        runner = CliRunner(command="{agent} {workspace} {output_dir} {model} {timeout} {max_budget_usd} {args}")
+        result = runner._resolve_command({
+            "agent": "sk", "workspace": "/ws", "output_dir": "/ws/output",
+            "model": "m", "timeout": "600", "max_budget_usd": "5.0",
+            "args": "--flag", "subagent_model": "", "effort": "",
+            "system_prompt": "",
+        })
+        assert result == "sk /ws /ws/output m 600 5.0 --flag"
+
+    def test_subagent_model_and_effort_placeholders(self):
+        runner = CliRunner(
+            command="run --model {model} --subagent {subagent_model} --effort {effort}",
+            subagent_model="haiku",
+            effort="high",
+        )
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=Path("/tmp"),
+            model="opus", timeout_s=10,
+        )
+        # Can't easily check the resolved command, but verify it ran
+        # (the command will fail, but that's fine — we care about resolution)
+        assert isinstance(result.exit_code, int)
+
+    def test_system_prompt_placeholder(self):
+        runner = CliRunner(
+            command=["echo", "{system_prompt}"],
+            system_prompt="Be careful",
+        )
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=Path("/tmp"),
+            model="m", timeout_s=10,
+        )
+        assert "Be careful" in result.stdout
+
+    def test_run_skill_system_prompt_overrides_constructor(self):
+        runner = CliRunner(
+            command=["echo", "{system_prompt}"],
+            system_prompt="from constructor",
+        )
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=Path("/tmp"),
+            model="m", timeout_s=10,
+            system_prompt="from caller",
+        )
+        assert "from caller" in result.stdout
+        assert "from constructor" not in result.stdout
+
+
+class TestCliRunnerExecution:
+    """End-to-end execution tests using simple shell commands."""
+
+    def test_successful_command(self, tmp_path):
+        runner = CliRunner(command="echo hello")
+        result = runner.run_skill(
+            skill_name="test",
+            args="",
+            workspace=tmp_path,
+            model="test-model",
+        )
+        assert result.exit_code == 0
+        assert "hello" in result.stdout
+        assert isinstance(result.duration_s, float)
+        assert result.duration_s > 0
+
+    def test_failing_command(self, tmp_path):
+        runner = CliRunner(command="exit 42", log_prefix="test")
+        result = runner.run_skill(
+            skill_name="test",
+            args="",
+            workspace=tmp_path,
+            model="test-model",
+        )
+        assert result.exit_code == 42
+
+    def test_workspace_placeholders(self, tmp_path):
+        runner = CliRunner(command=["echo", "{workspace}", "{output_dir}"])
+        result = runner.run_skill(
+            skill_name="test",
+            args="",
+            workspace=tmp_path,
+            model="m",
+        )
+        assert str(tmp_path) in result.stdout
+        assert str(tmp_path / "output") in result.stdout
+
+    def test_model_placeholder(self, tmp_path):
+        runner = CliRunner(command=["echo", "{model}"])
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=tmp_path, model="opus")
+        assert "opus" in result.stdout
+
+    def test_agent_placeholder(self, tmp_path):
+        runner = CliRunner(command="echo {agent}")
+        result = runner.run_skill(
+            skill_name="my-skill", args="", workspace=tmp_path, model="m")
+        assert "my-skill" in result.stdout
+
+    def test_input_yaml_fields(self, tmp_path):
+        (tmp_path / "input.yaml").write_text(yaml.dump({
+            "ticket": "PROJ-123",
+            "priority": "high",
+        }))
+        runner = CliRunner(command="echo {ticket} {priority}")
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=tmp_path, model="m")
+        assert "PROJ-123" in result.stdout
+        assert "high" in result.stdout
+
+    def test_input_yaml_does_not_override_builtins(self, tmp_path):
+        (tmp_path / "input.yaml").write_text(yaml.dump({
+            "model": "should-not-override",
+        }))
+        runner = CliRunner(command="echo {model}")
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=tmp_path, model="real-model")
+        assert "real-model" in result.stdout
+
+    def test_timeout(self, tmp_path):
+        runner = CliRunner(command="sleep 60")
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=tmp_path,
+            model="m", timeout_s=1)
+        assert result.exit_code == -1
+        assert "Timed out" in result.stderr
+
+    def test_output_dir_created(self, tmp_path):
+        runner = CliRunner(command="ls {output_dir}")
+        runner.run_skill(
+            skill_name="test", args="", workspace=tmp_path, model="m")
+        assert (tmp_path / "output").is_dir()
+
+    def test_metrics_json_parsed(self, tmp_path):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        (output_dir / "metrics.json").write_text(json.dumps({
+            "token_usage": {"input": 100, "output": 50},
+            "cost_usd": 0.03,
+            "num_turns": 5,
+            "model": "gpt-4",
+        }))
+        runner = CliRunner(command="echo done")
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=tmp_path, model="m")
+        assert result.exit_code == 0
+        assert result.token_usage == {"input": 100, "output": 50}
+        assert result.cost_usd == 0.03
+        assert result.num_turns == 5
+        assert result.resolved_model == "gpt-4"
+
+    def test_no_metrics_json(self, tmp_path):
+        runner = CliRunner(command="echo done")
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=tmp_path, model="m")
+        assert result.token_usage is None
+        assert result.cost_usd is None
+
+    def test_invalid_metrics_json(self, tmp_path):
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        (output_dir / "metrics.json").write_text("not json")
+        runner = CliRunner(command="echo done")
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=tmp_path, model="m")
+        assert result.token_usage is None
+
+    def test_extra_env_vars(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MY_SECRET", "s3cret")
+        runner = CliRunner(
+            command="echo $MY_VAR $RESOLVED",
+            env={"MY_VAR": "hello", "RESOLVED": "$MY_SECRET"})
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=tmp_path, model="m")
+        assert "hello" in result.stdout
+        assert "s3cret" in result.stdout
+
+    def test_list_command_no_shell(self, tmp_path):
+        """List-form commands should not use shell interpretation."""
+        runner = CliRunner(command=["echo", "hello world"])
+        result = runner.run_skill(
+            skill_name="test", args="", workspace=tmp_path, model="m")
+        assert "hello world" in result.stdout
+
+
+class TestFromConfig:
+    """Test the from_config class method."""
+
+    def _write(self, tmp_path, body):
+        p = tmp_path / "eval.yaml"
+        p.write_text(body)
+        return p
+
+    def test_from_config_string_command(self, tmp_path):
+        cfg = EvalConfig.from_yaml(self._write(tmp_path, """
+name: t
+skill: s
+runner:
+  type: cli
+  command: "my-runner run {agent}"
+execution:
+  env:
+    MY_VAR: hello
+"""))
+        runner = CliRunner.from_config(cfg, log_prefix="test")
+        assert runner.name == "cli"
+        assert runner._command == "my-runner run {agent}"
+        assert runner._extra_env == {"MY_VAR": "hello"}
+        assert runner._log_prefix == "test"
+
+    def test_from_config_list_command(self, tmp_path):
+        cfg = EvalConfig.from_yaml(self._write(tmp_path, """
+name: t
+skill: s
+runner:
+  type: cli
+  command:
+    - my-runner
+    - "{agent}"
+"""))
+        runner = CliRunner.from_config(cfg)
+        assert runner._command == ["my-runner", "{agent}"]
+
+    def test_from_config_ignores_extra_overrides(self, tmp_path):
+        cfg = EvalConfig.from_yaml(self._write(tmp_path, """
+name: t
+skill: s
+runner:
+  type: cli
+  command: "echo test"
+"""))
+        runner = CliRunner.from_config(
+            cfg, log_prefix="x",
+            subagent_model="sonnet",
+            mlflow_experiment="e",
+            effort="high",
+        )
+        assert runner.name == "cli"
+
+
+class TestCliRunnerInRegistry:
+    """Verify the runner is registered and discoverable."""
+
+    def test_registered(self):
+        from agent_eval.agent import RUNNERS
+        assert "cli" in RUNNERS
+
+    def test_is_eval_runner(self):
+        from agent_eval.agent.base import EvalRunner
+        assert issubclass(CliRunner, EvalRunner)


### PR DESCRIPTION
## Summary

- Adds a `cli` runner type that delegates skill execution to a user-provided command template with placeholder substitution, enabling the eval harness to drive non-Claude agents without custom code
- Introduces `from_config()` factory on `EvalRunner` ABC, implemented for both `ClaudeCodeRunner` and `CliRunner`, replacing inline kwargs in `execute.py`
- Includes shell injection protection (`shlex.quote()` on string-form commands), process group cleanup on timeout (`start_new_session=True` + `os.killpg()`), and hyphenated placeholder key support

Closes #59

## Test plan

- [x] 33 unit tests in `tests/test_cli_runner.py` — all passing
- [x] 8 config tests in `tests/test_config.py` — all passing
- [ ] Manual smoke test with a real CLI agent command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "cli" runner type that executes configurable command templates with placeholder substitution (agent, workspace, output dir, model, timeout, effort, system prompt, args), per-case configuration overrides, timeout enforcement, and parsing of output metrics.

* **Configuration**
  * Runner config now accepts a command template (string or list) and per-case/override construction for runners.

* **Documentation**
  * README updated with runner.type/cli examples and a detailed CLI runner contract doc.

* **Tests**
  * Added end-to-end and unit tests covering config parsing, placeholder resolution, execution, timeouts, and metrics handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->