### PR TITLE
feat: add dataset.workspace.files for provisioning case source files

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -364,7 +364,9 @@ class EvalConfig:
                 dataset.get("path", ""), "dataset.path",
                 allow_absolute=True),
             dataset_schema=dataset.get("schema", ""),
-            dataset_input_files_dir=dataset.get("input_files_dir", "files"),
+            dataset_input_files_dir=_validate_relative_path(
+                dataset.get("input_files_dir", "files"),
+                "dataset.input_files_dir"),
         )
 
         # Outputs (path or tool)

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -8,9 +8,12 @@ import sys
 import yaml
 
 
-def _validate_relative_path(value: str, field_name: str,
-                            reject_root: bool = False,
-                            allow_absolute: bool = False) -> str:
+def _validate_relative_path(
+    value: str,
+    field_name: str,
+    reject_root: bool = False,
+    allow_absolute: bool = False,
+) -> str:
     """Reject parent-traversing paths (and optionally absolute paths).
 
     Args:
@@ -33,7 +36,8 @@ def _validate_relative_path(value: str, field_name: str,
         raise ValueError(
             f"{field_name} cannot be '.' (project root) — use a subdirectory. "
             f"Outputs must be in a named subdirectory so the harness can "
-            f"identify, collect, and clean them without affecting the project.")
+            f"identify, collect, and clean them without affecting the project."
+        )
     return value
 
 
@@ -43,6 +47,27 @@ class DiscoveryResult:
     path: Path
     eval_name: str
     is_root: bool
+
+
+@dataclass
+class WorkspaceConfig:
+    """Workspace file provisioning for evaluation cases.
+
+    ``files`` is a whitelist of relative paths inside each case directory
+    to copy into the agent workspace.  Directory entries copy recursively;
+    file entries copy the single file.  Paths not listed are left behind.
+    """
+
+    files: list = field(default_factory=list)
+
+
+@dataclass
+class DatasetConfig:
+    """Dataset location, schema, and workspace provisioning."""
+
+    path: str = ""
+    schema: str = ""
+    workspace: WorkspaceConfig = field(default_factory=WorkspaceConfig)
 
 
 @dataclass
@@ -60,20 +85,22 @@ class OutputConfig:
       name starts with the expanded prefix are assigned to that case.
       Use "*" for shared directories (copied to every case).
     """
-    path: str = ""       # File artifacts directory
-    tool: str = ""       # Tool call name/pattern to capture
+
+    path: str = ""  # File artifacts directory
+    tool: str = ""  # Tool call name/pattern to capture
     schema: str = ""
     batch_pattern: str = ""  # Batch collection pattern (empty = auto-detect)
-    types: dict = None   # Semantic types for artifacts (filename or glob → type)
+    types: dict = None  # Semantic types for artifacts (filename or glob → type)
 
 
 @dataclass
 class TracesConfig:
     """What execution traces to capture and make available to judges."""
-    stdout: bool = True    # Capture stdout.log
-    stderr: bool = True    # Capture stderr.log
-    events: bool = True    # Parse JSONL into events.json
-    metrics: bool = True   # Capture run_result.json metrics
+
+    stdout: bool = True  # Capture stdout.log
+    stderr: bool = True  # Capture stderr.log
+    events: bool = True  # Parse JSONL into events.json
+    metrics: bool = True  # Capture run_result.json metrics
 
 
 @dataclass
@@ -84,14 +111,16 @@ class ToolInputConfig:
     eval-analyze populates this based on skill analysis. eval-run resolves
     it to concrete patterns at workspace setup time.
     """
-    match: str = ""           # Natural language: what to intercept (tools, scripts, APIs)
-    prompt: str = ""          # Natural language instruction for how to handle
-    prompt_file: str = ""     # External file with detailed instructions
+
+    match: str = ""  # Natural language: what to intercept (tools, scripts, APIs)
+    prompt: str = ""  # Natural language instruction for how to handle
+    prompt_file: str = ""  # External file with detailed instructions
 
 
 @dataclass
 class InputsConfig:
     """Tool interception configuration for headless execution."""
+
     tools: list = field(default_factory=list)  # List of ToolInputConfig
 
 
@@ -119,6 +148,7 @@ class ExecutionConfig:
       (e.g., ``$JIRA_TOKEN`` → ``os.environ["JIRA_TOKEN"]``).  Missing
       vars are silently omitted.  Literal values are passed through as-is.
     """
+
     mode: str = "case"
     arguments: str = ""
     timeout: Optional[int] = None
@@ -140,6 +170,7 @@ class RunnerConfig:
     references resolved from the caller's environment.  Additive to the
     runner's built-in safe defaults (Claude Code allowlist).
     """
+
     type: str = "claude-code"
     command: Optional[Union[str, list]] = None  # CLI runner: command template
     settings: dict = field(default_factory=dict)
@@ -161,6 +192,7 @@ class MlflowConfig:
         MLFLOW_TRACKING_URI env var.
     tags: tags applied to every run logged for this eval.
     """
+
     experiment: str = ""
     tracking_uri: Optional[str] = None
     tags: dict = field(default_factory=dict)
@@ -176,6 +208,7 @@ class ModelsConfig:
     - judge: per-judge JudgeConfig.model > models.judge > EVAL_JUDGE_MODEL
       env var (must resolve to non-empty for LLM judges)
     """
+
     skill: Optional[str] = None
     subagent: Optional[str] = None
     judge: Optional[str] = None
@@ -191,6 +224,7 @@ class JudgeConfig:
     - LLM judge: `prompt` or `prompt_file` contains evaluation instructions
     - External code: `module` and `function` reference a Python callable
     """
+
     name: str = ""
     description: str = ""  # What this judge checks (context for LLM judges)
     # Condition — Python expression evaluated against the outputs dict.
@@ -202,7 +236,9 @@ class JudgeConfig:
     # LLM judge / pairwise
     prompt: str = ""
     prompt_file: str = ""
-    context: list = field(default_factory=list)  # File paths loaded as supplementary context
+    context: list = field(
+        default_factory=list
+    )  # File paths loaded as supplementary context
     feedback_type: str = ""  # Optional: int, float, bool, str. Inferred if omitted.
     model: str = ""  # Override model for this judge (pairwise, LLM)
     # External code judge
@@ -222,6 +258,7 @@ class EvalConfig:
     in natural language. The harness interprets these descriptions via LLM
     (once, cached) to drive prepare, collect, and score steps.
     """
+
     name: str = ""
     description: str = ""
     skill: str = ""
@@ -239,10 +276,8 @@ class EvalConfig:
     # MLflow logging target
     mlflow: MlflowConfig = field(default_factory=MlflowConfig)
 
-    # Dataset — natural language schema + path
-    dataset_path: str = ""
-    dataset_schema: str = ""
-    dataset_input_files_dir: str = "files"
+    # Dataset — location, schema, and workspace file provisioning
+    dataset: DatasetConfig = field(default_factory=DatasetConfig)
 
     # Outputs — file artifacts and/or tool calls
     outputs: list = field(default_factory=list)
@@ -311,10 +346,10 @@ class EvalConfig:
         command = runner_raw.get("command")
         if command is not None:
             valid_list = isinstance(command, list) and all(
-                isinstance(x, str) for x in command)
+                isinstance(x, str) for x in command
+            )
             if not (isinstance(command, str) or valid_list):
-                raise ValueError(
-                    "runner.command must be a string or list of strings")
+                raise ValueError("runner.command must be a string or list of strings")
         runner = RunnerConfig(
             type=runner_raw.get("type", "claude-code"),
             command=command,
@@ -350,6 +385,26 @@ class EvalConfig:
             tags=mlflow_raw.get("tags", {}) or {},
         )
 
+        # Dataset — path, schema, and workspace file provisioning
+        ws_raw = dataset.get("workspace", {}) or {}
+        ws_files_raw = ws_raw.get("files", []) or []
+        ws_files = []
+        for i, f in enumerate(ws_files_raw):
+            if not isinstance(f, str):
+                raise ValueError(
+                    f"dataset.workspace.files[{i}] must be a string, got {type(f).__name__}"
+                )
+            ws_files.append(
+                _validate_relative_path(f.rstrip("/"), "dataset.workspace.files")
+            )
+        dataset_config = DatasetConfig(
+            path=_validate_relative_path(
+                dataset.get("path", ""), "dataset.path", allow_absolute=True
+            ),
+            schema=dataset.get("schema", ""),
+            workspace=WorkspaceConfig(files=ws_files),
+        )
+
         config = cls(
             name=raw.get("name", path.stem),
             description=raw.get("description", ""),
@@ -360,35 +415,33 @@ class EvalConfig:
             models=models,
             mlflow=mlflow,
             config_dir=path.resolve().parent,
-            dataset_path=_validate_relative_path(
-                dataset.get("path", ""), "dataset.path",
-                allow_absolute=True),
-            dataset_schema=dataset.get("schema", ""),
-            dataset_input_files_dir=_validate_relative_path(
-                dataset.get("input_files_dir", "files"),
-                "dataset.input_files_dir"),
+            dataset=dataset_config,
         )
 
         # Outputs (path or tool)
         for i, o in enumerate(raw.get("outputs", [])):
-            config.outputs.append(OutputConfig(
-                path=_validate_relative_path(
-                    o.get("path", ""), f"outputs[{i}].path",
-                    reject_root=True),
-                tool=o.get("tool", ""),
-                schema=o.get("schema", ""),
-                batch_pattern=o.get("batch_pattern", ""),
-                types=o.get("types") or None,
-            ))
+            config.outputs.append(
+                OutputConfig(
+                    path=_validate_relative_path(
+                        o.get("path", ""), f"outputs[{i}].path", reject_root=True
+                    ),
+                    tool=o.get("tool", ""),
+                    schema=o.get("schema", ""),
+                    batch_pattern=o.get("batch_pattern", ""),
+                    types=o.get("types") or None,
+                )
+            )
 
         # Inputs (tool interception)
         inputs_raw = raw.get("inputs", {})
-        for t in (inputs_raw.get("tools") or []):
-            config.inputs.tools.append(ToolInputConfig(
-                match=t.get("match", ""),
-                prompt=t.get("prompt", ""),
-                prompt_file=t.get("prompt_file", ""),
-            ))
+        for t in inputs_raw.get("tools") or []:
+            config.inputs.tools.append(
+                ToolInputConfig(
+                    match=t.get("match", ""),
+                    prompt=t.get("prompt", ""),
+                    prompt_file=t.get("prompt_file", ""),
+                )
+            )
 
         # Traces
         traces = raw.get("traces", {})
@@ -407,28 +460,32 @@ class EvalConfig:
                 builtin_val = ""
             if not isinstance(builtin_val, str):
                 raise ValueError(
-                    f"Judge '{j.get('name', '')}': 'builtin' must be a string")
+                    f"Judge '{j.get('name', '')}': 'builtin' must be a string"
+                )
             args_val = j.get("arguments")
             if args_val is None:
                 args_val = {}
             elif not isinstance(args_val, dict):
                 raise ValueError(
-                    f"Judge '{j.get('name', '')}': 'arguments' must be a mapping")
-            config.judges.append(JudgeConfig(
-                name=j.get("name", ""),
-                description=j.get("description", ""),
-                condition=j.get("if", ""),
-                check=j.get("check", ""),
-                prompt=j.get("prompt", ""),
-                prompt_file=j.get("prompt_file", ""),
-                context=j.get("context", []),
-                feedback_type=j.get("feedback_type", ""),
-                model=j.get("model", ""),
-                module=j.get("module", ""),
-                function=j.get("function", ""),
-                builtin=builtin_val,
-                arguments=args_val,
-            ))
+                    f"Judge '{j.get('name', '')}': 'arguments' must be a mapping"
+                )
+            config.judges.append(
+                JudgeConfig(
+                    name=j.get("name", ""),
+                    description=j.get("description", ""),
+                    condition=j.get("if", ""),
+                    check=j.get("check", ""),
+                    prompt=j.get("prompt", ""),
+                    prompt_file=j.get("prompt_file", ""),
+                    context=j.get("context", []),
+                    feedback_type=j.get("feedback_type", ""),
+                    model=j.get("model", ""),
+                    module=j.get("module", ""),
+                    function=j.get("function", ""),
+                    builtin=builtin_val,
+                    arguments=args_val,
+                )
+            )
 
         # Thresholds
         config.thresholds = raw.get("thresholds", {})

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -242,6 +242,7 @@ class EvalConfig:
     # Dataset — natural language schema + path
     dataset_path: str = ""
     dataset_schema: str = ""
+    dataset_input_files_dir: str = "files"
 
     # Outputs — file artifacts and/or tool calls
     outputs: list = field(default_factory=list)
@@ -363,6 +364,7 @@ class EvalConfig:
                 dataset.get("path", ""), "dataset.path",
                 allow_absolute=True),
             dataset_schema=dataset.get("schema", ""),
+            dataset_input_files_dir=dataset.get("input_files_dir", "files"),
         )
 
         # Outputs (path or tool)

--- a/agent_eval/evalhub/adapter.py
+++ b/agent_eval/evalhub/adapter.py
@@ -191,13 +191,13 @@ class AgentEvalAdapter(FrameworkAdapter):
         log.info("Loading eval config from %s", self._eval_config_path)
         eval_config = EvalConfig.from_yaml(self._eval_config_path)
         log.info("Eval config loaded: skill=%s, dataset_path=%s, %d judges",
-                 eval_config.skill, eval_config.dataset_path, len(eval_config.judges))
+                 eval_config.skill, eval_config.dataset.path, len(eval_config.judges))
 
         # 2. Load dataset — use local path if it exists, otherwise download from S3
         #    Always copy to a writable temp dir (baked-in container paths are read-only)
         params = config.parameters or {}
         eval_config_dir = Path(self._eval_config_path).parent
-        local_dataset = eval_config_dir / eval_config.dataset_path
+        local_dataset = eval_config_dir / eval_config.dataset.path
         _tmp_dir = tempfile.TemporaryDirectory()
         tmp_root = Path(_tmp_dir.name)
         if local_dataset.is_dir() and any(local_dataset.iterdir()):

--- a/skills/eval-mlflow/scripts/sync_dataset.py
+++ b/skills/eval-mlflow/scripts/sync_dataset.py
@@ -79,7 +79,7 @@ def main():
         sys.exit(1)
 
     # Find case directories
-    cases_dir = config.resolve_path(config.dataset_path)
+    cases_dir = config.resolve_path(config.dataset.path)
     if not cases_dir.exists():
         print(f"ERROR: dataset path not found: {cases_dir}", file=sys.stderr)
         sys.exit(1)

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -70,8 +70,8 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
     # --- Annotations (from dataset case directory) ---
     record["annotations"] = {}
     case_id = case_dir.name
-    if config.dataset_path:
-        dataset_root = config.resolve_path(config.dataset_path).resolve()
+    if config.dataset.path:
+        dataset_root = config.resolve_path(config.dataset.path).resolve()
         annotations_path = (dataset_root / case_id / "annotations.yaml").resolve()
         if (annotations_path.is_relative_to(dataset_root)
                 and annotations_path.is_file()

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -322,8 +322,9 @@ def _read_input(case_dir, config=None):
     _SKIP_NAMES = {"answers", "reference", "expected", "gold"}
     if config is not None:
         ws = getattr(getattr(config, "dataset", None), "workspace", None)
-        for f in getattr(ws, "files", None) or []:
-            _SKIP_NAMES.add(Path(f).parts[0])
+        _SKIP_NAMES = _SKIP_NAMES | {
+            Path(f).parts[0] for f in (getattr(ws, "files", None) or [])
+        }
 
     # First pass: look for a file named 'input.*'
     for suffix in (".yaml", ".yml", ".json"):

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import yaml
 
 from agent_eval.config import EvalConfig
+from workspace_files import _copy_input_files
 
 
 def main():
@@ -285,28 +286,6 @@ def _find_input_file(case_dir):
         if candidate.is_file():
             return candidate
     return None
-
-
-def _copy_input_files(case_dir, workspace, config):
-    """Copy the input files directory into the workspace.
-
-    If the case directory contains a subdirectory matching
-    ``config.dataset_input_files_dir`` (default: ``files/``), its contents
-    are recursively copied into the workspace root, preserving relative
-    paths.  This allows test cases to ship source code, config files, or
-    other artifacts the agent needs without embedding them in input.yaml.
-    """
-    dir_name = getattr(config, "dataset_input_files_dir", "files") or "files"
-    files_dir = case_dir / dir_name
-    if not files_dir.is_dir():
-        return
-    for item in files_dir.rglob("*"):
-        if not item.is_file():
-            continue
-        rel = item.relative_to(files_dir)
-        dst = workspace / rel
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(item, dst)
 
 
 def _read_input(case_dir):

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -113,6 +113,9 @@ def main():
             batch_entries.append(input_content)
             case_order.append({"case_id": case_dir.name, "entry_count": 1})
 
+        # Copy input files directory if present
+        _copy_input_files(case_dir, workspace, config)
+
     # Write batch.yaml
     with open(workspace / "batch.yaml", "w") as f:
         yaml.dump(batch_entries, f, default_flow_style=False,
@@ -208,6 +211,11 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
         if answers_src.is_file():
             shutil.copy2(answers_src, case_ws / "answers.yaml")
 
+        # Copy input files directory if present (e.g., source code for the
+        # agent to work on). Contents are placed at the workspace root,
+        # preserving relative paths within the directory.
+        _copy_input_files(case_dir, case_ws, config)
+
         # Create output directories
         for output in config.outputs:
             if output.path and output.path != ".":
@@ -279,6 +287,28 @@ def _find_input_file(case_dir):
     return None
 
 
+def _copy_input_files(case_dir, workspace, config):
+    """Copy the input files directory into the workspace.
+
+    If the case directory contains a subdirectory matching
+    ``config.dataset_input_files_dir`` (default: ``files/``), its contents
+    are recursively copied into the workspace root, preserving relative
+    paths.  This allows test cases to ship source code, config files, or
+    other artifacts the agent needs without embedding them in input.yaml.
+    """
+    dir_name = getattr(config, "dataset_input_files_dir", "files") or "files"
+    files_dir = case_dir / dir_name
+    if not files_dir.is_dir():
+        return
+    for item in files_dir.rglob("*"):
+        if not item.is_file():
+            continue
+        rel = item.relative_to(files_dir)
+        dst = workspace / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, dst)
+
+
 def _read_input(case_dir):
     """Read the input file from a case directory.
 
@@ -286,7 +316,7 @@ def _read_input(case_dir):
     Prefers files named 'input.*', then falls back to first parseable file.
     Skips known non-input files like answers.yaml and reference.*.
     """
-    _SKIP_NAMES = {"answers", "reference", "expected", "gold"}
+    _SKIP_NAMES = {"answers", "reference", "expected", "gold", "files"}
 
     # First pass: look for a file named 'input.*'
     for suffix in (".yaml", ".yml", ".json"):

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -31,19 +31,23 @@ from workspace_files import _copy_input_files
 
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("--config", required=True)
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--cases", nargs="*", default=None)
-    parser.add_argument("--symlinks", default=None,
-                        help="Comma-separated dirs/files to symlink into workspace "
-                             "(default: scripts,.claude,CLAUDE.md,.context,skills)")
+    parser.add_argument(
+        "--symlinks",
+        default=None,
+        help="Comma-separated dirs/files to symlink into workspace "
+        "(default: scripts,.claude,CLAUDE.md,.context,skills)",
+    )
     args = parser.parse_args()
 
     config = EvalConfig.from_yaml(args.config)
 
-    cases_dir = config.resolve_path(config.dataset_path)
+    cases_dir = config.resolve_path(config.dataset.path)
     if not cases_dir.exists():
         print(f"ERROR: dataset path not found: {cases_dir}", file=sys.stderr)
         sys.exit(1)
@@ -102,14 +106,16 @@ def main():
 
     for case_dir in case_dirs:
         # Find the input file (first .yaml or .json in the case dir)
-        input_content = _read_input(case_dir)
+        input_content = _read_input(case_dir, config)
         if input_content is None:
             continue
 
         # Flatten list inputs so batch.yaml is a single flat list
         if isinstance(input_content, list):
             batch_entries.extend(input_content)
-            case_order.append({"case_id": case_dir.name, "entry_count": len(input_content)})
+            case_order.append(
+                {"case_id": case_dir.name, "entry_count": len(input_content)}
+            )
         else:
             batch_entries.append(input_content)
             case_order.append({"case_id": case_dir.name, "entry_count": 1})
@@ -119,8 +125,9 @@ def main():
 
     # Write batch.yaml
     with open(workspace / "batch.yaml", "w") as f:
-        yaml.dump(batch_entries, f, default_flow_style=False,
-                  allow_unicode=True, width=120)
+        yaml.dump(
+            batch_entries, f, default_flow_style=False, allow_unicode=True, width=120
+        )
 
     # Write case order
     with open(workspace / "case_order.yaml", "w") as f:
@@ -137,15 +144,15 @@ def main():
     skip_symlinks = {".claude"}
     symlink_names = (
         [s.strip() for s in args.symlinks.split(",") if s.strip()]
-        if args.symlinks else default_symlinks
+        if args.symlinks
+        else default_symlinks
     )
     for name in symlink_names:
         if name in skip_symlinks:
             continue
         p = Path(name)
         if p.is_absolute() or ".." in p.parts:
-            print(f"WARNING: skipping invalid symlink entry: {name}",
-                  file=sys.stderr)
+            print(f"WARNING: skipping invalid symlink entry: {name}", file=sys.stderr)
             continue
         target = project_root / name
         link = workspace / name
@@ -189,7 +196,8 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
     default_symlinks = ["scripts", ".claude", "CLAUDE.md", ".context", "skills"]
     symlink_names = (
         [s.strip() for s in args.symlinks.split(",") if s.strip()]
-        if args.symlinks else default_symlinks
+        if args.symlinks
+        else default_symlinks
     )
 
     case_order = []
@@ -227,16 +235,31 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
                     out.mkdir(parents=True, exist_ok=True)
 
         # Snapshot initial state so collect.py can diff for in-place edits
-        _git_env = {**os.environ,
-                    "GIT_AUTHOR_NAME": "eval-harness",
-                    "GIT_AUTHOR_EMAIL": "eval@harness",
-                    "GIT_COMMITTER_NAME": "eval-harness",
-                    "GIT_COMMITTER_EMAIL": "eval@harness"}
-        subprocess.run(["git", "-C", str(case_ws), "add", "-A"],
-                       check=True, capture_output=True)
-        subprocess.run(["git", "-C", str(case_ws), "commit", "-q",
-                        "-m", "initial", "--allow-empty"],
-                       check=True, capture_output=True, env=_git_env)
+        _git_env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "eval-harness",
+            "GIT_AUTHOR_EMAIL": "eval@harness",
+            "GIT_COMMITTER_NAME": "eval-harness",
+            "GIT_COMMITTER_EMAIL": "eval@harness",
+        }
+        subprocess.run(
+            ["git", "-C", str(case_ws), "add", "-A"], check=True, capture_output=True
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(case_ws),
+                "commit",
+                "-q",
+                "-m",
+                "initial",
+                "--allow-empty",
+            ],
+            check=True,
+            capture_output=True,
+            env=_git_env,
+        )
 
         # Symlink project resources (skip .claude — we create our own)
         for name in symlink_names:
@@ -288,14 +311,19 @@ def _find_input_file(case_dir):
     return None
 
 
-def _read_input(case_dir):
+def _read_input(case_dir, config=None):
     """Read the input file from a case directory.
 
     Returns the parsed content (dict) or None if no input file found.
     Prefers files named 'input.*', then falls back to first parseable file.
     Skips known non-input files like answers.yaml and reference.*.
+    When *config* is provided, workspace file roots are also skipped.
     """
-    _SKIP_NAMES = {"answers", "reference", "expected", "gold", "files"}
+    _SKIP_NAMES = {"answers", "reference", "expected", "gold"}
+    if config is not None:
+        ws = getattr(getattr(config, "dataset", None), "workspace", None)
+        for f in getattr(ws, "files", None) or []:
+            _SKIP_NAMES.add(Path(f).parts[0])
 
     # First pass: look for a file named 'input.*'
     for suffix in (".yaml", ".yml", ".json"):
@@ -324,6 +352,7 @@ def _parse_file(path):
                 return yaml.safe_load(f)
         elif path.suffix == ".json":
             import json
+
             with open(path) as f:
                 return json.load(f)
     except Exception as e:
@@ -342,13 +371,13 @@ def _expand_symlink_permissions(allow_list):
     """
     extras = []
     for pattern in allow_list:
-        m = re.match(r'(Write|Edit|Bash)\((.+)\)', pattern)
+        m = re.match(r"(Write|Edit|Bash)\((.+)\)", pattern)
         if not m:
             continue
         tool, glob_path = m.groups()
         # Extract the directory prefix (everything before the first glob char)
-        prefix = re.split(r'[*?]', glob_path, maxsplit=1)[0].rstrip('/')
-        if not prefix or not prefix.startswith('/'):
+        prefix = re.split(r"[*?]", glob_path, maxsplit=1)[0].rstrip("/")
+        if not prefix or not prefix.startswith("/"):
             continue
         resolved = str(Path(prefix).resolve())
         if resolved != prefix:
@@ -402,13 +431,18 @@ def _carry_over_permissions(settings):
             if resolved != d and resolved not in dirs:
                 dirs.append(resolved)
         settings.setdefault("permissions", {}).setdefault(
-            "additionalDirectories", []).extend(dirs)
+            "additionalDirectories", []
+        ).extend(dirs)
 
 
 def _merge_harness_permissions(settings, config):
     """Merge eval.yaml permissions.allow into settings so named subagents
     (which may not inherit --allowed-tools) receive the harness patterns."""
-    allow = (config.permissions or {}).get("allow") if hasattr(config, "permissions") else None
+    allow = (
+        (config.permissions or {}).get("allow")
+        if hasattr(config, "permissions")
+        else None
+    )
     if not allow:
         return
     harness_allow = _expand_symlink_permissions(list(allow))
@@ -464,10 +498,12 @@ def _setup_subagent_only_hook(workspace, config):
     # Grant project root access
     project_root = str(Path.cwd().resolve())
     settings.setdefault("permissions", {}).setdefault(
-        "additionalDirectories", []).append(project_root)
+        "additionalDirectories", []
+    ).append(project_root)
 
     # Add SubagentStop hook
     from agent_eval.agent.stream_capture import setup_subagent_hook
+
     subagent_dir = str((workspace / "subagents").resolve())
     setup_subagent_hook(settings, subagent_dir)
 
@@ -491,15 +527,25 @@ def _extract_tool_patterns(match_text):
     at runtime by reading eval.md.
     """
     import re
+
     patterns = []
     # Known tool names
-    known_tools = ["AskUserQuestion", "Bash", "Read", "Write", "Edit",
-                   "Glob", "Grep", "Agent", "Skill"]
+    known_tools = [
+        "AskUserQuestion",
+        "Bash",
+        "Read",
+        "Write",
+        "Edit",
+        "Glob",
+        "Grep",
+        "Agent",
+        "Skill",
+    ]
     for tool in known_tools:
         if tool.lower() in match_text.lower():
             patterns.append(tool)
     # MCP tool patterns (mcp__something__*)
-    for m in re.finditer(r'(mcp__\w+(?:__\w+)*(?:\*)?)', match_text):
+    for m in re.finditer(r"(mcp__\w+(?:__\w+)*(?:\*)?)", match_text):
         patterns.append(m.group(1))
     # If nothing found, add "Bash" as fallback for script-based interception
     if not patterns and ("script" in match_text.lower() or "api" in match_text.lower()):
@@ -550,13 +596,17 @@ def _setup_tool_hooks(workspace, config):
 
     settings = {"hooks": {"PreToolUse": []}}
     for matcher in sorted(hook_matchers):
-        settings["hooks"]["PreToolUse"].append({
-            "matcher": matcher,
-            "hooks": [{
-                "type": "command",
-                "command": f"python3 {workspace}/hooks/tools.py",
-            }],
-        })
+        settings["hooks"]["PreToolUse"].append(
+            {
+                "matcher": matcher,
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": f"python3 {workspace}/hooks/tools.py",
+                    }
+                ],
+            }
+        )
 
     # Carry over permissions (allow, deny, additionalDirectories)
     _carry_over_permissions(settings)
@@ -567,13 +617,15 @@ def _setup_tool_hooks(workspace, config):
     # scripts, context) can be read by the sandbox.
     project_root = str(Path.cwd().resolve())
     settings.setdefault("permissions", {}).setdefault(
-        "additionalDirectories", []).append(project_root)
+        "additionalDirectories", []
+    ).append(project_root)
 
     # Add SubagentStop hook to capture background agent transcripts.
     # The hook copies each subagent's .jsonl file to workspace/subagents/.
     # Requires session persistence ON (the runner must NOT pass
     # --no-session-persistence) so transcript files survive until the hook fires.
     from agent_eval.agent.stream_capture import setup_subagent_hook
+
     subagent_dir = str((workspace / "subagents").resolve())
     setup_subagent_hook(settings, subagent_dir)
 

--- a/skills/eval-run/scripts/workspace_files.py
+++ b/skills/eval-run/scripts/workspace_files.py
@@ -5,34 +5,53 @@ side effects from workspace.py.
 """
 
 import shutil
-from pathlib import Path
 
 
 def _copy_input_files(case_dir, workspace, config):
-    """Copy the input files directory into the workspace.
+    """Copy workspace files from the case directory into the workspace.
 
-    If the case directory contains a subdirectory matching
-    ``config.dataset_input_files_dir`` (default: ``files/``), its contents
-    are recursively copied into the workspace root, preserving relative
-    paths.  This allows test cases to ship source code, config files, or
-    other artifacts the agent needs without embedding them in input.yaml.
-
-    Symlinks are skipped to prevent copying targets outside the files
-    directory.
+    Iterates ``config.dataset.workspace.files`` and copies each listed
+    path from *case_dir* into *workspace*, preserving relative structure.
+    Directory entries are copied recursively.  Symlinks are skipped to
+    prevent escaping the case directory.
     """
-    dir_name = getattr(config, "dataset_input_files_dir", "files") or "files"
-    files_dir = case_dir / dir_name
-    if not files_dir.is_dir():
+    ds = getattr(config, "dataset", None)
+    if ds is None:
         return
-    resolved_root = files_dir.resolve()
-    for item in files_dir.rglob("*"):
+    ws = getattr(ds, "workspace", None)
+    if ws is None:
+        return
+    files = ws.files or []
+    if not files:
+        return
+
+    case_root = case_dir.resolve()
+    for entry in files:
+        src = case_dir / entry
+        if src.is_symlink():
+            continue
+        if src.is_dir():
+            _copy_tree(src, case_dir, workspace, case_root)
+        elif src.is_file():
+            if not src.resolve().is_relative_to(case_root):
+                continue
+            rel = src.relative_to(case_dir)
+            dst = workspace / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+
+
+def _copy_tree(src_dir, case_dir, workspace, case_root):
+    """Recursively copy a directory, skipping symlinks."""
+    resolved_root = src_dir.resolve()
+    for item in src_dir.rglob("*"):
         if item.is_symlink():
             continue
         if not item.is_file():
             continue
         if not item.resolve().is_relative_to(resolved_root):
             continue
-        rel = item.relative_to(files_dir)
+        rel = item.relative_to(case_dir)
         dst = workspace / rel
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(item, dst)

--- a/skills/eval-run/scripts/workspace_files.py
+++ b/skills/eval-run/scripts/workspace_files.py
@@ -1,0 +1,38 @@
+"""Helpers for copying input files into eval workspaces.
+
+Extracted so tests can import without triggering agent_eval._bootstrap
+side effects from workspace.py.
+"""
+
+import shutil
+from pathlib import Path
+
+
+def _copy_input_files(case_dir, workspace, config):
+    """Copy the input files directory into the workspace.
+
+    If the case directory contains a subdirectory matching
+    ``config.dataset_input_files_dir`` (default: ``files/``), its contents
+    are recursively copied into the workspace root, preserving relative
+    paths.  This allows test cases to ship source code, config files, or
+    other artifacts the agent needs without embedding them in input.yaml.
+
+    Symlinks are skipped to prevent copying targets outside the files
+    directory.
+    """
+    dir_name = getattr(config, "dataset_input_files_dir", "files") or "files"
+    files_dir = case_dir / dir_name
+    if not files_dir.is_dir():
+        return
+    resolved_root = files_dir.resolve()
+    for item in files_dir.rglob("*"):
+        if item.is_symlink():
+            continue
+        if not item.is_file():
+            continue
+        if not item.resolve().is_relative_to(resolved_root):
+            continue
+        rel = item.relative_to(files_dir)
+        dst = workspace / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, dst)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ import pytest
 # Ensure agent_eval is importable
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from agent_eval.config import EvalConfig, JudgeConfig, ModelsConfig
+from agent_eval.config import DatasetConfig, EvalConfig, JudgeConfig, ModelsConfig
 from score import _resolve_judge_model
 
 
@@ -163,7 +163,7 @@ skill: s
 dataset:
   path: cases/
 """))
-    resolved = cfg.resolve_path(cfg.dataset_path)
+    resolved = cfg.resolve_path(cfg.dataset.path)
     assert resolved == tmp_path.resolve() / "cases"
 
 
@@ -183,7 +183,7 @@ skill: s
 dataset:
   path: /shared/datasets/my-cases
 """))
-    assert cfg.dataset_path == "/shared/datasets/my-cases"
+    assert cfg.dataset.path == "/shared/datasets/my-cases"
 
 
 def test_parent_traversal_rejected(tmp_path):
@@ -209,7 +209,7 @@ dataset:
   path: cases/
 """, name="eval/my-eval/eval.yaml")
     cfg = EvalConfig.from_yaml(p)
-    resolved = cfg.resolve_path(cfg.dataset_path)
+    resolved = cfg.resolve_path(cfg.dataset.path)
     assert resolved == cases_dir
 
 
@@ -219,12 +219,12 @@ def test_shared_dataset_two_configs(tmp_path):
     shared.mkdir()
     cfg_a = EvalConfig(name="a", skill="alpha",
                        config_dir=tmp_path / "eval" / "alpha",
-                       dataset_path=str(shared.resolve()))
+                       dataset=DatasetConfig(path=str(shared.resolve())))
     cfg_b = EvalConfig(name="b", skill="beta",
                        config_dir=tmp_path / "eval" / "beta",
-                       dataset_path=str(shared.resolve()))
-    assert cfg_a.resolve_path(cfg_a.dataset_path) == shared.resolve()
-    assert cfg_b.resolve_path(cfg_b.dataset_path) == shared.resolve()
+                       dataset=DatasetConfig(path=str(shared.resolve())))
+    assert cfg_a.resolve_path(cfg_a.dataset.path) == shared.resolve()
+    assert cfg_b.resolve_path(cfg_b.dataset.path) == shared.resolve()
 
 
 def test_absolute_dataset_path_used_as_is(tmp_path):
@@ -237,5 +237,5 @@ skill: s
 dataset:
   path: {abs_path}
 """, name="eval/my-eval/eval.yaml"))
-    resolved = cfg.resolve_path(cfg.dataset_path)
+    resolved = cfg.resolve_path(cfg.dataset.path)
     assert resolved == abs_path

--- a/tests/test_input_files.py
+++ b/tests/test_input_files.py
@@ -1,10 +1,10 @@
-"""Tests for dataset.input_files_dir support."""
+"""Tests for dataset.workspace.files support."""
 
 import os
 
 import pytest
 
-from agent_eval.config import EvalConfig
+from agent_eval.config import DatasetConfig, EvalConfig, WorkspaceConfig
 from workspace_files import _copy_input_files
 
 
@@ -14,64 +14,157 @@ def _write(tmp_path, body):
     return p
 
 
-def test_input_files_dir_defaults_to_files(tmp_path):
+# ── Config parsing ──────────────────────────────────────────────────
+
+
+def test_workspace_files_defaults_to_empty(tmp_path):
     cfg = EvalConfig.from_yaml(_write(tmp_path, "name: t\nskill: s\n"))
-    assert cfg.dataset_input_files_dir == "files"
+    assert cfg.dataset.workspace.files == []
 
 
-def test_input_files_dir_custom(tmp_path):
-    cfg = EvalConfig.from_yaml(_write(tmp_path, """
+def test_workspace_files_parsed(tmp_path):
+    cfg = EvalConfig.from_yaml(
+        _write(
+            tmp_path,
+            """
+name: t
+skill: s
+dataset:
+  workspace:
+    files:
+      - src/
+      - tickets/JIRA-123.md
+      - config/settings.json
+""",
+        )
+    )
+    assert cfg.dataset.workspace.files == [
+        "src",
+        "tickets/JIRA-123.md",
+        "config/settings.json",
+    ]
+
+
+def test_workspace_files_rejects_absolute_path(tmp_path):
+    with pytest.raises(ValueError, match="must be a relative path"):
+        EvalConfig.from_yaml(
+            _write(
+                tmp_path,
+                """
+name: t
+skill: s
+dataset:
+  workspace:
+    files:
+      - /etc/passwd
+""",
+            )
+        )
+
+
+def test_workspace_files_rejects_non_string_entry(tmp_path):
+    with pytest.raises(ValueError, match="must be a string"):
+        EvalConfig.from_yaml(
+            _write(
+                tmp_path,
+                """\
+name: t
+skill: s
+dataset:
+  workspace:
+    files:
+      - 42
+""",
+            )
+        )
+
+
+def test_workspace_files_rejects_parent_traversal(tmp_path):
+    with pytest.raises(ValueError, match="must be a relative path"):
+        EvalConfig.from_yaml(
+            _write(
+                tmp_path,
+                """
+name: t
+skill: s
+dataset:
+  workspace:
+    files:
+      - ../secrets
+""",
+            )
+        )
+
+
+def test_dataset_config_grouped(tmp_path):
+    """dataset.path and dataset.schema are accessible via DatasetConfig."""
+    cfg = EvalConfig.from_yaml(
+        _write(
+            tmp_path,
+            """
 name: t
 skill: s
 dataset:
   path: cases
-  input_files_dir: source
-"""))
-    assert cfg.dataset_input_files_dir == "source"
+  schema: "Each case has a ticket and code."
+""",
+        )
+    )
+    assert cfg.dataset.path == "cases"
+    assert cfg.dataset.schema == "Each case has a ticket and code."
 
 
-def test_input_files_dir_rejects_absolute_path(tmp_path):
-    with pytest.raises(ValueError, match="must be a relative path"):
-        EvalConfig.from_yaml(_write(tmp_path, """
-name: t
-skill: s
-dataset:
-  input_files_dir: /etc/passwd
-"""))
+# ── File copying ────────────────────────────────────────────────────
 
 
-def test_input_files_dir_rejects_parent_traversal(tmp_path):
-    with pytest.raises(ValueError, match="must be a relative path"):
-        EvalConfig.from_yaml(_write(tmp_path, """
-name: t
-skill: s
-dataset:
-  input_files_dir: ../secrets
-"""))
-
-
-def test_copy_input_files_places_files_in_workspace(tmp_path):
-    """files/ directory contents are copied to workspace root."""
+def test_copy_workspace_files_directory(tmp_path):
+    """Directory entries copy the full subtree."""
     case_dir = tmp_path / "cases" / "case-001"
-    files_dir = case_dir / "files"
-    (files_dir / "src").mkdir(parents=True)
-    (files_dir / "app.py").write_text("print('hello')")
-    (files_dir / "src" / "lib.py").write_text("x = 1")
+    (case_dir / "src").mkdir(parents=True)
+    (case_dir / "src" / "main.py").write_text("print('hello')")
+    (case_dir / "src" / "lib.py").write_text("x = 1")
     (case_dir / "annotations.yaml").write_text("expected: pass")
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
-    config = EvalConfig(name="t", skill="s", dataset_input_files_dir="files")
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(workspace=WorkspaceConfig(files=["src"])),
+    )
     _copy_input_files(case_dir, workspace, config)
 
-    assert (workspace / "app.py").read_text() == "print('hello')"
+    assert (workspace / "src" / "main.py").read_text() == "print('hello')"
     assert (workspace / "src" / "lib.py").read_text() == "x = 1"
     assert not (workspace / "annotations.yaml").exists()
 
 
-def test_copy_input_files_noop_when_dir_missing(tmp_path):
-    """No error when the files/ directory does not exist."""
+def test_copy_workspace_files_single_file(tmp_path):
+    """File entries copy only the named file."""
+    case_dir = tmp_path / "cases" / "case-001"
+    (case_dir / "config").mkdir(parents=True)
+    (case_dir / "config" / "settings.json").write_text('{"a":1}')
+    (case_dir / "config" / "secrets.json").write_text('{"key":"x"}')
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(
+            workspace=WorkspaceConfig(files=["config/settings.json"]),
+        ),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert (workspace / "config" / "settings.json").read_text() == '{"a":1}'
+    assert not (workspace / "config" / "secrets.json").exists()
+
+
+def test_copy_workspace_files_noop_when_empty(tmp_path):
+    """No error when workspace.files is empty."""
     case_dir = tmp_path / "cases" / "case-001"
     case_dir.mkdir(parents=True)
 
@@ -84,44 +177,72 @@ def test_copy_input_files_noop_when_dir_missing(tmp_path):
     assert list(workspace.iterdir()) == []
 
 
-def test_copy_input_files_custom_dir_name(tmp_path):
-    """Custom input_files_dir name is respected."""
+def test_copy_workspace_files_noop_when_path_missing(tmp_path):
+    """No error when a listed path doesn't exist in the case directory."""
     case_dir = tmp_path / "cases" / "case-001"
-    source_dir = case_dir / "source"
-    source_dir.mkdir(parents=True)
-    (source_dir / "main.py").write_text("main()")
-
-    (case_dir / "files").mkdir()
-    (case_dir / "files" / "decoy.txt").write_text("should not be copied")
+    case_dir.mkdir(parents=True)
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
-    config = EvalConfig(name="t", skill="s", dataset_input_files_dir="source")
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(
+            workspace=WorkspaceConfig(files=["nonexistent/"]),
+        ),
+    )
     _copy_input_files(case_dir, workspace, config)
 
-    assert (workspace / "main.py").read_text() == "main()"
-    assert not (workspace / "decoy.txt").exists()
+    assert list(workspace.iterdir()) == []
 
 
-def test_copy_input_files_skips_symlinks(tmp_path):
-    """Symlinks inside files/ are not followed."""
+def test_copy_workspace_files_skips_symlinks(tmp_path):
+    """Symlinks in workspace file entries are not followed."""
     case_dir = tmp_path / "cases" / "case-001"
-    files_dir = case_dir / "files"
-    files_dir.mkdir(parents=True)
-    (files_dir / "real.py").write_text("real")
+    (case_dir / "src").mkdir(parents=True)
+    (case_dir / "src" / "real.py").write_text("real")
 
     outside = tmp_path / "outside"
     outside.mkdir()
     (outside / "secret.txt").write_text("secret")
 
-    os.symlink(outside / "secret.txt", files_dir / "link.txt")
+    os.symlink(outside / "secret.txt", case_dir / "src" / "link.txt")
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
 
-    config = EvalConfig(name="t", skill="s", dataset_input_files_dir="files")
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(workspace=WorkspaceConfig(files=["src"])),
+    )
     _copy_input_files(case_dir, workspace, config)
 
-    assert (workspace / "real.py").read_text() == "real"
-    assert not (workspace / "link.txt").exists()
+    assert (workspace / "src" / "real.py").read_text() == "real"
+    assert not (workspace / "src" / "link.txt").exists()
+
+
+def test_copy_workspace_files_skips_symlinked_entry(tmp_path):
+    """A top-level symlinked directory entry is skipped entirely."""
+    case_dir = tmp_path / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret")
+
+    os.symlink(outside, case_dir / "evil")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(workspace=WorkspaceConfig(files=["evil"])),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert not (workspace / "evil").exists()
+    assert not (workspace / "secret.txt").exists()

--- a/tests/test_input_files.py
+++ b/tests/test_input_files.py
@@ -80,7 +80,7 @@ dataset:
 
 
 def test_workspace_files_rejects_parent_traversal(tmp_path):
-    with pytest.raises(ValueError, match="must be a relative path"):
+    with pytest.raises(ValueError, match="must not contain '\\.\\.'"):
         EvalConfig.from_yaml(
             _write(
                 tmp_path,
@@ -220,7 +220,7 @@ def test_copy_workspace_files_skips_symlinks(tmp_path):
     _copy_input_files(case_dir, workspace, config)
 
     assert (workspace / "src" / "real.py").read_text() == "real"
-    assert not (workspace / "src" / "link.txt").exists()
+    assert not os.path.lexists(workspace / "src" / "link.txt")
 
 
 def test_copy_workspace_files_skips_symlinked_entry(tmp_path):
@@ -244,5 +244,5 @@ def test_copy_workspace_files_skips_symlinked_entry(tmp_path):
     )
     _copy_input_files(case_dir, workspace, config)
 
-    assert not (workspace / "evil").exists()
-    assert not (workspace / "secret.txt").exists()
+    assert not os.path.lexists(workspace / "evil")
+    assert list(workspace.iterdir()) == []

--- a/tests/test_input_files.py
+++ b/tests/test_input_files.py
@@ -1,12 +1,11 @@
 """Tests for dataset.input_files_dir support."""
 
-import shutil
-import sys
-from pathlib import Path
+import os
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
+import pytest
 
 from agent_eval.config import EvalConfig
+from workspace_files import _copy_input_files
 
 
 def _write(tmp_path, body):
@@ -31,20 +30,24 @@ dataset:
     assert cfg.dataset_input_files_dir == "source"
 
 
-def _copy_input_files(case_dir, workspace, config):
-    """Local copy of the function under test to avoid importing workspace.py
-    (which has an agent_eval._bootstrap side-effect import)."""
-    dir_name = getattr(config, "dataset_input_files_dir", "files") or "files"
-    files_dir = case_dir / dir_name
-    if not files_dir.is_dir():
-        return
-    for item in files_dir.rglob("*"):
-        if not item.is_file():
-            continue
-        rel = item.relative_to(files_dir)
-        dst = workspace / rel
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(item, dst)
+def test_input_files_dir_rejects_absolute_path(tmp_path):
+    with pytest.raises(ValueError, match="must be a relative path"):
+        EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+skill: s
+dataset:
+  input_files_dir: /etc/passwd
+"""))
+
+
+def test_input_files_dir_rejects_parent_traversal(tmp_path):
+    with pytest.raises(ValueError, match="must be a relative path"):
+        EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+skill: s
+dataset:
+  input_files_dir: ../secrets
+"""))
 
 
 def test_copy_input_files_places_files_in_workspace(tmp_path):
@@ -99,3 +102,26 @@ def test_copy_input_files_custom_dir_name(tmp_path):
 
     assert (workspace / "main.py").read_text() == "main()"
     assert not (workspace / "decoy.txt").exists()
+
+
+def test_copy_input_files_skips_symlinks(tmp_path):
+    """Symlinks inside files/ are not followed."""
+    case_dir = tmp_path / "cases" / "case-001"
+    files_dir = case_dir / "files"
+    files_dir.mkdir(parents=True)
+    (files_dir / "real.py").write_text("real")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret")
+
+    os.symlink(outside / "secret.txt", files_dir / "link.txt")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(name="t", skill="s", dataset_input_files_dir="files")
+    _copy_input_files(case_dir, workspace, config)
+
+    assert (workspace / "real.py").read_text() == "real"
+    assert not (workspace / "link.txt").exists()

--- a/tests/test_input_files.py
+++ b/tests/test_input_files.py
@@ -1,0 +1,101 @@
+"""Tests for dataset.input_files_dir support."""
+
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.config import EvalConfig
+
+
+def _write(tmp_path, body):
+    p = tmp_path / "eval.yaml"
+    p.write_text(body)
+    return p
+
+
+def test_input_files_dir_defaults_to_files(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, "name: t\nskill: s\n"))
+    assert cfg.dataset_input_files_dir == "files"
+
+
+def test_input_files_dir_custom(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+skill: s
+dataset:
+  path: cases
+  input_files_dir: source
+"""))
+    assert cfg.dataset_input_files_dir == "source"
+
+
+def _copy_input_files(case_dir, workspace, config):
+    """Local copy of the function under test to avoid importing workspace.py
+    (which has an agent_eval._bootstrap side-effect import)."""
+    dir_name = getattr(config, "dataset_input_files_dir", "files") or "files"
+    files_dir = case_dir / dir_name
+    if not files_dir.is_dir():
+        return
+    for item in files_dir.rglob("*"):
+        if not item.is_file():
+            continue
+        rel = item.relative_to(files_dir)
+        dst = workspace / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, dst)
+
+
+def test_copy_input_files_places_files_in_workspace(tmp_path):
+    """files/ directory contents are copied to workspace root."""
+    case_dir = tmp_path / "cases" / "case-001"
+    files_dir = case_dir / "files"
+    (files_dir / "src").mkdir(parents=True)
+    (files_dir / "app.py").write_text("print('hello')")
+    (files_dir / "src" / "lib.py").write_text("x = 1")
+    (case_dir / "annotations.yaml").write_text("expected: pass")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(name="t", skill="s", dataset_input_files_dir="files")
+    _copy_input_files(case_dir, workspace, config)
+
+    assert (workspace / "app.py").read_text() == "print('hello')"
+    assert (workspace / "src" / "lib.py").read_text() == "x = 1"
+    assert not (workspace / "annotations.yaml").exists()
+
+
+def test_copy_input_files_noop_when_dir_missing(tmp_path):
+    """No error when the files/ directory does not exist."""
+    case_dir = tmp_path / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(name="t", skill="s")
+    _copy_input_files(case_dir, workspace, config)
+
+    assert list(workspace.iterdir()) == []
+
+
+def test_copy_input_files_custom_dir_name(tmp_path):
+    """Custom input_files_dir name is respected."""
+    case_dir = tmp_path / "cases" / "case-001"
+    source_dir = case_dir / "source"
+    source_dir.mkdir(parents=True)
+    (source_dir / "main.py").write_text("main()")
+
+    (case_dir / "files").mkdir()
+    (case_dir / "files" / "decoy.txt").write_text("should not be copied")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(name="t", skill="s", dataset_input_files_dir="source")
+    _copy_input_files(case_dir, workspace, config)
+
+    assert (workspace / "main.py").read_text() == "main()"
+    assert not (workspace / "decoy.txt").exists()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Skills that operate on source code (e.g., autofix) need actual files in the workspace, not just input.yaml metadata. Add a dataset.input_files_dir config field (default: files). When a case directory contains a subdirectory with that name, its contents are recursively copied into the workspace root. The directory name is added to _SKIP_NAMES so it is not treated as input data in batch mode. No breaking changes -- cases without a files/ directory are unaffected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using autofix-skills as a testbed.

```
Yes, confirmed! The code change is working correctly:

  Dataset structure:
  - Files are in eval/cases/case-001-simple-null-pointer-fix/files/ subdirectory ✓

  Workspace structure:
  - Files copied to workspace root /tmp/agent-eval/2026-05-21-opus-v2/cases/case-001-simple-null-pointer-fix/ ✓
  - user_profile.py and test_user_profile.py are directly accessible ✓

  Execution:
  - Skill is successfully reading the files (logs show "Reading: implement-agent.md") ✓
  - No file-not-found errors ✓

  The updated harness is correctly loading files from the files/ subdirectory (as specified by input_files_dir: files in eval.yaml line 48) and copying them
  to the workspace root where the skill expects them.
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dataset settings are grouped under a single dataset section in config.
  * Config can list workspace input files; listed inputs are copied into evaluation workspaces, preserving nested structure.

* **Bug Fixes**
  * Workspace file entries validated (must be relative strings, no parent traversal).
  * Symlink escapes prevented; missing entries are treated as no-ops.

* **Tests**
  * Added comprehensive tests for parsing, copying behavior, and security edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->