### PR TITLE
Add --bare mode for reproducible headless execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ agent_eval/              # Python package (config, runner, state)
   state.py               # Shared state persistence (key-value store)
   agent/
     base.py              # EvalRunner ABC + RunResult
-    claude_code.py       # Claude Code CLI runner (claude --print)
+    claude_code.py       # Claude Code CLI runner (claude --bare --print)
     cli_runner.py        # Opaque CLI runner (arbitrary command templates)
     stream_capture.py    # Stream-json processing (events, timestamps, usage, hooks)
   mlflow/
@@ -147,6 +147,13 @@ eval-analyze, eval-dataset, eval-optimize, eval-review — authoring workflows
 
 ### EvalHub-managed (via provider)
 Execution, result storage, regression detection, OCI export (MLflow tracking is optional)
+
+## Claude Code References
+
+The harness runs skills via `claude --bare --print`. Key docs:
+- [Headless mode](https://code.claude.com/docs/en/headless) — `--bare`, `--print`, `--output-format`, `--allowed-tools`
+- [Tools reference](https://code.claude.com/docs/en/tools-reference) — tool names for permission rules (`Bash`, `Read`, `Edit`, `Skill`, etc.)
+- [Permissions](https://code.claude.com/docs/en/permissions) — `allow`/`deny` rule syntax, `ToolName(specifier)` patterns
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -105,8 +105,13 @@ class ClaudeCodeRunner(EvalRunner):
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
     ) -> RunResult:
+        # --bare skips auto-discovery of hooks, plugins, MCP servers, and
+        # settings, loading only what we pass via flags. This makes runs
+        # faster, reproducible, and independent of the machine's config.
+        # See: https://code.claude.com/docs/en/headless
         cmd = [
             "claude",
+            "--bare",
             "--print",
             "--model", model,
             "--output-format", "stream-json" if self._log_prefix else "json",

--- a/agent_eval/evalhub/adapter.py
+++ b/agent_eval/evalhub/adapter.py
@@ -63,6 +63,33 @@ except ImportError:
     EVALHUB_AVAILABLE = False
 
 
+def _ensure_case_settings(case_dir: Path, eval_config: "EvalConfig") -> Path:
+    """Create a minimal .claude/settings.json for a case workspace.
+
+    With --bare mode, Claude Code loads nothing automatically. This
+    ensures permissions from eval.yaml are available to the runner.
+    """
+    import json as _json
+
+    settings_dir = case_dir / ".claude"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    settings_path = settings_dir / "settings.json"
+
+    settings: dict[str, Any] = {}
+
+    # Merge eval.yaml permissions
+    perms = eval_config.permissions or {}
+    if perms.get("allow"):
+        settings.setdefault("permissions", {})["allow"] = list(perms["allow"])
+    if perms.get("deny"):
+        settings.setdefault("permissions", {})["deny"] = list(perms["deny"])
+
+    with open(settings_path, "w") as f:
+        _json.dump(settings, f, indent=2)
+
+    return settings_path
+
+
 def _resolve_arguments(template: str, input_data: dict) -> str:
     """Resolve {field} and {field?} placeholders from input.yaml data.
 
@@ -272,11 +299,17 @@ class AgentEvalAdapter(FrameworkAdapter):
                 timeout = eval_config.execution.timeout or 600
                 budget = eval_config.execution.max_budget_usd or 5.0
 
+                # Create minimal settings.json so --bare mode has
+                # permissions and plugin config. Without this, the
+                # runner would get no settings at all.
+                settings_path = _ensure_case_settings(case_dir, eval_config)
+
                 result = runner.run_skill(
                     skill_name=eval_config.skill,
                     args=args,
                     workspace=case_dir,
                     model=model_name,
+                    settings_path=settings_path,
                     max_budget_usd=budget,
                     timeout_s=timeout,
                 )

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -63,6 +63,7 @@ models:
 # If the skill under test invokes sub-skills via the Skill tool
 # (check its allowed-tools frontmatter for "Skill"), add "Skill"
 # to the allow list — otherwise nested skill calls silently fail.
+# Tool names and rule syntax: https://code.claude.com/docs/en/tools-reference
 permissions:
   allow: []     # Tool patterns to allow (e.g., "Skill", "Write(artifacts/**)")
   deny: []      # Tool patterns to block (e.g., "mcp__*")

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -56,7 +56,7 @@ Each case gets ALL files from the dataset case directory (not just input.yaml), 
 ## 2. Workspace → Execution
 
 **What execute.py does**:
-- Invokes the skill via the configured runner (e.g., `claude --print`)
+- Invokes the skill via the configured runner (e.g., `claude --bare --print`; see [headless docs](https://code.claude.com/docs/en/headless))
 - Passes `batch.yaml` content as the skill prompt via stdin
 - Captures stdout (stream-json events) and stderr
 - Writes `stdout.log` and `stderr.log` to `$AGENT_EVAL_RUNS_DIR/{id}/`
@@ -233,7 +233,7 @@ Note: `events.json` is generated at collection time by `collect.py` and includes
 
 ### Important: stdout format for Claude Code runner
 
-When `runner.type: claude-code`, `outputs["stdout"]` contains the **raw JSONL event stream** from `claude --print`, not plain text. Each line is a JSON object with `type` (`user`, `assistant`, `system`, `result`). Assistant text is in objects like:
+When `runner.type: claude-code`, `outputs["stdout"]` contains the **raw JSONL event stream** from `claude --bare --print --output-format stream-json` (see [streaming docs](https://code.claude.com/docs/en/headless#stream-responses)), not plain text. Each line is a JSON object with `type` (`user`, `assistant`, `system`, `result`). Assistant text is in objects like:
 
 ```json
 {"type": "assistant", "message": {"content": [{"type": "text", "text": "..."}]}}

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -56,7 +56,7 @@ Each case gets ALL files from the dataset case directory (not just input.yaml), 
 ## 2. Workspace → Execution
 
 **What execute.py does**:
-- Invokes the skill via the configured runner (e.g., `claude --bare --print`; see [headless docs](https://code.claude.com/docs/en/headless))
+- Invokes the skill via the configured runner (e.g., `claude --bare --print --output-format stream-json`; see [headless docs](https://code.claude.com/docs/en/headless))
 - Passes `batch.yaml` content as the skill prompt via stdin
 - Captures stdout (stream-json events) and stderr
 - Writes `stdout.log` and `stderr.log` to `$AGENT_EVAL_RUNS_DIR/{id}/`


### PR DESCRIPTION
## Summary
- Add `--bare` flag to Claude Code CLI invocation for faster, reproducible eval runs
- Fix EvalHub adapter to create minimal settings.json per case (was passing no settings at all)
- Add Claude Code documentation references to CLAUDE.md, eval-yaml-template.md, and data-pipeline.md

## Details

**`--bare` mode** ([docs](https://code.claude.com/docs/en/headless#start-faster-with-bare-mode)) skips auto-discovery of hooks, plugins, MCP servers, and settings files. The harness already builds self-contained workspaces with explicit `--settings`, `--allowed-tools`, `--plugin-dir`, and `--append-system-prompt` flags — `--bare` just stops Claude from also loading things outside the workspace that the harness didn't put there.

Benefits:
- **Faster startup**: no scanning `~/.claude/`, `.mcp.json`, marketplace cache per invocation
- **Reproducible**: same result on every machine regardless of user/project config
- **Explicit**: only flags passed by the harness take effect

**EvalHub adapter fix**: the `AgentEvalAdapter.run_benchmark_job()` path called `run_skill()` without `settings_path`, so the runner had no settings file. With `--bare` this means no permissions at all. New `_ensure_case_settings()` creates a minimal `.claude/settings.json` with permissions from eval.yaml before each case run.

**Doc references** added:
- [Headless mode](https://code.claude.com/docs/en/headless) — `--bare`, `--print`, streaming
- [Tools reference](https://code.claude.com/docs/en/tools-reference) — tool names for permission rules
- [Permissions](https://code.claude.com/docs/en/permissions) — `allow`/`deny` rule syntax

## Test plan
- [x] 123 tests pass, 0 regressions
- [ ] Run eval with `--bare` and verify identical results to without

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude Code CLI runner documentation to reflect correct `--bare --print` invocation
  * Added references to headless mode, tools reference, and permissions documentation
  * Updated YAML template and data pipeline docs with correct invocation and output format details

* **New Features**
  * Claude Code runner now operates in headless bare mode for explicit configuration control
  * Permissions can now be configured per case workspace via settings files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->