### PR TITLE
Brainstorm: trajectory standardization + reusable judge library

### DIFF
--- a/brainstorm/00-overview.md
+++ b/brainstorm/00-overview.md
@@ -1,22 +1,23 @@
 # Brainstorm Overview
 
-Last updated: 2026-05-06
+Last updated: 2026-05-13
 
 ## Sessions
 
 | # | Date | Topic | Status | Spec |
 |---|------|-------|--------|------|
 | - | 2026-05-05 | stdout-template-variable | spec-created | 001 |
-| 01 | 2026-05-06 | structured-events | active | 002 |
+| 01 | 2026-05-06 | structured-events | merged | 002 |
 | 02 | 2026-05-06 | event-powered-judges | active | - |
+| 03 | 2026-05-13 | trajectory-standardization | active | - |
 
 ## Open Threads
-- Exact event schema (field names, nesting, type discriminators) (from #01)
-- Whether `extract_usage()` should adopt the shared parser (from #01)
-- Migration path for existing check judges parsing `outputs["stdout"]` (from #01)
 - Should framework ship built-in judge templates for common patterns? (from #02)
 - How should regression fingerprinting integrate with thresholds? (from #02)
 - Should process metrics be auto-computed from events? (from #02)
+- Reusable judge library: packaging, presets, versioning (from #02)
+- Trajectory format alignment with ATIF when adding a second runner (from #03)
+- OpenCode trace format investigation needed (from #03)
 
 ## Parked Ideas
 

--- a/brainstorm/02-event-powered-judges.md
+++ b/brainstorm/02-event-powered-judges.md
@@ -126,8 +126,84 @@ No decision needed yet. These are future judge patterns that become possible onc
 - Cost/efficiency judges may need access to `outputs["cost_usd"]` alongside events
 - Regression fingerprinting may require a new judge type or extension to the pairwise comparison system
 
+## E: Reusable Judge Library
+
+**Origin:** @astefanutti's feedback on PR #58: "I also wonder how we could start bundling those reusable / generic judges."
+
+The four judge patterns above (A-D) are deliberately skill-agnostic. A "no destructive commands" safety judge works for any skill, not just one. This raises the question of how to package and distribute them.
+
+### Packaging Options
+
+**Option 1: Built-in judge templates in eval.yaml**
+
+Ship judges as named presets that eval.yaml can reference:
+
+```yaml
+judges:
+  - name: safety-no-destructive-commands
+    type: builtin
+  - name: process-read-before-write
+    type: builtin
+  - name: my-custom-judge
+    type: check
+    script: judges/custom.py
+```
+
+The harness resolves `type: builtin` to bundled Python scripts. Simple to use, but couples the judge library to the harness release cycle.
+
+**Option 2: Judge pack directory**
+
+Ship a `judges/` directory in the harness with categorized judge scripts:
+
+```
+agent_eval/judges/
+  safety/
+    no_destructive_commands.py
+    no_path_traversal.py
+  process/
+    read_before_write.py
+    edit_thrashing.py
+  efficiency/
+    error_rate.py
+    cost_per_action.py
+```
+
+eval.yaml references them by path or module name. Judges are just Python files, easy to inspect, copy, and modify. Projects can vendor individual judges into their own eval directory.
+
+**Option 3: Judge presets (curated bundles)**
+
+Group judges into opinionated preset collections:
+
+```yaml
+judges:
+  - preset: safety-baseline    # no destructive commands, no path traversal, no secrets
+  - preset: process-quality    # read-before-write, no edit thrashing, tool selection
+  - name: my-skill-judge       # skill-specific judge alongside presets
+    type: prompt
+    prompt_file: judges/quality.md
+```
+
+Presets expand to multiple judges at config load time. Higher-level than individual judge files, but less flexible.
+
+### Recommended Approach
+
+**Option 2 (judge pack directory)** as the foundation, with **Option 1 (builtin references)** as syntactic sugar on top.
+
+The directory gives transparency and vendoring. The `type: builtin` shorthand makes common judges easy to add without knowing the file path. Presets (Option 3) can layer on later once we have enough judges to form meaningful bundles.
+
+### Discovery and Documentation
+
+Each judge file should include a docstring describing what it checks, what event fields it requires, and what a failure means. A `judges/README.md` or auto-generated index would list available judges with one-line descriptions, so skill authors can browse what's available.
+
+### Composability with Skill-Specific Judges
+
+The library judges should compose cleanly with skill-specific judges in eval.yaml. Ordering matters for reporting but not execution (judges run independently). The report should group library judges separately from skill-specific ones so it's clear which failures are generic guardrails vs. skill quality issues.
+
 ## Open Questions
 
 - Should the framework ship with built-in judge templates for common patterns (e.g., "no destructive commands" as a default safety judge)?
 - How should regression fingerprinting integrate with the existing `thresholds` system?
 - Should process quality metrics (tool call count, error rate) be auto-computed from events and exposed as `record["process_metrics"]`?
+- What's the minimum viable set of judges for a "safety-baseline" preset?
+- Should library judges have their own thresholds defaults, or always require explicit threshold config?
+- How do library judges version? Can a harness upgrade change judge behavior and break existing eval baselines?

--- a/brainstorm/03-trajectory-standardization.md
+++ b/brainstorm/03-trajectory-standardization.md
@@ -1,0 +1,90 @@
+# Brainstorm: Trajectory Format Standardization
+
+**Date:** 2026-05-13
+**Status:** active
+**Origin:** @astefanutti's feedback on PR #58, pointing to the [Harbor ATIF RFC](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md)
+
+## Problem Framing
+
+Our `events.json` format (from brainstorm #01) is currently Claude Code-specific: flat event list, type-discriminated, subagent events tagged with `parent_tool_use_id` and `agent_id`. As we add runners beyond Claude Code (OpenCode, Agent SDK, others), each runner will produce its own raw event stream. We need a strategy for whether our internal event format stays custom or aligns with an emerging standard.
+
+The Harbor framework has published ATIF (Agent Trajectory Interchange Format), a JSON spec for logging agent interactions across runtimes. It targets MiniSweAgent, OpenHands, Gemini CLI, and others. This is the most concrete attempt at a cross-runtime trajectory standard we've seen so far.
+
+## Current State
+
+Our `events.json` uses a **flat event list** with type discriminators:
+
+```json
+[
+  {"type": "assistant", "message": "...", "tools": [...]},
+  {"type": "tool_result", "tool_use_id": "...", "content": "..."},
+  {"type": "assistant", "message": "...", "tools": [...], "parent_tool_use_id": "..."}
+]
+```
+
+ATIF uses a **bundled step model** where each LLM turn groups message + tool calls + observations into a single step, with subagent trajectories as separately embedded objects.
+
+## Key Differences
+
+| Aspect | Our format | ATIF |
+|--------|-----------|------|
+| Granularity | One event per message/result | One step per LLM turn (bundles everything) |
+| Subagents | Flat list, tagged with parent pointers | Separate embedded trajectory objects |
+| Ordering | Array position | Explicit `step_id` ordinals |
+| Tool results | Separate `tool_result` events | Nested in `observation.results` within same step |
+| Metrics | Separate from events | Per-step `metrics` object |
+
+## Approaches Considered
+
+### A: Adopt ATIF as Internal Format
+
+Replace `events.json` with ATIF-shaped output. All runners produce ATIF, all judges consume ATIF.
+
+- Pros: Immediate interoperability, can ingest trajectories from other harnesses, community alignment
+- Cons: ATIF's bundled-step model is a worse fit for our judges (they iterate events sequentially, checking tool order and patterns). The step grouping adds complexity for process quality judges that care about individual actions. ATIF is also early-stage with no stable release yet.
+
+### B: ATIF as Export Format
+
+Keep our flat event list internally, add an ATIF export adapter. Judges work on our format; external tools can consume the ATIF export.
+
+- Pros: Best of both worlds. Judges keep the simple flat iteration they're designed for. Interoperability through export.
+- Cons: Maintaining two formats. Export fidelity might drift.
+
+### C: Convergence Layer per Runner
+
+Each runner has its own raw format. A per-runner normalizer converts to our internal format. If ATIF matures, we add an ATIF normalizer alongside Claude Code's.
+
+- Pros: Runner-agnostic without committing to ATIF prematurely. New runners just need a normalizer.
+- Cons: Still a custom internal format. Doesn't help with importing trajectories from other harnesses.
+
+### D: Wait and Watch
+
+ATIF is an RFC, not a standard. Monitor adoption before investing. Keep our format, revisit when adding a second runner.
+
+- Pros: No wasted effort if ATIF doesn't gain traction
+- Cons: Risk of building more judges against a format we'll later need to change
+
+## Preliminary Thinking
+
+**Approach C with B as a follow-up** seems pragmatic:
+
+1. Define a clean normalizer interface for when we add a second runner (OpenCode is the likely candidate)
+2. Keep our flat event format as the internal contract for judges
+3. Add ATIF export when there's a concrete consumer (e.g., sharing trajectories with another team's harness)
+
+The flat event list is genuinely better for our judge patterns. Process quality judges check tool ordering, cost judges count errors in sequence, safety judges scan individual commands. All of these are simpler with flat iteration than with ATIF's nested step structure. We shouldn't compromise judge ergonomics for format alignment.
+
+That said, exploring OpenCode's trajectory format early would inform whether our normalizer interface is general enough. Antonin's suggestion to "review the options" is the right first move.
+
+## Open Questions
+
+- What format does OpenCode use for its execution traces?
+- Has anyone else adopted ATIF yet, or is it still Harbor-only?
+- Do we need trajectory import (ingesting runs from other harnesses), or is export enough?
+- Should the normalizer interface live in `agent_eval/events.py` or as a per-runner concern?
+
+## Next Steps
+
+- Investigate OpenCode's trace format as a concrete second data point
+- Check ATIF adoption status (GitHub stars, issues, other implementors)
+- Define the normalizer interface shape when starting on a second runner


### PR DESCRIPTION
## Summary

Two follow-up brainstorms from @astefanutti's feedback on PR #58:

- **New brainstorm 03 (trajectory standardization):** Investigates alignment with the [Harbor ATIF RFC](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) for cross-runtime trajectory interchange. Compares ATIF's bundled-step model against our flat event list, evaluates four approaches (adopt, export-only, normalizer-per-runner, wait). Recommends a normalizer layer when adding a second runner, with ATIF export as a follow-up.
- **Extended brainstorm 02 (reusable judge library):** Explores how to package and distribute the generic judge patterns (safety, process quality, efficiency) that structured events enable. Three packaging options evaluated: builtin references in eval.yaml, a judge pack directory, and curated presets. Recommends the directory approach with builtin shorthand.

## Artifacts

- `brainstorm/03-trajectory-standardization.md` (new)
- `brainstorm/02-event-powered-judges.md` (extended with section E)
- `brainstorm/00-overview.md` (updated index)

## Open questions for discussion

- Should we investigate OpenCode's trace format now, or wait until we have a concrete second-runner use case?
- What's the minimum viable set of judges for a "safety-baseline" preset?
- Should library judges ship their own default thresholds?

Assisted-By: 🤖 Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project planning documentation with revised session status and new discussion items
  * Added documentation outlining judge library packaging, distribution, and composition patterns
  * Added new planning document exploring trajectory format standardization approaches for multi-runner compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->