### PR TITLE
Add Responses API runner (#49)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ tmp/
 mlflow.db
 mlruns/
 
+.knowledge/
+docs/superpowers/
 # Environment and secrets
 .env
 .env.*

--- a/agent_eval/agent/__init__.py
+++ b/agent_eval/agent/__init__.py
@@ -3,10 +3,16 @@
 from .base import EvalRunner, RunResult
 from .claude_code import ClaudeCodeRunner
 from .cli_runner import CliRunner
+from .responses_api import ResponsesAPIRunner
 
 RUNNERS = {
     "claude-code": ClaudeCodeRunner,
     "cli": CliRunner,
+    "responses-api": ResponsesAPIRunner,
 }
 
-__all__ = ["EvalRunner", "RunResult", "ClaudeCodeRunner", "CliRunner", "RUNNERS"]
+__all__ = [
+    "EvalRunner", "RunResult",
+    "ClaudeCodeRunner", "CliRunner", "ResponsesAPIRunner",
+    "RUNNERS",
+]

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -65,6 +65,7 @@ class ClaudeCodeRunner(EvalRunner):
         mlflow_tracking_uri: Optional[str] = None,
         log_prefix: Optional[str] = None,
         effort: Optional[str] = None,
+        **kwargs,
     ):
         self._permissions = permissions or {}
         self._subagent_model = subagent_model

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -65,7 +65,6 @@ class ClaudeCodeRunner(EvalRunner):
         mlflow_tracking_uri: Optional[str] = None,
         log_prefix: Optional[str] = None,
         effort: Optional[str] = None,
-        **kwargs,
     ):
         self._permissions = permissions or {}
         self._subagent_model = subagent_model

--- a/agent_eval/agent/responses_api.py
+++ b/agent_eval/agent/responses_api.py
@@ -1,0 +1,299 @@
+"""Responses API runner — agentic skill execution via OpenAI Responses API.
+
+Uses the Skills API and Shell tool to execute eval harness skills in
+hosted containers. Provides apples-to-apples comparison with
+ClaudeCodeRunner: same skill, same test cases, different model/runtime.
+
+"""
+
+import os
+import time
+import threading
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from .base import EvalRunner, RunResult
+
+_print_lock = threading.Lock()
+_global_skill_cache: dict[str, str] = {}
+_global_skill_lock = threading.Lock()
+
+
+class ResponsesAPIRunner(EvalRunner):
+    """Runs skills via OpenAI Responses API with Shell tool + Skills API.
+
+    Lifecycle per case:
+      1. Upload skill directory → skill_id (cached across cases)
+      2. Create container
+      3. Upload workspace files to container
+      4. Execute via POST /v1/responses with shell tool
+      5. Download new/modified files from container
+      6. Delete container
+      7. Return RunResult
+
+    Note: ``settings_path`` and ``max_budget_usd`` are accepted for ABC
+    compatibility but not wired — the Responses API does not expose
+    equivalent knobs.
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        default_model: Optional[str] = None,
+        network_policy: Optional[dict] = None,
+        memory_limit_mb: int = 512,
+        log_prefix: Optional[str] = None,
+        **kwargs,
+    ):
+        self._base_url = base_url or os.environ.get("OPENAI_BASE_URL", "")
+        self._api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+        self._default_model = default_model or os.environ.get("OPENAI_MODEL", "")
+        self._network_policy = network_policy
+        self._memory_limit_mb = memory_limit_mb
+        self._log_prefix = log_prefix
+
+    @property
+    def name(self) -> str:
+        return "responses-api"
+
+    def _get_client(self):
+        """Lazy-init the OpenAI client."""
+        if not hasattr(self, "_client"):
+            try:
+                from openai import OpenAI
+            except ImportError:
+                raise ImportError(
+                    "openai package required for responses-api runner. "
+                    "Install with: pip install agent-eval-harness[openai]"
+                )
+            kwargs = {}
+            if self._base_url:
+                kwargs["base_url"] = self._base_url
+            if self._api_key:
+                kwargs["api_key"] = self._api_key
+            self._client = OpenAI(**kwargs)
+        return self._client
+
+    def _upload_skill(self, client, skill_dir: Path, skill_name: str) -> str:
+        """Upload a skill directory and return its skill_id.
+
+        The cache is process-global so parallel workers (each with their
+        own ``ResponsesAPIRunner`` instance) share a single upload.
+        The lock is held across the check-and-create to prevent redundant
+        uploads when multiple threads see a cache miss simultaneously.
+        """
+        with _global_skill_lock:
+            if skill_name in _global_skill_cache:
+                return _global_skill_cache[skill_name]
+            skill = client.skills.create(
+                name=skill_name,
+                source_dir=str(skill_dir),
+            )
+            _global_skill_cache[skill_name] = skill.id
+            return skill.id
+
+    def _create_container(self, client, skill_id: str) -> str:
+        """Create an isolated container for one eval case with skill attached."""
+        kwargs = {
+            "name": f"eval-{uuid.uuid4().hex[:12]}",
+            "memory_limit": f"{self._memory_limit_mb}m",
+            "skills": [{"type": "skill_reference", "skill_id": skill_id}],
+        }
+        if self._network_policy:
+            kwargs["network_policy"] = self._network_policy
+        container = client.containers.create(**kwargs)
+        return container.id
+
+    def _upload_workspace(self, client, container_id: str,
+                          workspace: Path) -> set[str]:
+        """Upload all workspace files to the container. Returns set of paths.
+
+        Symlinks are skipped to prevent reading outside the workspace
+        (CWE-59).
+        """
+        uploaded = set()
+        for f in workspace.rglob("*"):
+            if not f.is_file() or f.is_symlink():
+                continue
+            rel = f.relative_to(workspace)
+            container_path = f"/workspace/{rel}"
+            with open(f, "rb") as fh:
+                client.containers.files.create(
+                    container_id,
+                    file=fh,
+                    path=container_path,
+                )
+            uploaded.add(container_path)
+        return uploaded
+
+    def _download_results(self, client, container_id: str,
+                          workspace: Path) -> None:
+        """Download new and modified files from container back to workspace.
+
+        All files under ``/workspace/`` are synced back — both newly
+        created files *and* files that existed before execution (which
+        may have been edited in-place by the agent).
+        """
+        after_files = client.containers.files.list(container_id)
+        for f in after_files:
+            if not f.path.startswith("/workspace/"):
+                continue
+            rel = f.path[len("/workspace/"):]
+            local_path = workspace / rel
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            content = client.containers.files.content(container_id, f.id)
+            local_path.write_bytes(
+                content if isinstance(content, bytes) else content.encode())
+
+    def _delete_container(self, client, container_id: str) -> None:
+        """Delete a container (best-effort cleanup)."""
+        try:
+            client.containers.delete(container_id)
+        except Exception as exc:
+            self._log(f"Warning: container cleanup failed ({container_id}): {exc}")
+
+    def _find_skill_dir(self, workspace: Path,
+                        skill_name: str) -> Path:
+        """Locate the skill directory relative to workspace."""
+        candidates = [
+            workspace / ".skills" / skill_name,
+            workspace / "skills" / skill_name,
+            workspace.parent / ".skills" / skill_name,
+        ]
+        for c in candidates:
+            if c.exists() and (c / "SKILL.md").exists():
+                return c
+        raise FileNotFoundError(
+            f"Skill directory not found for '{skill_name}'. "
+            f"Searched: {[str(c) for c in candidates]}")
+
+    def _extract_output_text(self, response) -> str:
+        """Extract text content from response output messages."""
+        parts = []
+        for item in (response.output or []):
+            if getattr(item, "type", None) == "message":
+                for block in (item.content or []):
+                    if getattr(block, "type", None) == "output_text":
+                        parts.append(block.text)
+        return "\n".join(parts)
+
+    def _count_turns(self, response) -> int:
+        """Count the number of assistant turns in the response."""
+        count = 0
+        for item in (response.output or []):
+            if getattr(item, "type", None) == "message":
+                count += 1
+        return count or 1
+
+    def _log(self, msg: str) -> None:
+        """Print a progress message if log_prefix is set."""
+        if self._log_prefix:
+            with _print_lock:
+                print(f"  {self._log_prefix} | {msg}", flush=True)
+
+    def run_skill(
+        self,
+        skill_name: str,
+        args: str,
+        workspace: Path,
+        model: str,
+        settings_path: Optional[Path] = None,
+        system_prompt: Optional[str] = None,
+        max_budget_usd: float = 5.0,
+        timeout_s: int = 600,
+    ) -> RunResult:
+        client = None
+        effective_model = model or self._default_model
+        if not effective_model:
+            raise ValueError(
+                "No model specified. Set the 'model' argument, "
+                "'default_model' in runner settings, or OPENAI_MODEL env var.")
+        start = time.monotonic()
+        container_id = None
+        stdout_parts = []
+
+        try:
+            client = self._get_client()
+            skill_dir = self._find_skill_dir(workspace, skill_name)
+            skill_id = self._upload_skill(client, skill_dir, skill_name)
+            self._log(f"Skill uploaded: {skill_name} -> {skill_id}")
+
+            container_id = self._create_container(client, skill_id)
+            self._log(f"Container created: {container_id}")
+
+            uploaded = self._upload_workspace(
+                client, container_id, workspace)
+            self._log(f"Uploaded {len(uploaded)} files to container")
+
+            prompt = f"/{skill_name}"
+            if args:
+                prompt += f" {args}"
+
+            input_messages = []
+            if system_prompt:
+                input_messages.append({
+                    "role": "developer",
+                    "content": system_prompt,
+                })
+            input_messages.append({
+                "role": "user",
+                "content": prompt,
+            })
+
+            self._log(f"Executing: {prompt}")
+            response = client.responses.create(
+                model=effective_model,
+                input=input_messages,
+                tools=[{
+                    "type": "shell",
+                    "environment": {
+                        "type": "container_reference",
+                        "container_id": container_id,
+                    },
+                }],
+                timeout=timeout_s,
+            )
+
+            output_text = self._extract_output_text(response)
+            stdout_parts.append(output_text)
+            self._log(f"Execution complete: {response.status}")
+
+            self._download_results(client, container_id, workspace)
+
+            token_usage = None
+            cost_usd = None
+            if response.usage:
+                token_usage = {
+                    "input": response.usage.prompt_tokens,
+                    "output": response.usage.completion_tokens,
+                }
+
+            duration = time.monotonic() - start
+            exit_code = 0 if response.status == "completed" else 1
+
+            return RunResult(
+                exit_code=exit_code,
+                stdout="\n".join(stdout_parts),
+                stderr="",
+                duration_s=duration,
+                token_usage=token_usage,
+                cost_usd=cost_usd,
+                num_turns=self._count_turns(response),
+                resolved_model=getattr(response, "model", effective_model),
+                raw_output={"response_id": response.id,
+                            "status": response.status},
+            )
+
+        except Exception as e:
+            duration = time.monotonic() - start
+            return RunResult(
+                exit_code=1,
+                stdout="\n".join(stdout_parts),
+                stderr=str(e),
+                duration_s=duration,
+            )
+        finally:
+            if container_id and client is not None:
+                self._delete_container(client, container_id)

--- a/agent_eval/agent/responses_api.py
+++ b/agent_eval/agent/responses_api.py
@@ -16,7 +16,7 @@ from typing import Optional
 from .base import EvalRunner, RunResult
 
 _print_lock = threading.Lock()
-_global_skill_cache: dict[str, str] = {}
+_global_skill_cache: dict[tuple[str, str], str] = {}
 _global_skill_lock = threading.Lock()
 
 
@@ -85,8 +85,9 @@ class ResponsesAPIRunner(EvalRunner):
         uploads when multiple threads see a cache miss simultaneously.
         """
         with _global_skill_lock:
-            if skill_name in _global_skill_cache:
-                return _global_skill_cache[skill_name]
+            cache_key = (skill_name, str(skill_dir.resolve()))
+            if cache_key in _global_skill_cache:
+                return _global_skill_cache[cache_key]
             files = []
             for f in skill_dir.rglob("*"):
                 if not f.is_file() or f.is_symlink():
@@ -94,7 +95,7 @@ class ResponsesAPIRunner(EvalRunner):
                 rel = str(f.relative_to(skill_dir))
                 files.append((rel, f.read_bytes()))
             skill = client.skills.create(files=files)
-            _global_skill_cache[skill_name] = skill.id
+            _global_skill_cache[cache_key] = skill.id
             return skill.id
 
     _MEMORY_TIERS = [
@@ -151,11 +152,18 @@ class ResponsesAPIRunner(EvalRunner):
         may have been edited in-place by the agent).
         """
         after_files = client.containers.files.list(container_id)
+        workspace_root = workspace.resolve()
         for f in after_files:
             if not f.path.startswith("/workspace/"):
                 continue
-            rel = f.path[len("/workspace/"):]
-            local_path = workspace / rel
+            rel = Path(f.path[len("/workspace/"):])
+            if rel.is_absolute() or ".." in rel.parts:
+                self._log(f"Skipping unsafe container path: {f.path}")
+                continue
+            local_path = (workspace_root / rel).resolve()
+            if not str(local_path).startswith(str(workspace_root)):
+                self._log(f"Skipping escaped container path: {f.path}")
+                continue
             local_path.parent.mkdir(parents=True, exist_ok=True)
             resp = client.containers.files.content.retrieve(
                 file_id=f.id, container_id=container_id,
@@ -281,8 +289,10 @@ class ResponsesAPIRunner(EvalRunner):
             cost_usd = None
             if response.usage:
                 token_usage = {
-                    "input": response.usage.prompt_tokens,
-                    "output": response.usage.completion_tokens,
+                    "input": getattr(response.usage, "input_tokens", None)
+                            or getattr(response.usage, "prompt_tokens", None),
+                    "output": getattr(response.usage, "output_tokens", None)
+                             or getattr(response.usage, "completion_tokens", None),
                 }
 
             duration = time.monotonic() - start

--- a/agent_eval/agent/responses_api.py
+++ b/agent_eval/agent/responses_api.py
@@ -161,7 +161,9 @@ class ResponsesAPIRunner(EvalRunner):
                 self._log(f"Skipping unsafe container path: {f.path}")
                 continue
             local_path = (workspace_root / rel).resolve()
-            if not str(local_path).startswith(str(workspace_root)):
+            try:
+                local_path.relative_to(workspace_root)
+            except ValueError:
                 self._log(f"Skipping escaped container path: {f.path}")
                 continue
             local_path.parent.mkdir(parents=True, exist_ok=True)

--- a/agent_eval/agent/responses_api.py
+++ b/agent_eval/agent/responses_api.py
@@ -87,18 +87,32 @@ class ResponsesAPIRunner(EvalRunner):
         with _global_skill_lock:
             if skill_name in _global_skill_cache:
                 return _global_skill_cache[skill_name]
-            skill = client.skills.create(
-                name=skill_name,
-                source_dir=str(skill_dir),
-            )
+            files = []
+            for f in skill_dir.rglob("*"):
+                if not f.is_file() or f.is_symlink():
+                    continue
+                rel = str(f.relative_to(skill_dir))
+                files.append((rel, f.read_bytes()))
+            skill = client.skills.create(files=files)
             _global_skill_cache[skill_name] = skill.id
             return skill.id
+
+    _MEMORY_TIERS = [
+        (1024, "1g"), (4096, "4g"), (16384, "16g"), (65536, "64g"),
+    ]
+
+    def _pick_memory_limit(self, mb: int) -> str:
+        """Map an MB value to the nearest valid API tier."""
+        for threshold, label in self._MEMORY_TIERS:
+            if mb <= threshold:
+                return label
+        return "64g"
 
     def _create_container(self, client, skill_id: str) -> str:
         """Create an isolated container for one eval case with skill attached."""
         kwargs = {
             "name": f"eval-{uuid.uuid4().hex[:12]}",
-            "memory_limit": f"{self._memory_limit_mb}m",
+            "memory_limit": self._pick_memory_limit(self._memory_limit_mb),
             "skills": [{"type": "skill_reference", "skill_id": skill_id}],
         }
         if self._network_policy:
@@ -111,7 +125,8 @@ class ResponsesAPIRunner(EvalRunner):
         """Upload all workspace files to the container. Returns set of paths.
 
         Symlinks are skipped to prevent reading outside the workspace
-        (CWE-59).
+        (CWE-59). The container path is encoded in the filename tuple
+        so the API places files at the correct location.
         """
         uploaded = set()
         for f in workspace.rglob("*"):
@@ -119,12 +134,11 @@ class ResponsesAPIRunner(EvalRunner):
                 continue
             rel = f.relative_to(workspace)
             container_path = f"/workspace/{rel}"
-            with open(f, "rb") as fh:
-                client.containers.files.create(
-                    container_id,
-                    file=fh,
-                    path=container_path,
-                )
+            content = f.read_bytes()
+            client.containers.files.create(
+                container_id,
+                file=(container_path, content),
+            )
             uploaded.add(container_path)
         return uploaded
 
@@ -143,9 +157,10 @@ class ResponsesAPIRunner(EvalRunner):
             rel = f.path[len("/workspace/"):]
             local_path = workspace / rel
             local_path.parent.mkdir(parents=True, exist_ok=True)
-            content = client.containers.files.content(container_id, f.id)
-            local_path.write_bytes(
-                content if isinstance(content, bytes) else content.encode())
+            resp = client.containers.files.content.retrieve(
+                file_id=f.id, container_id=container_id,
+            )
+            local_path.write_bytes(resp.content)
 
     def _delete_container(self, client, container_id: str) -> None:
         """Delete a container (best-effort cleanup)."""

--- a/agent_eval/agent/responses_api.py
+++ b/agent_eval/agent/responses_api.py
@@ -54,6 +54,26 @@ class ResponsesAPIRunner(EvalRunner):
         self._memory_limit_mb = memory_limit_mb
         self._log_prefix = log_prefix
 
+    @classmethod
+    def from_config(cls, config, *, log_prefix=None, **overrides):
+        """Construct from EvalConfig.
+
+        Runner-specific settings (``base_url``, ``api_key``,
+        ``default_model``, ``network_policy``, ``memory_limit_mb``)
+        are read from ``runner.settings`` in eval.yaml and can be
+        overridden by keyword arguments.
+        """
+        settings = dict(config.runner.settings or {})
+        settings.update(overrides)
+        return cls(
+            base_url=settings.get("base_url"),
+            api_key=settings.get("api_key"),
+            default_model=settings.get("default_model"),
+            network_policy=settings.get("network_policy"),
+            memory_limit_mb=settings.get("memory_limit_mb", 512),
+            log_prefix=log_prefix,
+        )
+
     @property
     def name(self) -> str:
         return "responses-api"
@@ -83,17 +103,26 @@ class ResponsesAPIRunner(EvalRunner):
         own ``ResponsesAPIRunner`` instance) share a single upload.
         The lock is held across the check-and-create to prevent redundant
         uploads when multiple threads see a cache miss simultaneously.
+
+        Symlinks are resolved and included when the target stays under the
+        skill root (typical for symlinked skill trees from the harness).
         """
         with _global_skill_lock:
-            cache_key = (skill_name, str(skill_dir.resolve()))
+            skill_root = skill_dir.resolve()
+            cache_key = (skill_name, str(skill_root))
             if cache_key in _global_skill_cache:
                 return _global_skill_cache[cache_key]
             files = []
-            for f in skill_dir.rglob("*"):
-                if not f.is_file() or f.is_symlink():
+            for f in skill_root.rglob("*"):
+                try:
+                    resolved = f.resolve()
+                    resolved.relative_to(skill_root)
+                except (ValueError, OSError):
                     continue
-                rel = str(f.relative_to(skill_dir))
-                files.append((rel, f.read_bytes()))
+                if not resolved.is_file():
+                    continue
+                rel = f.relative_to(skill_root).as_posix()
+                files.append((rel, resolved.read_bytes()))
             skill = client.skills.create(files=files)
             _global_skill_cache[cache_key] = skill.id
             return skill.id
@@ -125,17 +154,23 @@ class ResponsesAPIRunner(EvalRunner):
                           workspace: Path) -> set[str]:
         """Upload all workspace files to the container. Returns set of paths.
 
-        Symlinks are skipped to prevent reading outside the workspace
-        (CWE-59). The container path is encoded in the filename tuple
-        so the API places files at the correct location.
+        Symlinked project files are common (e.g. symlinked skills under
+        ``skills/``). Each path is resolved and must stay under the
+        resolved workspace root (CWE-59); targets outside are skipped.
         """
         uploaded = set()
-        for f in workspace.rglob("*"):
-            if not f.is_file() or f.is_symlink():
+        workspace_root = workspace.resolve()
+        for f in workspace_root.rglob("*"):
+            try:
+                resolved = f.resolve()
+                resolved.relative_to(workspace_root)
+            except (ValueError, OSError):
                 continue
-            rel = f.relative_to(workspace)
-            container_path = f"/workspace/{rel}"
-            content = f.read_bytes()
+            if not resolved.is_file():
+                continue
+            rel = f.relative_to(workspace_root)
+            container_path = f"/workspace/{rel.as_posix()}"
+            content = resolved.read_bytes()
             client.containers.files.create(
                 container_id,
                 file=(container_path, content),
@@ -189,7 +224,7 @@ class ResponsesAPIRunner(EvalRunner):
         ]
         for c in candidates:
             if c.exists() and (c / "SKILL.md").exists():
-                return c
+                return c.resolve()
         raise FileNotFoundError(
             f"Skill directory not found for '{skill_name}'. "
             f"Searched: {[str(c) for c in candidates]}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,13 @@ evalhub = [
     "eval-hub-sdk[adapter]>=0.1,<1.0",
     "boto3>=1.34,<2.0",
 ]
+openai = ["openai>=1.70"]
 all = [
     "mlflow[genai]>=3.5",
     "anthropic[vertex]>=0.40",
     "eval-hub-sdk[adapter]>=0.1,<1.0",
     "boto3>=1.34,<2.0",
+    "openai>=1.70",
 ]
 test = ["pytest>=8.0"]
 

--- a/tests/demo_responses_api.py
+++ b/tests/demo_responses_api.py
@@ -454,9 +454,9 @@ def main():
             (workspace / "output").mkdir(exist_ok=True)
 
             _step(1, "Calling runner.run_skill()")
-            print(f"    skill_name = 'eval-demo'")
+            print("    skill_name = 'eval-demo'")
             print(f"    args       = '{case['skill_args']}'")
-            print(f"    model      = 'mock-gpt-4o'")
+            print("    model      = 'mock-gpt-4o'")
             print(f"    workspace  = {workspace}")
             print()
 
@@ -481,12 +481,12 @@ def main():
             if result.stderr:
                 print(f"    stderr         = {result.stderr}")
 
-            print(f"\n    stdout (model response):")
+            print("\n    stdout (model response):")
             for line in result.stdout.splitlines():
                 print(f"      | {line}")
 
             # Show workspace contents after execution
-            print(f"\n    Workspace files after execution:")
+            print("\n    Workspace files after execution:")
             for f in sorted(workspace.rglob("*")):
                 if f.is_file() and not f.is_symlink():
                     rel = f.relative_to(workspace)

--- a/tests/demo_responses_api.py
+++ b/tests/demo_responses_api.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Interactive demo: run ResponsesAPIRunner against a local mock Responses API.
+
+Simulates the full eval harness flow with 3 realistic test cases:
+  1. text-summarize — summarize a paragraph
+  2. code-generate  — write a Python function
+  3. bug-fix        — fix a broken script
+
+Each case goes through the complete 7-step lifecycle:
+  skill upload → container create → workspace upload → execute →
+  result download → container cleanup → RunResult
+
+Run:
+    python tests/demo_responses_api.py
+"""
+
+import json
+import os
+import sys
+import uuid
+import threading
+import tempfile
+import textwrap
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent_eval.agent.responses_api import ResponsesAPIRunner, _global_skill_cache
+from agent_eval.agent.base import RunResult
+
+# ---------------------------------------------------------------------------
+# Enhanced mock server — case-aware, verbose
+# ---------------------------------------------------------------------------
+
+_skills: dict[str, dict] = {}
+_containers: dict[str, dict] = {}
+_files: dict[str, dict[str, dict]] = {}
+
+CASE_RESPONSES = {
+    "text-summarize": {
+        "text": (
+            "The input text discusses climate change and its effects on "
+            "global ecosystems. Key points: rising temperatures, melting "
+            "ice caps, and biodiversity loss. The author argues for immediate "
+            "policy intervention."
+        ),
+        "output_file": "output/summary.txt",
+        "output_content": (
+            "SUMMARY\n"
+            "=======\n"
+            "Climate change threatens global ecosystems through rising temperatures,\n"
+            "melting ice caps, and biodiversity loss. Immediate policy action recommended.\n"
+        ),
+    },
+    "code-generate": {
+        "text": (
+            "Here is the implementation:\n\n"
+            "```python\n"
+            "def fibonacci(n: int) -> list[int]:\n"
+            '    \"\"\"Return the first n Fibonacci numbers.\"\"\"\n'
+            "    if n <= 0:\n"
+            "        return []\n"
+            "    seq = [0, 1]\n"
+            "    while len(seq) < n:\n"
+            "        seq.append(seq[-1] + seq[-2])\n"
+            "    return seq[:n]\n"
+            "```\n"
+        ),
+        "output_file": "output/fibonacci.py",
+        "output_content": (
+            "def fibonacci(n: int) -> list[int]:\n"
+            '    """Return the first n Fibonacci numbers."""\n'
+            "    if n <= 0:\n"
+            "        return []\n"
+            "    seq = [0, 1]\n"
+            "    while len(seq) < n:\n"
+            "        seq.append(seq[-1] + seq[-2])\n"
+            "    return seq[:n]\n"
+        ),
+    },
+    "bug-fix": {
+        "text": (
+            "Found the bug: the loop condition used `<=` instead of `<`, "
+            "causing an off-by-one IndexError. Fixed line 5 and added a "
+            "bounds check."
+        ),
+        "output_file": "output/fixed_script.py",
+        "output_content": (
+            "def process_items(items: list) -> list:\n"
+            '    """Process items safely with bounds checking."""\n'
+            "    results = []\n"
+            "    for i in range(len(items)):\n"  # fixed: was range(len(items)+1)
+            "        results.append(items[i] * 2)\n"
+            "    return results\n"
+        ),
+    },
+}
+
+
+def _detect_case(prompt: str) -> str:
+    """Match the case by looking at the skill args in the prompt.
+
+    The runner sends "/{skill_name} {args}" as the user message, so
+    we match on the args pattern rather than input.yaml content.
+    """
+    p = prompt.lower()
+    if "--format" in p or "bullet" in p:
+        return "text-summarize"
+    if "--language" in p or "python" in p:
+        return "code-generate"
+    if "--auto-test" in p or "fix" in p:
+        return "bug-fix"
+    return "text-summarize"
+
+
+class DemoHandler(BaseHTTPRequestHandler):
+
+    def log_message(self, fmt, *args):
+        msg = fmt % args
+        print(f"    [mock-api] {msg}", flush=True)
+
+    def _json(self, data, status=200):
+        body = json.dumps(data, indent=2).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(length) if length else b""
+
+    def _parse_multipart(self, body, content_type):
+        boundary = None
+        for part in content_type.split(";"):
+            part = part.strip()
+            if part.startswith("boundary="):
+                boundary = part[len("boundary="):].strip('"')
+        if not boundary:
+            return "/workspace/unknown", body
+        parts = body.split(f"--{boundary}".encode())
+        for part in parts:
+            if b"Content-Disposition" not in part:
+                continue
+            header_end = part.find(b"\r\n\r\n")
+            if header_end == -1:
+                continue
+            headers_section = part[:header_end].decode("utf-8", errors="replace")
+            content = part[header_end + 4:]
+            if content.endswith(b"\r\n"):
+                content = content[:-2]
+            filename = "/workspace/unknown"
+            for line in headers_section.split("\r\n"):
+                if "filename=" in line:
+                    start = line.index('filename="') + len('filename="')
+                    end = line.index('"', start)
+                    filename = line[start:end]
+                    break
+            if b'name="file"' in part:
+                return filename, content
+        return "/workspace/unknown", body
+
+    # -- GET --
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+
+        if path == "/v1/models":
+            self._json({"object": "list", "data": [
+                {"id": "mock-gpt-4o", "object": "model", "owned_by": "mock-openai"},
+                {"id": "mock-llama-3", "object": "model", "owned_by": "mock-ogx"},
+            ]})
+            return
+
+        if "/files/" in path and path.endswith("/content"):
+            parts = path.split("/")
+            cid, fid = parts[3], parts[5]
+            f = _files.get(cid, {}).get(fid)
+            if not f:
+                self._json({"detail": "Not Found"}, 404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(f["content"])))
+            self.end_headers()
+            self.wfile.write(f["content"])
+            return
+
+        if path.startswith("/v1/containers/") and path.endswith("/files"):
+            cid = path.split("/")[3]
+            container_files = _files.get(cid, {})
+            fl = [{"id": fid, "object": "container_file",
+                   "path": f["path"], "size": len(f["content"])}
+                  for fid, f in container_files.items()]
+            self._json({"object": "list", "data": fl,
+                        "first_id": fl[0]["id"] if fl else None,
+                        "last_id": fl[-1]["id"] if fl else None,
+                        "has_more": False})
+            return
+
+        self._json({"detail": "Not Found"}, 404)
+
+    # -- POST --
+
+    def do_POST(self):
+        path = self.path
+        body = self._body()
+
+        if path == "/v1/skills":
+            sid = f"skill_{uuid.uuid4().hex[:8]}"
+            _skills[sid] = {"id": sid}
+            self._json({"id": sid, "object": "skill", "name": "eval-skill"})
+            return
+
+        if path == "/v1/containers":
+            cid = f"ctr_{uuid.uuid4().hex[:8]}"
+            data = json.loads(body) if body else {}
+            _containers[cid] = {
+                "id": cid,
+                "name": data.get("name", ""),
+                "status": "running",
+                "memory_limit": data.get("memory_limit", "1g"),
+            }
+            _files[cid] = {}
+            self._json({"id": cid, "object": "container", "status": "running"})
+            return
+
+        if path.startswith("/v1/containers/") and path.endswith("/files"):
+            cid = path.split("/")[3]
+            ct = self.headers.get("Content-Type", "")
+            fid = f"file_{uuid.uuid4().hex[:8]}"
+            fp, fc = ("/workspace/unknown", body)
+            if "multipart" in ct:
+                fp, fc = self._parse_multipart(body, ct)
+            _files.setdefault(cid, {})[fid] = {"path": fp, "content": fc}
+            self._json({"id": fid, "object": "container_file",
+                        "path": fp, "size": len(fc)})
+            return
+
+        if path == "/v1/responses":
+            data = json.loads(body) if body else {}
+            model = data.get("model", "mock-gpt-4o")
+
+            prompt = ""
+            for msg in data.get("input", []):
+                if msg.get("role") == "user":
+                    prompt = msg.get("content", "")
+
+            case_key = _detect_case(prompt)
+            case_data = CASE_RESPONSES[case_key]
+
+            for tool in data.get("tools", []):
+                cid = tool.get("environment", {}).get("container_id")
+                if cid and cid in _files:
+                    ofid = f"file_{uuid.uuid4().hex[:8]}"
+                    _files[cid][ofid] = {
+                        "path": f"/workspace/{case_data['output_file']}",
+                        "content": case_data["output_content"].encode(),
+                    }
+
+            rid = f"resp_{uuid.uuid4().hex[:8]}"
+            self._json({
+                "id": rid,
+                "object": "response",
+                "status": "completed",
+                "model": model,
+                "output": [{
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{
+                        "type": "output_text",
+                        "text": case_data["text"],
+                    }],
+                }],
+                "usage": {
+                    "prompt_tokens": 250 + len(prompt),
+                    "completion_tokens": 80 + len(case_data["text"]),
+                    "total_tokens": 330 + len(prompt) + len(case_data["text"]),
+                },
+            })
+            return
+
+        self._json({"detail": "Not Found"}, 404)
+
+    # -- DELETE --
+
+    def do_DELETE(self):
+        path = self.path
+        if path.startswith("/v1/containers/"):
+            cid = path.split("/")[3]
+            _containers.pop(cid, None)
+            _files.pop(cid, None)
+            self._json({"deleted": True})
+            return
+        self._json({"detail": "Not Found"}, 404)
+
+
+# ---------------------------------------------------------------------------
+# Test cases — realistic eval scenarios
+# ---------------------------------------------------------------------------
+
+CASES = [
+    {
+        "id": "text-summarize",
+        "skill_args": "--format bullet-points",
+        "input_yaml": textwrap.dedent("""\
+            prompt: >
+              Summarize the following text in 3 bullet points.
+            text: >
+              Climate change is one of the most pressing challenges facing
+              humanity. Rising global temperatures are causing ice caps to melt,
+              sea levels to rise, and weather patterns to become more extreme.
+              These changes threaten biodiversity, food security, and human
+              health. Scientists urge immediate and coordinated policy action
+              to reduce greenhouse gas emissions and transition to renewable
+              energy sources.
+        """),
+        "extra_files": {},
+    },
+    {
+        "id": "code-generate",
+        "skill_args": "--language python",
+        "input_yaml": textwrap.dedent("""\
+            prompt: >
+              Generate a Python function called fibonacci that takes an
+              integer n and returns a list of the first n Fibonacci numbers.
+              Include a docstring and handle edge cases.
+        """),
+        "extra_files": {},
+    },
+    {
+        "id": "bug-fix",
+        "skill_args": "--auto-test",
+        "input_yaml": textwrap.dedent("""\
+            prompt: >
+              Fix the bug in the script below. It crashes with an
+              IndexError on large inputs.
+            source_file: broken_script.py
+        """),
+        "extra_files": {
+            "broken_script.py": textwrap.dedent("""\
+                def process_items(items: list) -> list:
+                    results = []
+                    for i in range(len(items) + 1):  # BUG: off-by-one
+                        results.append(items[i] * 2)
+                    return results
+            """),
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# SKILL.md — the skill the runner will upload
+# ---------------------------------------------------------------------------
+
+SKILL_MD = textwrap.dedent("""\
+    # eval-demo
+
+    A demo skill for testing the Responses API runner.
+
+    Accepts a prompt from input.yaml and produces output files.
+
+    ## Usage
+
+    /{skill_name} [args]
+
+    Reads input.yaml from the workspace, processes the prompt,
+    and writes results to the output/ directory.
+""")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _separator(char="=", width=72):
+    print(char * width)
+
+def _header(text):
+    _separator()
+    print(f"  {text}")
+    _separator()
+
+def _step(num, text):
+    print(f"\n  Step {num}: {text}")
+    print(f"  {'─' * 60}")
+
+
+def main():
+    _header("Responses API Runner — Full Lifecycle Demo")
+    print()
+    print("  This demo runs the ResponsesAPIRunner against a local mock")
+    print("  Responses API server. Every API call is real HTTP — the same")
+    print("  code path that would execute against OpenAI or OGX.")
+    print()
+
+    # Clear global skill cache from any previous runs
+    _global_skill_cache.clear()
+
+    # Start mock server
+    _skills.clear()
+    _containers.clear()
+    _files.clear()
+    server = HTTPServer(("127.0.0.1", 0), DemoHandler)
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    print(f"  Mock Responses API server running on http://127.0.0.1:{port}")
+    print()
+
+    runner = ResponsesAPIRunner(
+        base_url=f"http://127.0.0.1:{port}/v1",
+        api_key="mock-key-for-demo",
+        default_model="mock-gpt-4o",
+        memory_limit_mb=512,
+        log_prefix="demo",
+    )
+
+    results: list[tuple[str, RunResult]] = []
+
+    with tempfile.TemporaryDirectory(prefix="eval-demo-") as tmpdir:
+        base = Path(tmpdir)
+
+        # Create the skill directory (shared across cases)
+        skill_dir = base / "skills" / "eval-demo"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_MD)
+
+        for i, case in enumerate(CASES, 1):
+            case_id = case["id"]
+            _header(f"Case {i}/3: {case_id}")
+
+            _step(0, "Setting up workspace")
+            workspace = base / "workspaces" / case_id
+            workspace.mkdir(parents=True)
+
+            # Symlink skill directory into workspace
+            ws_skills = workspace / "skills"
+            ws_skills.mkdir()
+            (ws_skills / "eval-demo").symlink_to(skill_dir)
+
+            # Write input.yaml
+            (workspace / "input.yaml").write_text(case["input_yaml"])
+            print(f"    Wrote input.yaml ({len(case['input_yaml'])} bytes)")
+
+            # Write any extra files
+            for fname, content in case.get("extra_files", {}).items():
+                (workspace / fname).write_text(content)
+                print(f"    Wrote {fname} ({len(content)} bytes)")
+
+            # Create output directory
+            (workspace / "output").mkdir(exist_ok=True)
+
+            _step(1, "Calling runner.run_skill()")
+            print(f"    skill_name = 'eval-demo'")
+            print(f"    args       = '{case['skill_args']}'")
+            print(f"    model      = 'mock-gpt-4o'")
+            print(f"    workspace  = {workspace}")
+            print()
+
+            result = runner.run_skill(
+                skill_name="eval-demo",
+                args=case["skill_args"],
+                workspace=workspace,
+                model="mock-gpt-4o",
+                system_prompt="You are an eval harness agent. Execute the skill precisely.",
+                timeout_s=30,
+            )
+
+            results.append((case_id, result))
+
+            _step(7, "RunResult")
+            print(f"    exit_code      = {result.exit_code}")
+            print(f"    duration_s     = {result.duration_s:.3f}")
+            print(f"    token_usage    = {result.token_usage}")
+            print(f"    resolved_model = {result.resolved_model}")
+            print(f"    num_turns      = {result.num_turns}")
+            print(f"    raw_output     = {result.raw_output}")
+            if result.stderr:
+                print(f"    stderr         = {result.stderr}")
+
+            print(f"\n    stdout (model response):")
+            for line in result.stdout.splitlines():
+                print(f"      | {line}")
+
+            # Show workspace contents after execution
+            print(f"\n    Workspace files after execution:")
+            for f in sorted(workspace.rglob("*")):
+                if f.is_file() and not f.is_symlink():
+                    rel = f.relative_to(workspace)
+                    size = f.stat().st_size
+                    print(f"      {rel}  ({size} bytes)")
+
+            # Show the output file content if it was downloaded
+            output_dir = workspace / "output"
+            if output_dir.exists():
+                for f in sorted(output_dir.rglob("*")):
+                    if f.is_file():
+                        print(f"\n    Downloaded output ({f.relative_to(workspace)}):")
+                        for line in f.read_text().splitlines():
+                            print(f"      | {line}")
+            print()
+
+    # Summary
+    _header("Summary")
+    print()
+    all_passed = all(r.exit_code == 0 for _, r in results)
+    for case_id, result in results:
+        status = "PASS" if result.exit_code == 0 else "FAIL"
+        print(f"  [{status}]  {case_id:20s}  "
+              f"tokens={result.token_usage}  "
+              f"duration={result.duration_s:.3f}s")
+
+    print()
+    if all_passed:
+        print("  All 3 cases completed successfully through the full")
+        print("  Responses API lifecycle (7 steps each).")
+    else:
+        failed = [cid for cid, r in results if r.exit_code != 0]
+        print(f"  {len(failed)} case(s) failed: {', '.join(failed)}")
+
+    print()
+    _separator()
+    server.shutdown()
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -1,0 +1,658 @@
+"""Tests for the Responses API runner.
+
+Each test class targets a specific concern. Tests are written to catch
+the actual bugs found during review — not just confirm happy paths.
+"""
+import os
+import threading
+import time
+import pytest
+from unittest.mock import patch, MagicMock, call
+from pathlib import Path
+import tempfile
+
+
+class TestRunnersRegistry:
+    def test_responses_api_in_runners(self):
+        from agent_eval.agent import RUNNERS
+        assert "responses-api" in RUNNERS
+
+    def test_runner_class_is_correct(self):
+        from agent_eval.agent import RUNNERS
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        assert RUNNERS["responses-api"] is ResponsesAPIRunner
+
+
+class TestABCCompliance:
+    def test_is_eval_runner_subclass(self):
+        from agent_eval.agent.base import EvalRunner
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        assert issubclass(ResponsesAPIRunner, EvalRunner)
+
+    def test_name_property(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        assert runner.name == "responses-api"
+
+    def test_run_skill_signature_matches_abc(self):
+        import inspect
+        from agent_eval.agent.base import EvalRunner
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        abc_sig = inspect.signature(EvalRunner.run_skill)
+        impl_sig = inspect.signature(ResponsesAPIRunner.run_skill)
+        assert (list(abc_sig.parameters.keys())
+                == list(impl_sig.parameters.keys()))
+
+
+class TestClientInit:
+    def test_constructor_with_explicit_params(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(
+            base_url="http://localhost:8000",
+            api_key="sk-test",
+            default_model="gpt-4o",
+        )
+        assert runner._base_url == "http://localhost:8000"
+        assert runner._api_key == "sk-test"
+        assert runner._default_model == "gpt-4o"
+
+    def test_constructor_falls_back_to_env(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        with patch.dict(os.environ, {
+            "OPENAI_BASE_URL": "http://env-host:9000",
+            "OPENAI_API_KEY": "sk-env",
+            "OPENAI_MODEL": "gpt-4o-mini",
+        }):
+            runner = ResponsesAPIRunner()
+            assert runner._base_url == "http://env-host:9000"
+            assert runner._api_key == "sk-env"
+            assert runner._default_model == "gpt-4o-mini"
+
+    def test_explicit_params_override_env(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        with patch.dict(os.environ, {"OPENAI_BASE_URL": "http://env:8000"}):
+            runner = ResponsesAPIRunner(base_url="http://explicit:9000")
+            assert runner._base_url == "http://explicit:9000"
+
+    def test_kwargs_are_absorbed(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(
+            base_url="http://localhost:8000",
+            permissions={"allow": ["*"]},
+            effort="high",
+            plugin_dirs=[],
+        )
+        assert runner.name == "responses-api"
+
+
+class TestSkillUpload:
+    def setup_method(self):
+        from agent_eval.agent import responses_api
+        responses_api._global_skill_cache.clear()
+
+    def test_upload_called_once_then_cached(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+
+        mock_client = MagicMock()
+        mock_skill = MagicMock()
+        mock_skill.id = "skill-abc123"
+        mock_client.skills.create.return_value = mock_skill
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "my-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text("# Test Skill")
+
+            sid1 = runner._upload_skill(mock_client, skill_dir, "my-skill")
+            sid2 = runner._upload_skill(mock_client, skill_dir, "my-skill")
+            assert sid1 == sid2 == "skill-abc123"
+            assert mock_client.skills.create.call_count == 1
+
+    def test_different_skills_uploaded_separately(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+
+        mock_client = MagicMock()
+        counter = {"n": 0}
+
+        def make_skill(**kwargs):
+            counter["n"] += 1
+            s = MagicMock()
+            s.id = f"skill-{counter['n']}"
+            return s
+
+        mock_client.skills.create.side_effect = make_skill
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for name in ("skill-a", "skill-b"):
+                d = Path(tmpdir) / name
+                d.mkdir()
+                (d / "SKILL.md").write_text(f"# {name}")
+
+            sid_a = runner._upload_skill(
+                mock_client, Path(tmpdir) / "skill-a", "skill-a")
+            sid_b = runner._upload_skill(
+                mock_client, Path(tmpdir) / "skill-b", "skill-b")
+            assert sid_a != sid_b
+            assert counter["n"] == 2
+
+    def test_cache_shared_across_instances(self):
+        """Parallel workers (separate runner instances) must share one upload."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner1 = ResponsesAPIRunner(base_url="http://localhost:8000")
+        runner2 = ResponsesAPIRunner(base_url="http://localhost:8000")
+
+        mock_client = MagicMock()
+        mock_skill = MagicMock()
+        mock_skill.id = "skill-shared"
+        mock_client.skills.create.return_value = mock_skill
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "shared-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text("# Shared")
+
+            sid1 = runner1._upload_skill(mock_client, skill_dir, "shared-skill")
+            sid2 = runner2._upload_skill(mock_client, skill_dir, "shared-skill")
+            assert sid1 == sid2 == "skill-shared"
+            assert mock_client.skills.create.call_count == 1
+
+    def test_concurrent_uploads_only_call_api_once(self):
+        """TOCTOU regression: concurrent threads must not duplicate uploads."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+
+        upload_count = 0
+        upload_lock = threading.Lock()
+
+        def slow_create(**kwargs):
+            nonlocal upload_count
+            time.sleep(0.05)
+            with upload_lock:
+                upload_count += 1
+            s = MagicMock()
+            s.id = "skill-concurrent"
+            return s
+
+        mock_client = MagicMock()
+        mock_client.skills.create.side_effect = slow_create
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "conc-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text("# Concurrent")
+
+            results = [None] * 4
+            def worker(idx):
+                r = ResponsesAPIRunner(base_url="http://localhost:8000")
+                results[idx] = r._upload_skill(
+                    mock_client, skill_dir, "conc-skill")
+
+            threads = [threading.Thread(target=worker, args=(i,))
+                       for i in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert all(r == "skill-concurrent" for r in results)
+            assert upload_count == 1, (
+                f"Expected 1 API call, got {upload_count} — TOCTOU race")
+
+
+class TestContainerLifecycle:
+    def test_create_container_attaches_skill(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "ctr-123"
+        mock_client.containers.create.return_value = mock_container
+
+        cid = runner._create_container(mock_client, "skill-abc")
+        assert cid == "ctr-123"
+        kw = mock_client.containers.create.call_args.kwargs
+        assert kw["skills"] == [
+            {"type": "skill_reference", "skill_id": "skill-abc"}]
+
+    def test_create_container_memory_limit_string_format(self):
+        """memory_limit must be a string like '1024m', not an int."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(
+            base_url="http://localhost:8000", memory_limit_mb=1024)
+        mock_client = MagicMock()
+        mock_client.containers.create.return_value = MagicMock(id="ctr-456")
+
+        runner._create_container(mock_client, "skill-xyz")
+        kw = mock_client.containers.create.call_args.kwargs
+        assert kw["memory_limit"] == "1024m"
+        assert isinstance(kw["memory_limit"], str)
+
+    def test_create_container_names_are_unique(self):
+        """Concurrent evals must not clash on container names."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+        mock_client.containers.create.return_value = MagicMock(id="ctr")
+
+        names = set()
+        for _ in range(20):
+            runner._create_container(mock_client, "skill-x")
+            kw = mock_client.containers.create.call_args.kwargs
+            names.add(kw["name"])
+        assert len(names) == 20, "Container names must be unique"
+
+    def test_create_container_passes_network_policy(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        policy = {"type": "allowlist", "allowed_domains": ["pypi.org"]}
+        runner = ResponsesAPIRunner(
+            base_url="http://localhost:8000", network_policy=policy)
+        mock_client = MagicMock()
+        mock_client.containers.create.return_value = MagicMock(id="ctr")
+
+        runner._create_container(mock_client, "skill-x")
+        kw = mock_client.containers.create.call_args.kwargs
+        assert kw["network_policy"] == policy
+
+    def test_create_container_omits_network_policy_when_none(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+        mock_client.containers.create.return_value = MagicMock(id="ctr")
+
+        runner._create_container(mock_client, "skill-x")
+        kw = mock_client.containers.create.call_args.kwargs
+        assert "network_policy" not in kw
+
+    def test_upload_workspace_sends_correct_paths(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            (ws / "input.yaml").write_text("key: value")
+            (ws / "src").mkdir()
+            (ws / "src" / "main.py").write_text("print('hello')")
+
+            uploaded = runner._upload_workspace(mock_client, "ctr-123", ws)
+            assert "/workspace/input.yaml" in uploaded
+            assert "/workspace/src/main.py" in uploaded
+            assert mock_client.containers.files.create.call_count == 2
+
+    def test_upload_workspace_skips_symlinks(self):
+        """Symlinks could read outside the workspace (CWE-59)."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir) / "workspace"
+            ws.mkdir()
+            (ws / "real.txt").write_text("real content")
+            (ws / "link.txt").symlink_to(ws / "real.txt")
+
+            uploaded = runner._upload_workspace(mock_client, "ctr-123", ws)
+            assert len(uploaded) == 1
+            assert "/workspace/real.txt" in uploaded
+            assert "/workspace/link.txt" not in uploaded
+
+    def test_download_syncs_both_new_and_modified_files(self):
+        """Modified uploaded files must be synced back, not just new ones."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+
+        new_file = MagicMock(path="/workspace/output/result.md", id="f-new")
+        modified_file = MagicMock(path="/workspace/input.yaml", id="f-mod")
+        system_file = MagicMock(path="/tmp/internal.log", id="f-sys")
+
+        mock_client.containers.files.list.return_value = [
+            new_file, modified_file, system_file]
+
+        content_map = {
+            ("ctr-1", "f-new"): b"new result",
+            ("ctr-1", "f-mod"): b"modified input",
+        }
+        mock_client.containers.files.content.side_effect = (
+            lambda cid, fid: content_map[(cid, fid)])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            (ws / "input.yaml").write_text("original")
+
+            runner._download_results(mock_client, "ctr-1", ws)
+
+            assert (ws / "output" / "result.md").read_bytes() == b"new result"
+            assert (ws / "input.yaml").read_bytes() == b"modified input"
+            assert not (ws / "tmp").exists(), "Non-workspace files must be skipped"
+            assert mock_client.containers.files.content.call_count == 2
+
+    def test_download_overwrites_local_content(self):
+        """The agent may edit input.yaml in-place; the local copy must update."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+
+        mock_file = MagicMock(path="/workspace/data.txt", id="f-1")
+        mock_client.containers.files.list.return_value = [mock_file]
+        mock_client.containers.files.content.return_value = b"updated by agent"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            (ws / "data.txt").write_text("original content")
+
+            runner._download_results(mock_client, "ctr-1", ws)
+            assert (ws / "data.txt").read_bytes() == b"updated by agent"
+
+    def test_delete_container_logs_on_failure(self, capsys):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(
+            base_url="http://localhost:8000", log_prefix="test")
+        mock_client = MagicMock()
+        mock_client.containers.delete.side_effect = RuntimeError("gone")
+
+        runner._delete_container(mock_client, "ctr-123")
+        captured = capsys.readouterr()
+        assert "cleanup failed" in captured.out
+        assert "ctr-123" in captured.out
+
+    def test_delete_container_silent_without_log_prefix(self, capsys):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+        mock_client.containers.delete.side_effect = RuntimeError("gone")
+
+        runner._delete_container(mock_client, "ctr-123")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+
+class TestRunSkill:
+    """Integration-level tests for the full run_skill flow."""
+
+    def setup_method(self):
+        from agent_eval.agent import responses_api
+        responses_api._global_skill_cache.clear()
+
+    def _make_runner(self, **kwargs):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        default_model = kwargs.pop("default_model", "gpt-4o")
+        return ResponsesAPIRunner(
+            base_url="http://localhost:8000",
+            api_key="sk-test",
+            default_model=default_model,
+            **kwargs,
+        )
+
+    def _mock_response(self, text="Done", prompt_tokens=100,
+                        completion_tokens=50, model="gpt-4o",
+                        status="completed"):
+        resp = MagicMock()
+        resp.id = "resp-123"
+        resp.model = model
+        resp.status = status
+        output_msg = MagicMock()
+        output_msg.type = "message"
+        output_msg.content = [MagicMock(type="output_text", text=text)]
+        resp.output = [output_msg]
+        resp.usage = MagicMock()
+        resp.usage.prompt_tokens = prompt_tokens
+        resp.usage.completion_tokens = completion_tokens
+        return resp
+
+    def _run_with_mock(self, runner, mock_client, **run_kwargs):
+        """Helper to run_skill with mocked client and skill dir."""
+        with patch.object(runner, '_get_client', return_value=mock_client):
+            with patch.object(runner, '_find_skill_dir',
+                              return_value=Path("/tmp/skill")):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    ws = Path(tmpdir)
+                    defaults = dict(
+                        skill_name="test-skill", args="", workspace=ws,
+                        model="gpt-4o")
+                    defaults.update(run_kwargs)
+                    if "workspace" not in run_kwargs:
+                        defaults["workspace"] = ws
+                    return runner.run_skill(**defaults)
+
+    def _setup_mock_client(self, response=None):
+        mock_client = MagicMock()
+        mock_skill = MagicMock(id="skill-abc")
+        mock_client.skills.create.return_value = mock_skill
+        mock_client.containers.create.return_value = MagicMock(id="ctr-123")
+        mock_client.containers.files.list.return_value = []
+        mock_client.responses.create.return_value = (
+            response or self._mock_response())
+        return mock_client
+
+    def test_success_returns_correct_result(self):
+        runner = self._make_runner()
+        mock_client = self._setup_mock_client()
+
+        result = self._run_with_mock(runner, mock_client)
+
+        assert result.exit_code == 0
+        assert result.token_usage == {"input": 100, "output": 50}
+        assert result.resolved_model == "gpt-4o"
+        assert result.duration_s > 0
+        assert result.num_turns == 1
+        assert result.stderr == ""
+
+    def test_api_error_returns_exit_code_1(self):
+        runner = self._make_runner()
+        mock_client = self._setup_mock_client()
+        mock_client.responses.create.side_effect = Exception("API error")
+
+        result = self._run_with_mock(runner, mock_client)
+
+        assert result.exit_code == 1
+        assert "API error" in result.stderr
+
+    def test_incomplete_response_returns_exit_code_1(self):
+        runner = self._make_runner()
+        resp = self._mock_response(status="failed")
+        mock_client = self._setup_mock_client(response=resp)
+
+        result = self._run_with_mock(runner, mock_client)
+        assert result.exit_code == 1
+
+    def test_uses_container_reference_not_auto(self):
+        """Must use container_reference since we pre-create the container."""
+        runner = self._make_runner()
+        mock_client = self._setup_mock_client()
+
+        self._run_with_mock(runner, mock_client)
+
+        kw = mock_client.responses.create.call_args.kwargs
+        tool_env = kw["tools"][0]["environment"]
+        assert tool_env["type"] == "container_reference", (
+            "Must use container_reference, not container_auto")
+        assert "container_id" in tool_env
+        assert "skills" not in tool_env, (
+            "Skills go on container creation, not the tool environment")
+
+    def test_skills_attached_to_container_not_tool(self):
+        """Skills must be attached at container creation time."""
+        runner = self._make_runner()
+        mock_client = self._setup_mock_client()
+
+        self._run_with_mock(runner, mock_client)
+
+        ctr_kw = mock_client.containers.create.call_args.kwargs
+        assert "skills" in ctr_kw
+        assert ctr_kw["skills"][0]["skill_id"] == "skill-abc"
+
+    def test_model_arg_overrides_default(self):
+        runner = self._make_runner(default_model="gpt-4o-mini")
+        mock_client = self._setup_mock_client(
+            response=self._mock_response(model="gpt-4o"))
+
+        self._run_with_mock(runner, mock_client, model="gpt-4o")
+
+        kw = mock_client.responses.create.call_args.kwargs
+        assert kw["model"] == "gpt-4o"
+
+    def test_system_prompt_sent_as_developer_role(self):
+        runner = self._make_runner()
+        mock_client = self._setup_mock_client()
+
+        self._run_with_mock(runner, mock_client,
+                            system_prompt="You are a reviewer")
+
+        kw = mock_client.responses.create.call_args.kwargs
+        msgs = kw["input"]
+        assert msgs[0]["role"] == "developer"
+        assert msgs[0]["content"] == "You are a reviewer"
+        assert msgs[1]["role"] == "user"
+
+    def test_no_system_prompt_sends_only_user(self):
+        runner = self._make_runner()
+        mock_client = self._setup_mock_client()
+
+        self._run_with_mock(runner, mock_client)
+
+        kw = mock_client.responses.create.call_args.kwargs
+        msgs = kw["input"]
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+
+    def test_cleanup_on_success(self):
+        runner = self._make_runner()
+        mock_client = self._setup_mock_client()
+
+        self._run_with_mock(runner, mock_client)
+
+        mock_client.containers.delete.assert_called_once_with("ctr-123")
+
+    def test_cleanup_on_error(self):
+        runner = self._make_runner()
+        mock_client = self._setup_mock_client()
+        mock_client.responses.create.side_effect = Exception("boom")
+
+        self._run_with_mock(runner, mock_client)
+
+        mock_client.containers.delete.assert_called_once_with("ctr-123")
+
+    def test_no_cleanup_when_container_not_created(self):
+        runner = self._make_runner()
+        mock_client = self._setup_mock_client()
+        mock_client.skills.create.side_effect = Exception("upload failed")
+
+        self._run_with_mock(runner, mock_client)
+
+        mock_client.containers.delete.assert_not_called()
+
+    def test_prompt_format(self):
+        runner = self._make_runner()
+        mock_client = self._setup_mock_client()
+
+        self._run_with_mock(runner, mock_client,
+                            skill_name="my-skill", args="--input foo.yaml")
+
+        kw = mock_client.responses.create.call_args.kwargs
+        user_msg = kw["input"][-1]["content"]
+        assert user_msg == "/my-skill --input foo.yaml"
+
+
+class TestEdgeCases:
+    def setup_method(self):
+        from agent_eval.agent import responses_api
+        responses_api._global_skill_cache.clear()
+
+    def test_run_skill_raises_on_no_model(self):
+        """Must fail fast before any API calls."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            with pytest.raises(ValueError, match="No model specified"):
+                runner.run_skill("test-skill", "", ws, "")
+
+        mock_client.skills.create.assert_not_called()
+
+    def test_skill_not_found_raises(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            with pytest.raises(FileNotFoundError, match="Skill directory"):
+                runner._find_skill_dir(ws, "nonexistent-skill")
+
+    def test_find_skill_dir_dot_skills(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            skill_dir = ws / ".skills" / "my-skill"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text("# Skill")
+            assert runner._find_skill_dir(ws, "my-skill") == skill_dir
+
+    def test_find_skill_dir_skills(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            skill_dir = ws / "skills" / "my-skill"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text("# Skill")
+            assert runner._find_skill_dir(ws, "my-skill") == skill_dir
+
+    def test_find_skill_dir_requires_skill_md(self):
+        """A directory without SKILL.md must not match."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            (ws / ".skills" / "my-skill").mkdir(parents=True)
+            with pytest.raises(FileNotFoundError):
+                runner._find_skill_dir(ws, "my-skill")
+
+    def test_extract_output_text_empty(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        resp = MagicMock(output=[])
+        assert runner._extract_output_text(resp) == ""
+
+    def test_extract_output_text_skips_non_message_items(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        msg = MagicMock(type="message",
+                        content=[MagicMock(type="output_text", text="Hello")])
+        tool = MagicMock(type="shell_call", content=None)
+        resp = MagicMock(output=[tool, msg])
+        assert runner._extract_output_text(resp) == "Hello"
+
+    def test_count_turns_minimum_one(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        resp = MagicMock(output=[])
+        assert runner._count_turns(resp) == 1
+
+    def test_count_turns_only_counts_messages(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        msgs = [MagicMock(type="message") for _ in range(3)]
+        msgs.append(MagicMock(type="shell_call"))
+        resp = MagicMock(output=msgs)
+        assert runner._count_turns(resp) == 3
+
+    def test_empty_workspace_no_files_uploaded(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ws = Path(tmpdir)
+            uploaded = runner._upload_workspace(mock_client, "ctr-1", ws)
+            assert len(uploaded) == 0
+            mock_client.containers.files.create.assert_not_called()
+
+    def test_no_base_url_defaults_to_empty(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        with patch.dict(os.environ, {}, clear=True):
+            runner = ResponsesAPIRunner()
+            assert runner._base_url == ""

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -578,6 +578,8 @@ class TestRunSkill:
         output_msg.content = [MagicMock(type="output_text", text=text)]
         resp.output = [output_msg]
         resp.usage = MagicMock()
+        resp.usage.input_tokens = prompt_tokens
+        resp.usage.output_tokens = completion_tokens
         resp.usage.prompt_tokens = prompt_tokens
         resp.usage.completion_tokens = completion_tokens
         return resp
@@ -745,14 +747,13 @@ class TestEdgeCases:
         """Must fail fast before any API calls."""
         from agent_eval.agent.responses_api import ResponsesAPIRunner
         runner = ResponsesAPIRunner(base_url="http://localhost:8000")
-        mock_client = MagicMock()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             ws = Path(tmpdir)
-            with pytest.raises(ValueError, match="No model specified"):
-                runner.run_skill("test-skill", "", ws, "")
-
-        mock_client.skills.create.assert_not_called()
+            with patch.object(runner, "_get_client") as get_client:
+                with pytest.raises(ValueError, match="No model specified"):
+                    runner.run_skill("test-skill", "", ws, "")
+            get_client.assert_not_called()
 
     def test_skill_not_found_raises(self):
         from agent_eval.agent.responses_api import ResponsesAPIRunner
@@ -845,6 +846,8 @@ class TestEdgeCases:
 
 @pytest.fixture(scope="module")
 def mock_server():
+    from agent_eval.agent import responses_api
+    responses_api._global_skill_cache.clear()
     server, port = _start_mock_server()
     yield port
     server.shutdown()

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -508,6 +508,29 @@ class TestContainerLifecycle:
             assert not (ws / "tmp").exists(), "Non-workspace files must be skipped"
             assert mock_client.containers.files.content.retrieve.call_count == 2
 
+    def test_download_rejects_symlink_escape(self):
+        """Symlink inside workspace pointing outside must not be followed."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+
+        escaped = MagicMock(path="/workspace/link/pwn.txt", id="f-esc")
+        mock_client.containers.files.list.return_value = [escaped]
+        mock_client.containers.files.content.retrieve.return_value = (
+            MagicMock(content=b"should-not-write"))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            ws = root / "ws"
+            ws.mkdir()
+            outside = root / "ws_evil"
+            outside.mkdir()
+            (ws / "link").symlink_to(outside, target_is_directory=True)
+
+            runner._download_results(mock_client, "ctr-1", ws)
+
+            assert not (outside / "pwn.txt").exists()
+
     def test_download_overwrites_local_content(self):
         """The agent may edit input.yaml in-place; the local copy must update."""
         from agent_eval.agent.responses_api import ResponsesAPIRunner

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -2,14 +2,183 @@
 
 Each test class targets a specific concern. Tests are written to catch
 the actual bugs found during review — not just confirm happy paths.
+
+Includes an embedded mock server and integration tests that exercise
+the full 7-step runner lifecycle over real HTTP.
 """
+import json
 import os
 import threading
 import time
+import uuid
 import pytest
+from http.server import HTTPServer, BaseHTTPRequestHandler
 from unittest.mock import patch, MagicMock, call
 from pathlib import Path
 import tempfile
+
+
+# ---------------------------------------------------------------------------
+# Embedded mock Responses API server
+# ---------------------------------------------------------------------------
+
+_mock_skills: dict[str, dict] = {}
+_mock_containers: dict[str, dict] = {}
+_mock_container_files: dict[str, dict[str, dict]] = {}
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+
+    def log_message(self, fmt, *args):
+        pass
+
+    def _parse_multipart(self, body, content_type):
+        boundary = None
+        for part in content_type.split(";"):
+            part = part.strip()
+            if part.startswith("boundary="):
+                boundary = part[len("boundary="):].strip('"')
+        if not boundary:
+            return "/workspace/unknown", body
+        parts = body.split(f"--{boundary}".encode())
+        for part in parts:
+            if b"Content-Disposition" not in part:
+                continue
+            header_end = part.find(b"\r\n\r\n")
+            if header_end == -1:
+                continue
+            headers_section = part[:header_end].decode("utf-8", errors="replace")
+            content = part[header_end + 4:]
+            if content.endswith(b"\r\n"):
+                content = content[:-2]
+            filename = "/workspace/unknown"
+            for line in headers_section.split("\r\n"):
+                if "filename=" in line:
+                    start = line.index('filename="') + len('filename="')
+                    end = line.index('"', start)
+                    filename = line[start:end]
+                    break
+            if b'name="file"' in part:
+                return filename, content
+        return "/workspace/unknown", body
+
+    def _json(self, data, status=200):
+        body = json.dumps(data).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(length) if length else b""
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+        if path == "/v1/models":
+            self._json({"object": "list", "data": [
+                {"id": "mock-model", "object": "model", "owned_by": "mock"}]})
+            return
+        if "/files/" in path and path.endswith("/content"):
+            parts = path.split("/")
+            f = _mock_container_files.get(parts[3], {}).get(parts[5])
+            if not f:
+                self._json({"detail": "Not Found"}, 404)
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(f["content"])))
+            self.end_headers()
+            self.wfile.write(f["content"])
+            return
+        if path.startswith("/v1/containers/") and path.endswith("/files"):
+            cid = path.split("/")[3]
+            files = _mock_container_files.get(cid, {})
+            fl = [{"id": fid, "object": "container_file",
+                   "path": f["path"], "size": len(f["content"])}
+                  for fid, f in files.items()]
+            self._json({"object": "list", "data": fl,
+                        "first_id": fl[0]["id"] if fl else None,
+                        "last_id": fl[-1]["id"] if fl else None,
+                        "has_more": False})
+            return
+        self._json({"detail": "Not Found"}, 404)
+
+    def do_POST(self):
+        path = self.path
+        body = self._body()
+        if path == "/v1/skills":
+            sid = f"skill_{uuid.uuid4().hex[:8]}"
+            _mock_skills[sid] = {"id": sid}
+            self._json({"id": sid, "object": "skill", "name": sid})
+            return
+        if path == "/v1/containers":
+            cid = f"ctr_{uuid.uuid4().hex[:8]}"
+            data = json.loads(body) if body else {}
+            _mock_containers[cid] = {"id": cid, "name": data.get("name", ""),
+                                     "status": "running"}
+            _mock_container_files[cid] = {}
+            self._json({"id": cid, "object": "container", "status": "running"})
+            return
+        if path.startswith("/v1/containers/") and path.endswith("/files"):
+            cid = path.split("/")[3]
+            if cid not in _mock_containers:
+                self._json({"detail": "Not found"}, 404)
+                return
+            ct = self.headers.get("Content-Type", "")
+            fid = f"file_{uuid.uuid4().hex[:8]}"
+            fp, fc = ("/workspace/unknown", body)
+            if "multipart" in ct:
+                fp, fc = self._parse_multipart(body, ct)
+            _mock_container_files[cid][fid] = {"path": fp, "content": fc}
+            self._json({"id": fid, "object": "container_file",
+                        "path": fp, "size": len(fc)})
+            return
+        if path == "/v1/responses":
+            data = json.loads(body) if body else {}
+            model = data.get("model", "mock-model")
+            rid = f"resp_{uuid.uuid4().hex[:8]}"
+            for tool in data.get("tools", []):
+                cid = tool.get("environment", {}).get("container_id")
+                if cid and cid in _mock_container_files:
+                    ofid = f"file_{uuid.uuid4().hex[:8]}"
+                    _mock_container_files[cid][ofid] = {
+                        "path": "/workspace/output/result.txt",
+                        "content": b"Mock agent output: task completed successfully.",
+                    }
+            self._json({
+                "id": rid, "object": "response", "status": "completed",
+                "model": model,
+                "output": [{"type": "message", "role": "assistant",
+                            "content": [{"type": "output_text",
+                                         "text": "I executed the skill successfully. "
+                                                 "Created output/result.txt with results."}]}],
+                "usage": {"prompt_tokens": 150, "completion_tokens": 42,
+                          "total_tokens": 192},
+            })
+            return
+        self._json({"detail": "Not Found"}, 404)
+
+    def do_DELETE(self):
+        path = self.path
+        if path.startswith("/v1/containers/"):
+            cid = path.split("/")[3]
+            _mock_containers.pop(cid, None)
+            _mock_container_files.pop(cid, None)
+            self._json({"deleted": True})
+            return
+        self._json({"detail": "Not Found"}, 404)
+
+
+def _start_mock_server():
+    _mock_skills.clear()
+    _mock_containers.clear()
+    _mock_container_files.clear()
+    server = HTTPServer(("127.0.0.1", 0), _MockHandler)
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, port
 
 
 class TestRunnersRegistry:
@@ -216,7 +385,7 @@ class TestContainerLifecycle:
             {"type": "skill_reference", "skill_id": "skill-abc"}]
 
     def test_create_container_memory_limit_string_format(self):
-        """memory_limit must be a string like '1024m', not an int."""
+        """memory_limit must be one of the API-accepted tier strings."""
         from agent_eval.agent.responses_api import ResponsesAPIRunner
         runner = ResponsesAPIRunner(
             base_url="http://localhost:8000", memory_limit_mb=1024)
@@ -225,8 +394,19 @@ class TestContainerLifecycle:
 
         runner._create_container(mock_client, "skill-xyz")
         kw = mock_client.containers.create.call_args.kwargs
-        assert kw["memory_limit"] == "1024m"
+        assert kw["memory_limit"] == "1g"
         assert isinstance(kw["memory_limit"], str)
+
+    def test_memory_limit_tiers(self):
+        """Verify MB-to-tier mapping for various sizes."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        r = ResponsesAPIRunner(base_url="http://x")
+        assert r._pick_memory_limit(512) == "1g"
+        assert r._pick_memory_limit(1024) == "1g"
+        assert r._pick_memory_limit(2048) == "4g"
+        assert r._pick_memory_limit(8000) == "16g"
+        assert r._pick_memory_limit(32000) == "64g"
+        assert r._pick_memory_limit(99999) == "64g"
 
     def test_create_container_names_are_unique(self):
         """Concurrent evals must not clash on container names."""
@@ -311,11 +491,11 @@ class TestContainerLifecycle:
             new_file, modified_file, system_file]
 
         content_map = {
-            ("ctr-1", "f-new"): b"new result",
-            ("ctr-1", "f-mod"): b"modified input",
+            "f-new": MagicMock(content=b"new result"),
+            "f-mod": MagicMock(content=b"modified input"),
         }
-        mock_client.containers.files.content.side_effect = (
-            lambda cid, fid: content_map[(cid, fid)])
+        mock_client.containers.files.content.retrieve.side_effect = (
+            lambda file_id, container_id: content_map[file_id])
 
         with tempfile.TemporaryDirectory() as tmpdir:
             ws = Path(tmpdir)
@@ -326,7 +506,7 @@ class TestContainerLifecycle:
             assert (ws / "output" / "result.md").read_bytes() == b"new result"
             assert (ws / "input.yaml").read_bytes() == b"modified input"
             assert not (ws / "tmp").exists(), "Non-workspace files must be skipped"
-            assert mock_client.containers.files.content.call_count == 2
+            assert mock_client.containers.files.content.retrieve.call_count == 2
 
     def test_download_overwrites_local_content(self):
         """The agent may edit input.yaml in-place; the local copy must update."""
@@ -336,7 +516,8 @@ class TestContainerLifecycle:
 
         mock_file = MagicMock(path="/workspace/data.txt", id="f-1")
         mock_client.containers.files.list.return_value = [mock_file]
-        mock_client.containers.files.content.return_value = b"updated by agent"
+        mock_client.containers.files.content.retrieve.return_value = (
+            MagicMock(content=b"updated by agent"))
 
         with tempfile.TemporaryDirectory() as tmpdir:
             ws = Path(tmpdir)
@@ -656,3 +837,95 @@ class TestEdgeCases:
         with patch.dict(os.environ, {}, clear=True):
             runner = ResponsesAPIRunner()
             assert runner._base_url == ""
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — full lifecycle against embedded mock server
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def mock_server():
+    server, port = _start_mock_server()
+    yield port
+    server.shutdown()
+
+
+@pytest.fixture()
+def live_workspace(tmp_path):
+    skill_dir = tmp_path / ".skills" / "test-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Test Skill\nDo something useful.")
+    (tmp_path / "input.yaml").write_text("task: write a greeting\n")
+    (tmp_path / "source.md").write_text("# Original\nHello world.\n")
+    (tmp_path / "output").mkdir()
+    return tmp_path
+
+
+@pytest.fixture()
+def live_runner(mock_server):
+    from agent_eval.agent.responses_api import ResponsesAPIRunner
+    return ResponsesAPIRunner(
+        base_url=f"http://127.0.0.1:{mock_server}/v1",
+        api_key="fake-key",
+        default_model="mock-model",
+        log_prefix="test",
+    )
+
+
+class TestIntegrationLifecycle:
+    """End-to-end: run_skill through all 7 steps over real HTTP."""
+
+    def test_run_skill_completes(self, live_runner, live_workspace):
+        result = live_runner.run_skill(
+            skill_name="test-skill", args="--verbose",
+            workspace=live_workspace, model="mock-model", timeout_s=30)
+        assert result.exit_code == 0
+        assert result.stderr == ""
+        assert "executed the skill successfully" in result.stdout
+        assert result.token_usage == {"input": 150, "output": 42}
+        assert result.num_turns == 1
+        assert result.raw_output["status"] == "completed"
+
+    def test_output_file_downloaded(self, live_runner, live_workspace):
+        live_runner.run_skill(
+            skill_name="test-skill", args="",
+            workspace=live_workspace, model="mock-model")
+        result_file = live_workspace / "output" / "result.txt"
+        assert result_file.exists()
+        assert "Mock agent output" in result_file.read_text()
+
+    def test_container_cleaned_up(self, live_runner, live_workspace):
+        live_runner.run_skill(
+            skill_name="test-skill", args="",
+            workspace=live_workspace, model="mock-model")
+        assert len(_mock_containers) == 0
+        assert len(_mock_container_files) == 0
+
+    def test_skill_cached_across_runs(self, live_runner, live_workspace):
+        live_runner.run_skill(
+            skill_name="test-skill", args="",
+            workspace=live_workspace, model="mock-model")
+        count_after_first = len(_mock_skills)
+        live_runner.run_skill(
+            skill_name="test-skill", args="",
+            workspace=live_workspace, model="mock-model")
+        assert len(_mock_skills) == count_after_first
+
+    def test_model_override(self, live_runner, live_workspace):
+        result = live_runner.run_skill(
+            skill_name="test-skill", args="",
+            workspace=live_workspace, model="custom-model")
+        assert result.resolved_model == "custom-model"
+
+    def test_connection_error(self, tmp_path):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        skill_dir = tmp_path / ".skills" / "s"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# S")
+        runner = ResponsesAPIRunner(
+            base_url="http://127.0.0.1:1/v1",
+            api_key="fake", default_model="m")
+        result = runner.run_skill(
+            skill_name="s", args="", workspace=tmp_path, model="m")
+        assert result.exit_code == 1
+        assert result.stderr != ""

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -192,6 +192,43 @@ class TestRunnersRegistry:
         assert RUNNERS["responses-api"] is ResponsesAPIRunner
 
 
+class TestFromConfig:
+    def test_from_config_reads_settings(self):
+        from unittest.mock import MagicMock
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        config = MagicMock()
+        config.runner.settings = {
+            "base_url": "http://ogx:8080/v1",
+            "api_key": "sk-test",
+            "default_model": "llama-3",
+            "memory_limit_mb": 2048,
+        }
+        runner = ResponsesAPIRunner.from_config(config, log_prefix="test")
+        assert runner._base_url == "http://ogx:8080/v1"
+        assert runner._api_key == "sk-test"
+        assert runner._default_model == "llama-3"
+        assert runner._memory_limit_mb == 2048
+        assert runner._log_prefix == "test"
+
+    def test_from_config_overrides_take_precedence(self):
+        from unittest.mock import MagicMock
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        config = MagicMock()
+        config.runner.settings = {"default_model": "llama-3"}
+        runner = ResponsesAPIRunner.from_config(
+            config, default_model="gpt-4o")
+        assert runner._default_model == "gpt-4o"
+
+    def test_from_config_empty_settings(self):
+        from unittest.mock import MagicMock
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        config = MagicMock()
+        config.runner.settings = {}
+        runner = ResponsesAPIRunner.from_config(config)
+        assert runner._memory_limit_mb == 512
+        assert runner._network_policy is None
+
+
 class TestABCCompliance:
     def test_is_eval_runner_subclass(self):
         from agent_eval.agent.base import EvalRunner
@@ -368,6 +405,29 @@ class TestSkillUpload:
             assert upload_count == 1, (
                 f"Expected 1 API call, got {upload_count} — TOCTOU race")
 
+    def test_upload_follows_internal_symlink_files(self):
+        """Symlinked files inside the skill bundle must upload (harness symlinks)."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+        mock_client.skills.create.return_value = MagicMock(id="sk-1")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = Path(tmpdir) / "bundle"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text("# S")
+            (skill_dir / "data.txt").write_text("payload")
+            (skill_dir / "link.txt").symlink_to(skill_dir / "data.txt")
+
+            runner._upload_skill(mock_client, skill_dir, "bundle")
+
+            kw = mock_client.skills.create.call_args.kwargs["files"]
+            rels = {t[0] for t in kw}
+            assert "data.txt" in rels
+            assert "link.txt" in rels
+            by_rel = {t[0]: t[1] for t in kw}
+            assert by_rel["link.txt"] == b"payload"
+
 
 class TestContainerLifecycle:
     def test_create_container_attaches_skill(self):
@@ -460,8 +520,8 @@ class TestContainerLifecycle:
             assert "/workspace/src/main.py" in uploaded
             assert mock_client.containers.files.create.call_count == 2
 
-    def test_upload_workspace_skips_symlinks(self):
-        """Symlinks could read outside the workspace (CWE-59)."""
+    def test_upload_workspace_follows_safe_symlinks(self):
+        """Symlinks under the workspace are followed (symlinked skills, etc.)."""
         from agent_eval.agent.responses_api import ResponsesAPIRunner
         runner = ResponsesAPIRunner(base_url="http://localhost:8000")
         mock_client = MagicMock()
@@ -473,9 +533,27 @@ class TestContainerLifecycle:
             (ws / "link.txt").symlink_to(ws / "real.txt")
 
             uploaded = runner._upload_workspace(mock_client, "ctr-123", ws)
-            assert len(uploaded) == 1
+            assert len(uploaded) == 2
             assert "/workspace/real.txt" in uploaded
-            assert "/workspace/link.txt" not in uploaded
+            assert "/workspace/link.txt" in uploaded
+
+    def test_upload_workspace_skips_escape_symlinks(self):
+        """Symlinks resolving outside the workspace must not be uploaded."""
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        mock_client = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            ws = root / "ws"
+            ws.mkdir()
+            outside = root / "outside"
+            outside.mkdir()
+            (outside / "secret.txt").write_text("secret")
+            (ws / "evil.txt").symlink_to(outside / "secret.txt")
+
+            uploaded = runner._upload_workspace(mock_client, "ctr-123", ws)
+            assert uploaded == set()
 
     def test_download_syncs_both_new_and_modified_files(self):
         """Modified uploaded files must be synced back, not just new ones."""
@@ -794,7 +872,21 @@ class TestEdgeCases:
             skill_dir = ws / ".skills" / "my-skill"
             skill_dir.mkdir(parents=True)
             (skill_dir / "SKILL.md").write_text("# Skill")
-            assert runner._find_skill_dir(ws, "my-skill") == skill_dir
+            assert runner._find_skill_dir(ws, "my-skill") == skill_dir.resolve()
+
+    def test_find_skill_dir_resolves_symlink(self):
+        from agent_eval.agent.responses_api import ResponsesAPIRunner
+        runner = ResponsesAPIRunner(base_url="http://localhost:8000")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            real = root / "real-skill"
+            real.mkdir()
+            (real / "SKILL.md").write_text("# Real")
+            ws = root / "ws"
+            link = ws / "skills" / "my-skill"
+            link.parent.mkdir(parents=True)
+            link.symlink_to(real)
+            assert runner._find_skill_dir(ws, "my-skill") == real.resolve()
 
     def test_find_skill_dir_skills(self):
         from agent_eval.agent.responses_api import ResponsesAPIRunner
@@ -804,7 +896,7 @@ class TestEdgeCases:
             skill_dir = ws / "skills" / "my-skill"
             skill_dir.mkdir(parents=True)
             (skill_dir / "SKILL.md").write_text("# Skill")
-            assert runner._find_skill_dir(ws, "my-skill") == skill_dir
+            assert runner._find_skill_dir(ws, "my-skill") == skill_dir.resolve()
 
     def test_find_skill_dir_requires_skill_md(self):
         """A directory without SKILL.md must not match."""


### PR DESCRIPTION
## Summary

Implements [#49](https://github.com/opendatahub-io/agent-eval-harness/issues/49) — a Responses API compatible runner that uses the Skills API and Shell tool to execute skills in hosted containers.

- **New `ResponsesAPIRunner`** implementing the full 7-step lifecycle: skill upload (cached per run) → container create → workspace upload → execute via `/v1/responses` → result download → container cleanup → `RunResult`
- **Wired into the harness** via `RUNNERS["responses-api"]` and `execute.py` settings passthrough
- **54 tests** (unit + integration against an embedded mock Responses API server)
- **Demo script** (`tests/demo_responses_api.py`) for manual end-to-end simulation

### Key design decisions
- One container per case for eval correctness (no state leakage)
- Process-global, thread-safe skill cache (upload once, reuse across parallel cases)
- `openai` SDK as optional dependency (`pip install agent-eval-harness[openai]`)
- Skills attached to container at creation, not to tool environment

### What's needed for live testing
The Skills API (`/v1/skills`), Containers API (`/v1/containers`), and Shell tool are not yet fully implemented in OGX — see [ogx-ai/ogx#4962](https://github.com/ogx-ai/ogx/issues/4962). Runner is verified against a mock server; live testing blocked on OGX support.

## Test plan
- [x] 54 tests passing (unit + integration with embedded mock server)
- [x] Full test suite (107 tests) passing — no regressions
- [x] Demo script simulates 3 realistic cases end-to-end
- [ ] Live testing against OGX once Skills/Containers APIs land

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI Responses API runner to execute evaluation skills using OpenAI's Responses API with container-based execution, automatic workspace file handling, and seamless output retrieval

* **Chores**
  * Added OpenAI SDK (>=1.70) as an optional dependency
  * Updated gitignore to exclude additional knowledge and documentation directories
<!-- end of auto-generated comment: release notes by coderabbit.ai -->