### PR TITLE
Fix annotation file path validation to skip non-filename strings

### DIFF
--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -75,10 +75,21 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
                     record["annotations"] = yaml.safe_load(f) or {}
             except (yaml.YAMLError, OSError):
                 pass
-            # Load annotation-referenced files into the record
+            # Load annotation-referenced files into the record.
+            # Only treat values as file paths if they look like filenames:
+            # - Short enough to be a valid filename (< 256 chars)
+            # - No newlines (multi-line strings are descriptions, not paths)
+            # - No spaces at start/end (paths are usually trimmed)
             for key, val in record["annotations"].items():
                 if isinstance(val, str) and not val.startswith("/"):
-                    ref_path = (dataset_root / case_id / val).resolve()
+                    # Skip values that don't look like filenames
+                    if len(val) > 255 or "\n" in val or val != val.strip():
+                        continue
+                    try:
+                        ref_path = (dataset_root / case_id / val).resolve()
+                    except OSError:
+                        # Path resolution can fail for invalid characters
+                        continue
                     if (ref_path.is_file() and not ref_path.is_symlink()
                             and ref_path.is_relative_to(dataset_root)):
                         try:


### PR DESCRIPTION
## Summary

Fixes a bug in `load_case_record()` where multi-line annotation values (like `root_cause_description`) were incorrectly treated as file paths, causing `OSError: [Errno 36] File name too long`.

## Background

Annotations are the ground truth for each eval case — they live in `annotations.yaml` alongside `input.yaml`. The harness has a convenience feature: if an annotation value happens to be a filename that exists in the case directory, it reads that file and replaces the annotation value with the file contents. This lets eval authors store large expected outputs in separate files:

```yaml
# annotations.yaml
expected_report: expected_report.txt   # harness reads this file automatically
```

## The Bug

The code tries to resolve *every* string annotation value as a file path:

```python
for key, val in record["annotations"].items():
    if isinstance(val, str) and not val.startswith("/"):
        ref_path = (dataset_root / case_id / val).resolve()  # boom
```

When `val` is a multi-line description like:

```yaml
root_cause_description: >
  A change in cluster-kube-apiserver-operator (CKAO PR #2032) caused
  bootstrap failures in metal IPI IPv6 disconnected environments...
```

...the entire text is passed to `pathlib.resolve()`, which blows up with `OSError: [Errno 36] File name too long`.

## This Fix

This PR adds guards to skip values that are obviously not filenames (too long, contain newlines, have leading/trailing whitespace), and wraps the `resolve()` call in a try/except for any remaining edge cases. This is a backwards-compatible fix that doesn't change the existing API.

## Recommendation for upstream

The implicit "any annotation value might be a file path" convention is fragile. A better long-term approach would be to use an explicit `file:///` prefix convention:

```yaml
# Explicit — no ambiguity
expected_report: "file:///expected_report.txt"
notes: "This is just a string, not a file reference"
```

This would eliminate the guessing entirely. The current implicit behavior could be kept behind a deprecation warning for backwards compatibility. Happy to submit a follow-up PR for this if there's interest.

## Test plan

- [x] Tested against `eval-install-failure.yaml` case with multi-line `root_cause_description` annotation
- [x] Tested against `eval-hello-world.yaml` case with deliberately long `long_description` annotation
- [ ] Add unit test for `load_case_record()` with multi-line annotations

🤖 Generated with [Claude Code](https://claude.ai/code)