### PR TITLE
fix: restore stdout loading and events.json for batch mode

### DIFF
--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -137,6 +137,10 @@ def main():
         counts = ", ".join(f"{k}={v}" for k, v in info.items())
         print(f"  {case_id}: {counts}")
 
+    # Generate events.json from run-level stdout.log (shared across all cases)
+    if config.traces.events:
+        _generate_events_json(workspace, output_dir, config)
+
     if not results:
         print("WARNING: no artifacts collected", file=sys.stderr)
 

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -172,16 +172,18 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
 
     # --- Events (structured event stream) ---
     events_path = case_dir / "events.json"
+    if not events_path.exists() and run_id and runs_dir:
+        events_path = runs_dir / run_id / "events.json"
     if events_path.exists():
         try:
             with open(events_path) as f:
                 record["events"] = json.load(f)
             if not isinstance(record["events"], list):
-                print(f"  Warning: events.json is not a list in {case_dir}",
+                print(f"  Warning: events.json is not a list in {events_path}",
                       file=sys.stderr)
                 record["events"] = []
         except (json.JSONDecodeError, OSError) as e:
-            print(f"  Warning: malformed events.json in {case_dir}: {e}",
+            print(f"  Warning: malformed events.json in {events_path}: {e}",
                   file=sys.stderr)
             record["events"] = []
     else:
@@ -196,6 +198,15 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
 
     # --- Logs (if traces config enables them) ---
     if run_id:
+        if config.traces.stdout:
+            stdout_path = case_dir / "stdout.log"
+            if not stdout_path.exists():
+                stdout_path = runs_dir / run_id / "stdout.log"
+            if stdout_path.exists():
+                try:
+                    record["stdout"] = stdout_path.read_text()
+                except OSError:
+                    pass
         if config.traces.stderr:
             stderr_path = case_dir / "stderr.log"
             if not stderr_path.exists():


### PR DESCRIPTION
## Summary
- Restore stdout loading in `score.py` that was removed in 9dbf4a5
- Add run-level fallback for `events.json` in batch mode
- Generate `events.json` from batch-mode `stdout.log` in `collect.py`

## Context

In batch mode, `stdout.log` and `events.json` are single run-level files shared across all cases (unlike case mode where each case gets its own). Two problems:

1. **stdout loading was removed** in commit 9dbf4a5 ("Implement structured event stream for judges"). The refactor deleted the `record["stdout"]` loading block, so judges using `outputs["stdout"]` (like `pipeline_flow`) got empty strings. This caused systematic 0% pass rate across all 20 cases in a recent eval run — the judge reported "No stdout captured" for every case.

2. **events.json wasn't generated in batch mode**. The `_generate_events_json` call existed for per-case mode but was missing from the batch-mode path in `collect.py`. When `traces.events` is enabled, batch mode now generates `events.json` at the run level.

Both fixes add run-level fallback: when per-case files don't exist, check the run-level directory.

## Test plan
- [x] Verified `pipeline_flow` judge now finds stdout in batch mode
- [ ] Run full eval suite in both case and batch mode to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch mode now generates top-level event data collection when enabled, matching per-case functionality.

* **Bug Fixes**
  * Enhanced file discovery for events and log data with fallback to run-level directories when case-level files are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->