### PR TITLE
feat(eval-optimize): add optimization controls for robust skill improvement

### DIFF
--- a/skills/eval-optimize/SKILL.md
+++ b/skills/eval-optimize/SKILL.md
@@ -1,17 +1,23 @@
 ---
 name: eval-optimize
-description: Automated skill improvement loop. Runs eval, identifies failures, edits SKILL.md with evidence-based fixes, re-runs to verify, checks for regressions. Uses data splitting, validation gates, and bounded edits to prevent overfitting. Use when you want to automatically improve a skill, fix failing judges, improve scores, or iterate until tests pass. Triggers on "optimize the skill", "make it pass", "auto-fix", "improve the scores", "why is it failing". Works best after /eval-run.
+description: Automated skill improvement loop. Runs eval, identifies failures, edits SKILL.md with evidence-based fixes, re-runs to verify, checks for regressions. Selectable strategy — a lightweight linear flow for small datasets and a SkillOpt mode (data splitting, validation gate, bounded edits) that prevents overfitting on larger ones, auto-selected by dataset size. Use when you want to automatically improve a skill, fix failing judges, improve scores, or iterate until tests pass. Triggers on "optimize the skill", "make it pass", "auto-fix", "improve the scores", "why is it failing". Works best after /eval-run.
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent, Skill, AskUserQuestion
 ---
 
-You are an automated skill improver. You treat the skill document as trainable external state: data splitting prevents overfitting, bounded edit budgets prevent over-editing, a validation gate ensures only real improvements are accepted, and a rejected-edit buffer prevents retrying failed approaches. You iterate until judges pass or you hit the max iteration limit.
-
-Why these controls matter: without them, the optimization loop tends to overfit — an edit that helps one failing case breaks three passing ones, and the next iteration tries the same rejected edit again. Data splitting catches overfitting by testing edits on cases the optimizer didn't train on. The edit budget prevents making 10 changes at once (which makes it impossible to isolate what helped). The rejected-edit buffer ensures the loop makes forward progress instead of cycling.
+You are an automated skill improver. You run evaluations, identify what's failing and why, make targeted evidence-based edits to the skill's SKILL.md, re-run to verify, and check for regressions. You iterate until judges pass or you hit the max iteration limit.
 
 The key difference from `/eval-review`: you act autonomously. You read judge rationale and transcripts, form hypotheses about what's wrong, make targeted edits, and verify — without asking the user for feedback on each case. The user sets the goal ("make this pass") and you work toward it.
 
-For the full explanation of each optimization control, see `${CLAUDE_SKILL_DIR}/references/optimization-controls.md`.
+## Strategies
+
+This skill runs in one of two strategies, selected by `--strategy` (default `auto`):
+
+- **`lite`** — a lightweight linear flow: identify failures → analyze root causes → edit → re-run and verify → check regressions → iterate. Best for small datasets (the common case) and quick fixes.
+- **`skillopt`** — treats the skill document as trainable external state, adding controls that prevent overfitting on larger datasets: data splitting with a validation gate, minibatch reflection, a bounded edit budget, cross-iteration consolidation, and a meta-skill. See `${CLAUDE_SKILL_DIR}/references/optimization-controls.md` for the full explanation of each control.
+- **`auto`** (default) — picks `lite` for datasets with fewer than 20 cases and `skillopt` for 20 or more. Below ~20 cases the statistical machinery (train/selection/test splits, minibatches) is noise, so the lightweight flow is both cheaper and more reliable.
+
+Both strategies share the same always-on safeguards: every edit is grounded in evidence, regressions are checked after each edit, and a rejected-edit buffer prevents retrying failed approaches. Sections below marked **SkillOpt mode** apply only when the resolved strategy is `skillopt`.
 
 ## Step 0: Parse Arguments and Initialize
 
@@ -20,11 +26,12 @@ For the full explanation of each optimization control, see `${CLAUDE_SKILL_DIR}/
 | `--config <path>` | no | auto-discover | Path to eval config |
 | `--model <model>` | no | `models.skill` from eval.yaml | Model to use for eval runs (overrides config default) |
 | `--max-iterations <N>` | no | 4 | Stop after N improvement cycles |
+| `--strategy <mode>` | no | `auto` | `auto` (by dataset size), `lite`, or `skillopt` |
 | `--run-id <id>` | no | auto-generated | Base run ID (iterations append `-iter-N`) |
 | `--target-judge <name>` | no | all judges | Focus on a specific failing judge |
-| `--edit-budget <N>` | no | 4 | Max edits per iteration (ceiling — actual count is chosen adaptively) |
-| `--split <train:sel:test>` | no | `40:20:40` | Dataset split ratio |
-| `--update-mode <mode>` | no | `patch` | Edit mode: `patch` (surgical edits) or `rewrite` (full rewrite from proposals) |
+| `--edit-budget <N>` | no | 4 | (skillopt) Max edits per iteration (ceiling — actual count is chosen adaptively) |
+| `--split <train:sel:test>` | no | `40:20:40` | (skillopt) Dataset split ratio |
+| `--update-mode <mode>` | no | `patch` | (skillopt) Edit mode: `patch` (surgical edits) or `rewrite` (full rewrite from proposals) |
 
 ### Config Discovery
 
@@ -40,53 +47,67 @@ python3 ${CLAUDE_SKILL_DIR}/../../scripts/discover.py
 
 After selecting a config, read its `skill` field to set `<eval-name>` (used in `$AGENT_EVAL_RUNS_DIR/<eval-name>/<id>` paths below).
 
+### Resolve strategy
+
+If `--strategy` is `lite` or `skillopt`, use it directly. If `auto` (the default), count the test cases in the dataset and pick:
+
+```bash
+N=$(find <dataset_path> -mindepth 1 -maxdepth 1 -type d ! -name '.*' | wc -l | tr -d ' ')
+echo "Dataset has $N cases"
+# N < 20  → strategy=lite
+# N >= 20 → strategy=skillopt
+```
+
+Report which strategy was chosen and why (e.g., "12 cases (<20) → lite"). `<strategy>` below means the resolved value.
+
+### Record configuration
+
 ```bash
 mkdir -p tmp
 python3 ${CLAUDE_SKILL_DIR}/scripts/agent_eval/state.py init tmp/optimize-config.yaml \
-  model=<model> max_iterations=<N> run_id=<id> target_judge=<judge> \
+  model=<model> max_iterations=<N> run_id=<id> target_judge=<judge> strategy=<strategy> \
   edit_budget=<budget> split=<ratio> update_mode=<mode>
 ```
 
 ### Initialize optimization state
+
+The rejected-edit buffer is used by both strategies — it prevents the loop from retrying approaches that already failed:
+
+```bash
+test -f tmp/rejected-edits.yaml || echo "rejected_edits: []" > tmp/rejected-edits.yaml
+```
+
+**SkillOpt mode** — also initialize the longitudinal state files and split the dataset (in `lite` mode there is no split; the optimizer works against the full case set):
 
 ```bash
 test -f tmp/optimization-log.md || cat > tmp/optimization-log.md << 'EOF'
 # Optimization Log
 ## Iteration History
 EOF
-
-test -f tmp/rejected-edits.yaml || echo "rejected_edits: []" > tmp/rejected-edits.yaml
 test -f tmp/meta-skill.md || echo "# Meta Skill" > tmp/meta-skill.md
-```
 
-### Split the dataset
-
-```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/split_dataset.py \
   --dataset <dataset_path> \
   --ratio <split_ratio> \
   --output tmp/splits.yaml
-```
-
-```bash
 cat tmp/splits.yaml
 ```
 
 ## Step 1: Initial Eval Run
 
-If no recent eval results exist, run the eval suite on **train + selection** splits:
+If no recent eval results exist, run the eval suite. In `lite` mode, run **all** cases:
+
+```text
+Use the Skill tool to invoke /eval-run --run-id <id>-iter-0 --config <config> [--model <model>]
+```
+
+**SkillOpt mode** — run only the **train + selection** splits (the test split is reserved for the final generalization check):
 
 ```text
 Use the Skill tool to invoke /eval-run --run-id <id>-iter-0 --config <config> [--model <model>] --case <train_and_selection_cases>
 ```
 
-Pass `--model` only if the user provided one. Pass the same model on every iteration.
-
-If results already exist, use those — but note which cases are in train vs selection splits.
-
-If all judges pass on train+selection, run the test split to confirm generalization, report success, and exit.
-
-## Step 2: Identify Failures (Train Split Only)
+Pass `--model` only if the user provided one — otherwise let `/eval-run` fall back to `models.skill`. Pass the same model on every iteration for comparable results. If results already exist (the user just ran `/eval-run`), use those.
 
 Read the results:
 
@@ -94,19 +115,25 @@ Read the results:
 python3 ${CLAUDE_SKILL_DIR}/scripts/agent_eval/state.py read $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>-iter-0/summary.yaml
 ```
 
-From `summary.yaml`, filter to **train-split cases only**. The selection split is reserved for gating.
+If all judges pass, report success and exit — nothing to improve. (In SkillOpt mode, first run the test split to confirm generalization.)
 
-1. **Which judges failed** — and on which train-split cases
+## Step 2: Identify Failures
+
+From `summary.yaml`, identify:
+
+1. **Which judges failed** — and on which cases
 2. **Failure rationale** — what did each judge say about why it failed?
 3. **Failure patterns** — systematic (one judge fails everywhere) or input-dependent (specific cases)?
 
-Check for human feedback:
+**SkillOpt mode** — filter to **train-split cases only**; the selection split is reserved for the validation gate in Step 5.
+
+Check for human feedback — these catch things judges miss:
 
 ```bash
 test -f $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/review.yaml && echo "REVIEW_EXISTS" || echo "NO_REVIEW"
 ```
 
-If `review.yaml` exists, read its `feedback` and `mlflow_feedback` sections. Human feedback is higher-signal — prioritize it.
+If `review.yaml` exists, read its `feedback` section (human feedback from `/eval-review`) and `mlflow_feedback` section (annotations from the MLflow UI). Human feedback is higher-signal than judge rationale — prioritize it. If `--target-judge` was specified, focus only on that judge's failures.
 
 Build a failure map, noting each judge's type (`judge_type` in results: `builtin`, `check`, `llm`, `code`) — the type determines what you can do about it:
 
@@ -129,11 +156,42 @@ If ALL failures are case-specific (single case per judge, and rationale points t
 
 This prevents the optimizer from making unnecessary skill changes for test-case-quality problems.
 
-## Step 3: Analyze Root Causes (Minibatch Reflection)
+## Step 3: Analyze Root Causes
 
-### Build step context
+For each failure pattern, investigate why the skill produces bad output:
 
-Combine the rejected-edit buffer and failure patterns from previous steps into a single context block. This gives the analyst a complete picture of what was already tried:
+1. **Read the skill's SKILL.md** — locate it via eval.yaml's `skill` field:
+   ```bash
+   python3 ${CLAUDE_SKILL_DIR}/../eval-analyze/scripts/find_skills.py --name <skill>
+   ```
+
+2. **Read transcripts** (if available) — transcripts can be very large, so delegate to an Agent. Check `run_result.json` for `execution_mode`: in `case` mode, each case has its own transcript at `$AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/cases/<case>/stdout.log`; in `batch` mode, there's one at `$AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/stdout.log`. Focus on the failing cases. Include the specific judge failure so the agent traces the causal chain rather than producing a generic summary:
+   ```text
+   Agent tool, subagent_type="Explore": "Read the transcript at <path>.
+   The judge '<judge_name>' (<judge_type>) failed this case with rationale: '<rationale from summary.yaml>'.
+
+   Find evidence explaining WHY this failure happened:
+   - Where in the transcript did the skill handle (or skip) the relevant task?
+   - What instructions from SKILL.md led to this behavior?
+   - Did the skill attempt the right thing but produce wrong output, or skip it entirely?
+   - If it tried multiple approaches, which one stuck and why?"
+   ```
+   In `batch` mode, failures across cases may interact — ask the agent to check whether earlier cases' processing affected later ones.
+
+3. **Read failing case outputs** — use an Explore agent to examine the actual output files. Include what the judge expected so the comparison is targeted:
+   ```text
+   Agent tool, subagent_type="Explore": "Read the outputs in $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/cases/<failing_case>/.
+   The judge '<judge_name>' failed with: '<rationale>'.
+   Compare the actual output against this expectation — what specifically is missing or wrong?"
+   ```
+
+4. **Form hypotheses** — connect the judge rationale + transcript evidence + output examination to specific parts of the SKILL.md. Be specific: "The judge says the output is missing acceptance criteria. The transcript shows the skill skipped Step 4. Step 4 in SKILL.md says 'optionally add acceptance criteria' — the word 'optionally' is the problem."
+
+### SkillOpt mode: Minibatch Reflection
+
+On larger datasets, replace the direct reading above with parallel minibatch analysis — it scales better and surfaces systematic patterns across many cases.
+
+**Build step context** — combine the rejected-edit buffer and prior findings into one block so the analysts see what was already tried:
 
 ```bash
 cat tmp/rejected-edits.yaml
@@ -141,15 +199,9 @@ cat tmp/optimization-log.md
 cat tmp/meta-skill.md
 ```
 
-### Partition into minibatches
+**Partition into minibatches** — split failing cases into **groups of 5-8**, grouped by shared failing judge(s). Also form a separate success minibatch from passing cases.
 
-Partition failing cases into **groups of 5-8** and analyze each separately. Group by shared failing judge(s). Also form a separate success minibatch from passing cases.
-
-### Analyze failures and successes separately
-
-Spawn parallel sub-agents — one per minibatch. Use **different prompts** for failure and success analysis:
-
-**For each failure minibatch**:
+**Analyze failures and successes separately** — spawn parallel sub-agents, one per minibatch, with **different prompts** for failure vs success analysis:
 
 ```text
 Agent tool, subagent_type="Explore": "Follow ${CLAUDE_SKILL_DIR}/prompts/failure-analysis.md.
@@ -158,29 +210,38 @@ Judge failures: <judge: rationale per case>.
 Step context: <rejected edits + failure patterns>. Meta-skill: <tmp/meta-skill.md>."
 ```
 
-**For the success minibatch**:
-
 ```text
 Agent tool, subagent_type="Explore": "Follow ${CLAUDE_SKILL_DIR}/prompts/success-analysis.md.
 Cases: [list]. Skill: <path>. Transcripts: <paths>."
 ```
 
-### Hierarchical merge
+**Hierarchical merge** — after all minibatches complete, merge proposals in stages (not a flat dedup):
 
-After all minibatches complete, merge proposals in stages — not a flat dedup:
-
-1. **Merge failure proposals**: if multiple failure minibatches proposed similar edits, merge them. Track **support count** — how many minibatches independently proposed each edit. Higher support = more systematic.
+1. **Merge failure proposals**: combine similar edits across minibatches, tracking a **support count** (how many minibatches independently proposed each edit). Higher support = more systematic.
 2. **Merge success proposals**: consolidate "preserve" signals.
-3. **Final merge** with **failure priority**: combine failure and success proposals. Where they conflict (failure says change X, success says preserve X), failure takes precedence — but flag the conflict so you can monitor for regressions.
-4. **Filter**: discard edits with support count of 1 (single minibatch, likely case-specific).
+3. **Final merge** with **failure priority**: where failure and success conflict, failure wins — but flag the conflict to monitor for regressions.
+4. **Filter**: discard edits with a support count of 1 (single minibatch, likely case-specific).
 
 See `${CLAUDE_SKILL_DIR}/prompts/merge-proposals.md` for the merge framework.
 
-## Step 4: Rank, Budget, and Edit
+## Step 4: Edit the Skill
 
-### Rank by expected utility
+Apply targeted fixes to the SKILL.md. For each edit:
 
-Rank all merged proposals by four criteria:
+- **Ground it in evidence** — cite the judge, failing cases, and transcript evidence
+- **Be surgical** — change the minimum needed; don't rewrite sections that are working
+- **Explain the why** — explain to the model why the change matters, rather than adding rigid MUSTs
+- **Don't overfit** — a fix for 1 of N cases must be general enough not to break the others
+- **Check the rejected-edit buffer** — if a similar edit category was already rejected, try a different approach
+- **Respect protected regions** — never modify content between `<!-- SLOW_UPDATE_START -->` and `<!-- SLOW_UPDATE_END -->` markers (the SkillOpt consolidation step owns these)
+
+Show each edit before applying. If a change is risky (could affect passing cases), note it.
+
+### SkillOpt mode: Rank and budget
+
+Instead of editing directly, rank the merged proposals and apply only the top ones up to the edit budget.
+
+**Rank by expected utility**:
 - **Systematic impact**: how many cases does this affect? (support count)
 - **Complementarity**: does this edit reinforce or conflict with other selected edits?
 - **Generality**: will this help unseen cases or only the train split?
@@ -192,56 +253,42 @@ Rank all merged proposals by four criteria:
 3. [LOW] Clarify error handling — support: 1/3, 1 case, judge: robustness
 ```
 
-### Choose edit count (adaptive)
+**Choose edit count adaptively** — up to the `--edit-budget` ceiling (default 4). Don't use a fixed formula; weigh the evidence: more for high-support/systematic failures, fewer for conflicting proposals, late iterations with proven edits to protect, or many prior rejections. State your reasoning (e.g., "Applying 3 of 5: two at 3/3 support, no conflicts with success signals; holding back 2 low-support proposals") and log the held-back proposals for later iterations.
 
-Decide how many edits to apply this iteration — up to the `--edit-budget` ceiling (default 4). Don't use a fixed formula. Instead, look at the evidence:
+**Rewrite mode** — if `--update-mode rewrite` was specified, or patch edits have plateaued (persistent failures surviving 3+ iterations), produce a **complete skill rewrite** conditioned on the merged proposals instead of individual patches. Read `${CLAUDE_SKILL_DIR}/prompts/rewrite-skill.md` for the framework. Last resort — it risks undoing proven edits.
 
-- **High-support proposals** (3/3 minibatches agree) → safe to apply more
-- **Conflicting proposals** (success signals vs failure edits) → apply fewer, monitor closely
-- **Many rejections in previous iterations** → be more conservative
-- **Many systematic failures remaining** → apply more edits
-- **Few sporadic failures** → apply fewer, more targeted edits
-- **Late iteration with proven edits to protect** → apply fewer
+## Step 5: Re-Run and Verify
 
-State your reasoning: "Applying 3 of 5 proposals this iteration because support counts are high (2 at 3/3, 1 at 2/3) and no conflicts with success signals. Holding back 2 lower-support proposals for next iteration."
+Re-run eval with the baseline flag to detect regressions. If only a subset of cases failed, target them with `--cases` for faster verification; once they pass, do a final full run to confirm no regressions.
 
-Log remaining proposals for later iterations.
+```text
+# Targeted re-run (failing cases only)
+Use the Skill tool to invoke /eval-run --run-id <id>-iter-<N> --cases <failing-case-id> [<failing-case-id> ...] --baseline <id>-iter-<N-1> --config <config> [--model <model>]
 
-### Apply fixes (patch mode — default)
+# Full re-run (all cases) — final verification
+Use the Skill tool to invoke /eval-run --run-id <id>-iter-<N> --baseline <id>-iter-<N-1> --config <config> [--model <model>]
+```
 
-For each edit within budget:
-- **Ground in evidence** — cite judge, cases, transcript evidence, support count
-- **Be surgical** — change the minimum needed
-- **Explain the why** — explain to the model why the change matters, not rigid MUSTs
-- **Don't overfit** — a fix for 1/20 cases must be general enough for unseen cases
-- **Check rejected-edit buffer** — if a similar category was rejected, try a different approach
-- **Respect protected regions** — do NOT modify content between `<!-- SLOW_UPDATE_START -->` and `<!-- SLOW_UPDATE_END -->` markers. These are set by the consolidation step and can only be modified there.
+Consider `--no-llm-judges` when an edit only needs structural verification — it skips LLM API calls and runs only deterministic judges (check, Python builtins), which is faster and cheaper. Run the full judge set before declaring success.
 
-### Alternative: rewrite mode
+Read the new results:
 
-If `--update-mode rewrite` was specified, or if the skill has deep structural problems that surgical patches can't address (persistent failures surviving 3+ iterations):
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/agent_eval/state.py read $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>-iter-<N>/summary.yaml
+```
 
-Instead of applying individual edits, produce a **complete skill rewrite** conditioned on all the merged proposals. Read `${CLAUDE_SKILL_DIR}/prompts/rewrite-skill.md` for the rewrite framework — it covers preservation rules, structural integration, voice consistency, and a validation checklist.
+### SkillOpt mode: Validation gate (selection split)
 
-Rewrite mode is a last resort — it risks undoing proven edits. Only use it when patch mode has plateaued.
-
-## Step 5: Validation Gate (Selection Split)
-
-Run eval on **train + selection** together, then separate scores by split. Pass case IDs as a comma-separated `--case` filter (the filter uses substring matching, so ensure case IDs are distinct enough to avoid false matches):
+Re-run **train + selection** together, then separate scores by split. Pass case IDs as a comma-separated `--case` filter (the filter uses substring matching, so ensure case IDs are distinct enough to avoid false matches):
 
 ```text
 Use the Skill tool to invoke /eval-run --run-id <id>-iter-<N> --baseline <id>-iter-<N-1> --config <config> [--model <model>] --case <train_and_selection_cases>
 ```
 
-Consider `--no-llm-judges` when the edit only needs structural verification — it skips LLM API calls and runs only deterministic judges (check, Python builtins), which is faster and cheaper. Run the full judge set before accepting via the gate.
+**Accept only if the selection-split score strictly improves.** Ties are rejected.
 
-**Accept only if selection-split score strictly improves.** Ties are rejected.
-
-**If accepted**: continue to Step 6.
-
-**If rejected**: record in rejected-edit buffer with score delta and edit category, revert SKILL.md, return to Step 3. On second rejection in the same iteration, reduce budget by 1 and try next-ranked edits.
-
-Record the rejection by appending to the YAML file:
+- **Accepted**: continue to Step 6.
+- **Rejected**: record in the rejected-edit buffer (below), revert SKILL.md, return to Step 3. On a second rejection in the same iteration, reduce the budget by 1 and try next-ranked edits.
 
 ```bash
 python3 -c "
@@ -263,18 +310,18 @@ with open('tmp/rejected-edits.yaml', 'w') as f:
 
 ## Step 6: Check Regressions
 
-From the train+selection results already computed in Step 5:
+After re-running, check:
 
-- **Fixed**: did targeted failures pass?
+- **Fixed**: did the targeted failures pass?
 - **Regressions**: did previously passing cases/judges now fail?
 - **Net improvement**: did aggregate scores improve?
 
 If regressions:
 1. **Minor** (net positive) — continue
-2. **Major** — revert, record in rejected-edit buffer, try different approach
-3. **Stuck** — report to user, suggest `/eval-review` for human input
+2. **Major** — revert the edit, record it in the rejected-edit buffer, try a different approach
+3. **Stuck** — report to the user, suggest `/eval-review` for human input
 
-### Track cumulative cost
+### SkillOpt mode: Track cumulative cost
 
 Sum costs across all iterations:
 
@@ -289,9 +336,9 @@ print(f'Cumulative cost: \${total:.2f}')
 
 If cumulative exceeds 5× the iter-0 cost, warn the user that optimization may not be cost-effective.
 
-## Step 7: Consolidation (Iteration 2+)
+## Step 7: Consolidation (SkillOpt mode, iteration 2+)
 
-After iteration 2 or later, perform cross-iteration consolidation in two phases. Read `${CLAUDE_SKILL_DIR}/prompts/consolidation.md` for the full framework.
+`lite` mode skips this step. In SkillOpt mode, after iteration 2 or later, perform cross-iteration consolidation in two phases. Read `${CLAUDE_SKILL_DIR}/prompts/consolidation.md` for the full framework.
 
 **Phase 1**: Compare across all iterations — categorize each edit (stable/regressed/neutral), classify persistent failures, analyze which edit categories work for this skill.
 
@@ -348,35 +395,38 @@ EOF
 
 ## Step 8: Iterate or Report
 
-If failures remain and iterations < max: go back to Step 2. Each iteration targets different failures or tries different approaches. The edit count is chosen adaptively each iteration — it may increase or decrease based on evidence quality.
+If failures remain and iterations < max, go back to Step 2 and target different failures or try different approaches for persistent ones.
 
-If all judges pass on train + selection:
-- Run the **test split** to confirm generalization:
+If all judges pass:
+- **lite**: report success — which edits fixed which failures, how many iterations it took, and the final `summary.yaml` scores.
+- **SkillOpt mode**: run the **test split** to confirm generalization:
   ```text
   Use the Skill tool to invoke /eval-run --run-id <id>-final-test --config <config> [--model <model>] --case <test_cases>
   ```
-- Good test scores: report success with generalization confirmed
-- Low test scores: warn about overfitting
+  Good test scores → report success with generalization confirmed; low test scores → warn about overfitting.
 
 If max iterations reached with failures remaining:
 - Report what was fixed and what couldn't be fixed
-- Include optimization log summary
-- If patch mode plateaued, suggest re-running with `--update-mode rewrite`
-- Suggest `/eval-review --run-id <final-id>` for human assessment
+- Suggest `/eval-review --run-id <final-id>` for human assessment of the remaining issues
 - Suggest `/eval-dataset --strategy expand` if failures suggest missing coverage
+- **SkillOpt mode**: include the optimization-log summary; if patch mode plateaued, suggest re-running with `--update-mode rewrite`
 
 Always suggest `/eval-mlflow --run-id <final-id>` to log results.
 
 ## Rules
 
-- **Every edit must be grounded in evidence** — cite judge, cases, transcript evidence, support count. Never make broad, generic changes.
-- **Respect the edit budget ceiling** — choose the edit count adaptively but never exceed `--edit-budget`. State your reasoning.
-- **Respect the validation gate** — reject edits that don't improve selection scores. Record rejections.
-- **Don't modify protected regions** — content between SLOW_UPDATE markers can only be changed by consolidation.
-- **Read the step context** — rejected-edit buffer + failure patterns + meta-skill before proposing edits.
+Always-on (both strategies):
+
+- **Every edit must be grounded in evidence** — cite the judge, failing cases, and transcript evidence. Never make broad, generic changes.
 - **Check for regressions** — a fix that breaks other cases is not a fix.
+- **Use the rejected-edit buffer** — read it before proposing edits; if the same edit category failed twice, try a fundamentally different framing. Explain why instead of adding more rules.
 - **Stop after max iterations** — don't loop forever. Report what couldn't be fixed.
 - **Don't modify test cases, judges, or eval.yaml** — the eval harness is the ground truth. Builtin judges (from `agent_eval/judges/`) are versioned and shared — never edit their code; if a builtin judge's behavior needs adjustment, suggest changing its `arguments:` in eval.yaml. For inline check or LLM prompt judges, suggest improvements to the user but don't edit eval.yaml yourself.
-- **Try different approaches** — if the same edit category fails twice, try a fundamentally different framing. Explain why instead of adding more rules.
+
+SkillOpt mode:
+
+- **Respect the edit budget ceiling** — choose the edit count adaptively but never exceed `--edit-budget`. State your reasoning.
+- **Respect the validation gate** — reject edits that don't strictly improve the selection-split score. Record rejections.
+- **Don't modify protected regions** — content between SLOW_UPDATE markers can only be changed by the consolidation step.
 
 $ARGUMENTS

--- a/skills/eval-optimize/SKILL.md
+++ b/skills/eval-optimize/SKILL.md
@@ -1,23 +1,30 @@
 ---
 name: eval-optimize
-description: Automated skill improvement loop. Runs eval, identifies judge failures, reads traces and rationale, edits the SKILL.md to fix issues, re-runs to verify, and checks for regressions. Use when the user wants to automatically improve a skill based on eval results, fix failing judges, make the skill better, auto-fix quality issues, improve scores, or iterate until all judges pass. Triggers on "optimize the skill", "make it pass", "auto-fix", "improve the scores", "why is it failing". Works best after /eval-run has produced results to learn from.
+description: Automated skill improvement loop. Runs eval, identifies failures, edits SKILL.md with evidence-based fixes, re-runs to verify, checks for regressions. Uses data splitting, validation gates, and bounded edits to prevent overfitting. Use when you want to automatically improve a skill, fix failing judges, improve scores, or iterate until tests pass. Triggers on "optimize the skill", "make it pass", "auto-fix", "improve the scores", "why is it failing". Works best after /eval-run.
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent, Skill, AskUserQuestion
 ---
 
-You are an automated skill improver. You run evaluations, identify what's failing and why, edit the skill's SKILL.md to fix the issues, re-run to verify, and check for regressions. You iterate until judges pass or you hit the max iteration limit.
+You are an automated skill improver. You treat the skill document as trainable external state: data splitting prevents overfitting, bounded edit budgets prevent over-editing, a validation gate ensures only real improvements are accepted, and a rejected-edit buffer prevents retrying failed approaches. You iterate until judges pass or you hit the max iteration limit.
+
+Why these controls matter: without them, the optimization loop tends to overfit — an edit that helps one failing case breaks three passing ones, and the next iteration tries the same rejected edit again. Data splitting catches overfitting by testing edits on cases the optimizer didn't train on. The edit budget prevents making 10 changes at once (which makes it impossible to isolate what helped). The rejected-edit buffer ensures the loop makes forward progress instead of cycling.
 
 The key difference from `/eval-review`: you act autonomously. You read judge rationale and transcripts, form hypotheses about what's wrong, make targeted edits, and verify — without asking the user for feedback on each case. The user sets the goal ("make this pass") and you work toward it.
 
-## Step 0: Parse Arguments
+For the full explanation of each optimization control, see `${CLAUDE_SKILL_DIR}/references/optimization-controls.md`.
+
+## Step 0: Parse Arguments and Initialize
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `--config <path>` | no | auto-discover | Path to eval config |
 | `--model <model>` | no | `models.skill` from eval.yaml | Model to use for eval runs (overrides config default) |
-| `--max-iterations <N>` | no | 3 | Stop after N improvement cycles |
+| `--max-iterations <N>` | no | 4 | Stop after N improvement cycles |
 | `--run-id <id>` | no | auto-generated | Base run ID (iterations append `-iter-N`) |
 | `--target-judge <name>` | no | all judges | Focus on a specific failing judge |
+| `--edit-budget <N>` | no | 4 | Max edits per iteration (ceiling — actual count is chosen adaptively) |
+| `--split <train:sel:test>` | no | `40:20:40` | Dataset split ratio |
+| `--update-mode <mode>` | no | `patch` | Edit mode: `patch` (surgical edits) or `rewrite` (full rewrite from proposals) |
 
 ### Config Discovery
 
@@ -36,20 +43,50 @@ After selecting a config, read its `skill` field to set `<eval-name>` (used in `
 ```bash
 mkdir -p tmp
 python3 ${CLAUDE_SKILL_DIR}/scripts/agent_eval/state.py init tmp/optimize-config.yaml \
-  model=<model> max_iterations=<N> run_id=<id> target_judge=<judge>
+  model=<model> max_iterations=<N> run_id=<id> target_judge=<judge> \
+  edit_budget=<budget> split=<ratio> update_mode=<mode>
+```
+
+### Initialize optimization state
+
+```bash
+test -f tmp/optimization-log.md || cat > tmp/optimization-log.md << 'EOF'
+# Optimization Log
+## Iteration History
+EOF
+
+test -f tmp/rejected-edits.yaml || echo "rejected_edits: []" > tmp/rejected-edits.yaml
+test -f tmp/meta-skill.md || echo "# Meta Skill" > tmp/meta-skill.md
+```
+
+### Split the dataset
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/split_dataset.py \
+  --dataset <dataset_path> \
+  --ratio <split_ratio> \
+  --output tmp/splits.yaml
+```
+
+```bash
+cat tmp/splits.yaml
 ```
 
 ## Step 1: Initial Eval Run
 
-If no recent eval results exist, run the eval suite first:
+If no recent eval results exist, run the eval suite on **train + selection** splits:
 
 ```text
-Use the Skill tool to invoke /eval-run --run-id <id>-iter-0 --config <config> [--model <model>]
+Use the Skill tool to invoke /eval-run --run-id <id>-iter-0 --config <config> [--model <model>] --case <train_and_selection_cases>
 ```
 
-Pass `--model` only if the user provided one — otherwise let `/eval-run` fall back to `models.skill` from eval.yaml. Pass the same model on every iteration for comparable results.
+Pass `--model` only if the user provided one. Pass the same model on every iteration.
 
-If results already exist (the user just ran `/eval-run`), skip this and use the existing run.
+If results already exist, use those — but note which cases are in train vs selection splits.
+
+If all judges pass on train+selection, run the test split to confirm generalization, report success, and exit.
+
+## Step 2: Identify Failures (Train Split Only)
 
 Read the results:
 
@@ -57,25 +94,19 @@ Read the results:
 python3 ${CLAUDE_SKILL_DIR}/scripts/agent_eval/state.py read $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>-iter-0/summary.yaml
 ```
 
-If all judges pass, report success and exit — nothing to improve.
+From `summary.yaml`, filter to **train-split cases only**. The selection split is reserved for gating.
 
-## Step 2: Identify Failures
-
-From `summary.yaml`, identify:
-
-1. **Which judges failed** — and on which cases
+1. **Which judges failed** — and on which train-split cases
 2. **Failure rationale** — what did each judge say about why it failed?
-3. **Failure patterns** — does one judge fail everywhere (systematic) or only on specific cases (input-dependent)?
+3. **Failure patterns** — systematic (one judge fails everywhere) or input-dependent (specific cases)?
 
-Also check for human feedback — these catch things judges miss:
+Check for human feedback:
 
 ```bash
 test -f $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/review.yaml && echo "REVIEW_EXISTS" || echo "NO_REVIEW"
 ```
 
-If `review.yaml` exists, read its `feedback` section (human feedback from `/eval-review`) and `mlflow_feedback` section (annotations pulled from MLflow UI). Human feedback is higher-signal than judge rationale — prioritize issues the user flagged.
-
-If `--target-judge` was specified, focus only on that judge's failures.
+If `review.yaml` exists, read its `feedback` and `mlflow_feedback` sections. Human feedback is higher-signal — prioritize it.
 
 Build a failure map, noting each judge's type (`judge_type` in results: `builtin`, `check`, `llm`, `code`) — the type determines what you can do about it:
 
@@ -89,114 +120,263 @@ judge_name (type) → [case_id, case_id, ...] → rationale for each
 human_review → [case_id, ...] → user comment for each
 ```
 
-## Step 3: Analyze Root Causes
+### Early exit: case-specific-only failures
 
-For each failure pattern, investigate why the skill produces bad output:
+If ALL failures are case-specific (single case per judge, and rationale points to input issues rather than skill issues), skip the optimization loop. Report to the user:
+- Which cases failed and why
+- That the failures appear input-dependent, not skill-dependent
+- Suggest `/eval-dataset --strategy expand` to improve test coverage, or judge tuning if the judge expectations are wrong
 
-1. **Read the skill's SKILL.md** — locate it via eval.yaml's `skill` field:
-   ```bash
-   python3 ${CLAUDE_SKILL_DIR}/../eval-analyze/scripts/find_skills.py --name <skill>
-   ```
+This prevents the optimizer from making unnecessary skill changes for test-case-quality problems.
 
-2. **Read transcripts** (if available) — transcripts can be very large, so delegate to an Agent. Check `run_result.json` for `execution_mode`: in `case` mode, each case has its own transcript at `$AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/cases/<case>/stdout.log`; in `batch` mode, there's one at `$AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/stdout.log`. Focus on the failing cases.
+## Step 3: Analyze Root Causes (Minibatch Reflection)
 
-   Include the specific judge failure in the prompt so the agent traces the causal chain rather than producing a generic summary:
-   ```text
-   Agent tool, subagent_type="Explore": "Read the transcript at <path>.
-   The judge '<judge_name>' (<judge_type>) failed this case with rationale:
-   '<rationale from summary.yaml>'
+### Build step context
 
-   Find evidence explaining WHY this failure happened:
-   - Where in the transcript did the skill handle (or skip) the relevant task?
-   - What instructions from SKILL.md led to this behavior?
-   - Did the skill attempt the right thing but produce wrong output, or skip it entirely?
-   - If it tried multiple approaches, which one stuck and why?"
-   ```
-
-   In `batch` mode, failures across cases may interact — ask the agent to check whether earlier cases' processing affected later ones.
-
-3. **Read failing case outputs** — use an Explore agent to examine the actual output files. Include what the judge expected so the comparison is targeted:
-   ```text
-   Agent tool, subagent_type="Explore": "Read the outputs in $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/cases/<failing_case>/.
-   The judge '<judge_name>' failed with: '<rationale>'.
-   Compare the actual output against this expectation — what specifically is missing or wrong?"
-   ```
-
-4. **Form hypotheses** — connect the judge rationale + transcript evidence + output examination to specific parts of the SKILL.md. Be specific: "The judge says the output is missing acceptance criteria. The transcript shows the skill skipped Step 4 of the pipeline. Step 4 in SKILL.md says 'optionally add acceptance criteria' — the word 'optionally' is the problem."
-
-## Step 4: Edit the Skill
-
-Apply targeted fixes to the SKILL.md. For each edit:
-
-- **Ground it in evidence** — cite the judge name, failing cases, and transcript evidence
-- **Be surgical** — change the minimum needed. Don't rewrite sections that are working.
-- **Explain the why** — use the Skill Creator's principle: explain to the model why the change matters, rather than adding rigid MUSTs
-- **Don't overfit** — if only 1 of 20 cases fails, the fix should be general enough to help without breaking the other 19
-
-Show each edit before applying. If the change is risky (could affect passing cases), note it.
-
-**Execution mode context**: check `execution.mode` in eval.yaml. In `case` mode, each case runs in its own isolated workspace with all case files copied in — the skill receives case-specific arguments resolved from input.yaml. In `batch` mode, all cases are in one workspace via batch.yaml. Your edits must work for the configured mode.
-
-## Step 5: Re-Run and Verify
-
-Re-run eval with the baseline flag. If only a subset of cases failed, target them with `--cases` for faster verification. Once targeted cases pass, do a final full run (all cases) to check for regressions.
-
-Consider `--no-llm-judges` when you only need to verify structural fixes — it skips LLM API calls and runs only deterministic judges (check, Python builtins), which is faster and cheaper.
-
-```text
-# Targeted re-run (failing cases only)
-Use the Skill tool to invoke /eval-run --run-id <id>-iter-<N> --cases <failing-case-id> [<failing-case-id> ...] --baseline <id>-iter-<N-1> --config <config> [--model <model>]
-
-# Full re-run (all cases) — use for final verification
-Use the Skill tool to invoke /eval-run --run-id <id>-iter-<N> --baseline <id>-iter-<N-1> --config <config> [--model <model>]
-```
-
-Read the new results:
+Combine the rejected-edit buffer and failure patterns from previous steps into a single context block. This gives the analyst a complete picture of what was already tried:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/agent_eval/state.py read $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>-iter-<N>/summary.yaml
+cat tmp/rejected-edits.yaml
+cat tmp/optimization-log.md
+cat tmp/meta-skill.md
 ```
 
-Check:
-- **Fixed**: did the targeted failures pass now?
-- **Regressions**: did any previously passing cases/judges now fail?
-- **Score improvement**: did aggregate scores improve?
+### Partition into minibatches
 
-## Step 6: Handle Regressions
+Partition failing cases into **groups of 5-8** and analyze each separately. Group by shared failing judge(s). Also form a separate success minibatch from passing cases.
 
-If the fix caused regressions (previously passing cases now fail):
+### Analyze failures and successes separately
 
-1. **Assess severity** — is the regression worse than the original failure?
-2. **If minor** — the fix is still a net positive, continue
-3. **If major** — revert the edit and try a different approach. The skill's instructions may need a different framing rather than a different rule.
-4. **If stuck** — report to the user what you tried and why it didn't work. Suggest `/eval-review --run-id <id>` for human input on the tricky cases.
+Spawn parallel sub-agents — one per minibatch. Use **different prompts** for failure and success analysis:
 
-## Step 7: Iterate or Report
+**For each failure minibatch**:
 
-If failures remain and iterations < max:
-- Go back to Step 2 with the new results
-- Each iteration should target different failures or try different approaches for persistent ones
+```text
+Agent tool, subagent_type="Explore": "Follow ${CLAUDE_SKILL_DIR}/prompts/failure-analysis.md.
+Cases: [list]. Skill: <path>. Transcripts: <paths>.
+Judge failures: <judge: rationale per case>.
+Step context: <rejected edits + failure patterns>. Meta-skill: <tmp/meta-skill.md>."
+```
 
-If all judges pass:
-- Report success: which edits fixed which failures, how many iterations it took
-- Show the final summary.yaml scores
+**For the success minibatch**:
+
+```text
+Agent tool, subagent_type="Explore": "Follow ${CLAUDE_SKILL_DIR}/prompts/success-analysis.md.
+Cases: [list]. Skill: <path>. Transcripts: <paths>."
+```
+
+### Hierarchical merge
+
+After all minibatches complete, merge proposals in stages — not a flat dedup:
+
+1. **Merge failure proposals**: if multiple failure minibatches proposed similar edits, merge them. Track **support count** — how many minibatches independently proposed each edit. Higher support = more systematic.
+2. **Merge success proposals**: consolidate "preserve" signals.
+3. **Final merge** with **failure priority**: combine failure and success proposals. Where they conflict (failure says change X, success says preserve X), failure takes precedence — but flag the conflict so you can monitor for regressions.
+4. **Filter**: discard edits with support count of 1 (single minibatch, likely case-specific).
+
+See `${CLAUDE_SKILL_DIR}/prompts/merge-proposals.md` for the merge framework.
+
+## Step 4: Rank, Budget, and Edit
+
+### Rank by expected utility
+
+Rank all merged proposals by four criteria:
+- **Systematic impact**: how many cases does this affect? (support count)
+- **Complementarity**: does this edit reinforce or conflict with other selected edits?
+- **Generality**: will this help unseen cases or only the train split?
+- **Actionability**: is the edit concrete and unambiguous?
+
+```
+1. [HIGH] Remove "optionally" from Step 4 — support: 3/3 minibatches, 6 cases, judge: content_quality
+2. [MEDIUM] Add output format example — support: 2/3, 3 cases, judge: format_check
+3. [LOW] Clarify error handling — support: 1/3, 1 case, judge: robustness
+```
+
+### Choose edit count (adaptive)
+
+Decide how many edits to apply this iteration — up to the `--edit-budget` ceiling (default 4). Don't use a fixed formula. Instead, look at the evidence:
+
+- **High-support proposals** (3/3 minibatches agree) → safe to apply more
+- **Conflicting proposals** (success signals vs failure edits) → apply fewer, monitor closely
+- **Many rejections in previous iterations** → be more conservative
+- **Many systematic failures remaining** → apply more edits
+- **Few sporadic failures** → apply fewer, more targeted edits
+- **Late iteration with proven edits to protect** → apply fewer
+
+State your reasoning: "Applying 3 of 5 proposals this iteration because support counts are high (2 at 3/3, 1 at 2/3) and no conflicts with success signals. Holding back 2 lower-support proposals for next iteration."
+
+Log remaining proposals for later iterations.
+
+### Apply fixes (patch mode — default)
+
+For each edit within budget:
+- **Ground in evidence** — cite judge, cases, transcript evidence, support count
+- **Be surgical** — change the minimum needed
+- **Explain the why** — explain to the model why the change matters, not rigid MUSTs
+- **Don't overfit** — a fix for 1/20 cases must be general enough for unseen cases
+- **Check rejected-edit buffer** — if a similar category was rejected, try a different approach
+- **Respect protected regions** — do NOT modify content between `<!-- SLOW_UPDATE_START -->` and `<!-- SLOW_UPDATE_END -->` markers. These are set by the consolidation step and can only be modified there.
+
+### Alternative: rewrite mode
+
+If `--update-mode rewrite` was specified, or if the skill has deep structural problems that surgical patches can't address (persistent failures surviving 3+ iterations):
+
+Instead of applying individual edits, produce a **complete skill rewrite** conditioned on all the merged proposals. Read `${CLAUDE_SKILL_DIR}/prompts/rewrite-skill.md` for the rewrite framework — it covers preservation rules, structural integration, voice consistency, and a validation checklist.
+
+Rewrite mode is a last resort — it risks undoing proven edits. Only use it when patch mode has plateaued.
+
+## Step 5: Validation Gate (Selection Split)
+
+Run eval on **train + selection** together, then separate scores by split. Pass case IDs as a comma-separated `--case` filter (the filter uses substring matching, so ensure case IDs are distinct enough to avoid false matches):
+
+```text
+Use the Skill tool to invoke /eval-run --run-id <id>-iter-<N> --baseline <id>-iter-<N-1> --config <config> [--model <model>] --case <train_and_selection_cases>
+```
+
+Consider `--no-llm-judges` when the edit only needs structural verification — it skips LLM API calls and runs only deterministic judges (check, Python builtins), which is faster and cheaper. Run the full judge set before accepting via the gate.
+
+**Accept only if selection-split score strictly improves.** Ties are rejected.
+
+**If accepted**: continue to Step 6.
+
+**If rejected**: record in rejected-edit buffer with score delta and edit category, revert SKILL.md, return to Step 3. On second rejection in the same iteration, reduce budget by 1 and try next-ranked edits.
+
+Record the rejection by appending to the YAML file:
+
+```bash
+python3 -c "
+import yaml
+with open('tmp/rejected-edits.yaml') as f:
+    data = yaml.safe_load(f) or {}
+data.setdefault('rejected_edits', []).append({
+    'iteration': <N>,
+    'edit_summary': '<what was tried>',
+    'category': '<edit type>',
+    'score_before': <X>,
+    'score_after': <Y>,
+    'reason': 'selection gate'
+})
+with open('tmp/rejected-edits.yaml', 'w') as f:
+    yaml.dump(data, f)
+"
+```
+
+## Step 6: Check Regressions
+
+From the train+selection results already computed in Step 5:
+
+- **Fixed**: did targeted failures pass?
+- **Regressions**: did previously passing cases/judges now fail?
+- **Net improvement**: did aggregate scores improve?
+
+If regressions:
+1. **Minor** (net positive) — continue
+2. **Major** — revert, record in rejected-edit buffer, try different approach
+3. **Stuck** — report to user, suggest `/eval-review` for human input
+
+### Track cumulative cost
+
+Sum costs across all iterations:
+
+```bash
+python3 -c "
+import json, glob, sys
+total = sum(json.load(open(f)).get('cost_usd', 0) or 0
+            for f in glob.glob('$AGENT_EVAL_RUNS_DIR/<eval-name>/<id>-iter-*/run_result.json'))
+print(f'Cumulative cost: \${total:.2f}')
+"
+```
+
+If cumulative exceeds 5× the iter-0 cost, warn the user that optimization may not be cost-effective.
+
+## Step 7: Consolidation (Iteration 2+)
+
+After iteration 2 or later, perform cross-iteration consolidation in two phases. Read `${CLAUDE_SKILL_DIR}/prompts/consolidation.md` for the full framework.
+
+**Phase 1**: Compare across all iterations — categorize each edit (stable/regressed/neutral), classify persistent failures, analyze which edit categories work for this skill.
+
+**Phase 2**: Using the Phase 1 analysis, write three artifacts: slow-update guidance, meta-skill update, and optimization log entry.
+
+### Write slow-update guidance
+
+If persistent patterns are found across epochs, write longitudinal guidance into a **protected region** of the skill document:
+
+```markdown
+<!-- SLOW_UPDATE_START -->
+[Guidance derived from cross-iteration analysis — stable procedural lessons]
+<!-- SLOW_UPDATE_END -->
+```
+
+Step-level edits (Step 4) must NOT modify content between these markers. Only this consolidation step can update the slow-update region. This separates fast intra-iteration learning from slower cross-iteration consolidation.
+
+### Update meta-skill
+
+The meta-skill captures what edit patterns work best for THIS skill — meta-level learning about the optimization process itself. It is NOT shipped with the skill — it's optimizer-side context only.
+
+```bash
+cat > tmp/meta-skill.md << 'EOF'
+# Meta Skill — Optimizer Context
+
+## Edit Patterns That Work
+- "removed_ambiguity" edits consistently improve scores on this skill
+- Examples with concrete output formats are effective
+
+## Edit Patterns That Fail
+- "added_constraint" edits get rejected — this skill needs explanation, not rules
+- Edits targeting Step 2 have been rejected twice — Step 2 works well as-is
+
+## Strategy Guidance
+- Prefer "changed_framing" over "added_constraint" for this skill
+- Success minibatches show Step 3 is the strongest section — preserve it
+EOF
+```
+
+This meta-skill is read at the start of Step 3 and injected into analyst prompts so they can make better proposals. It persists across iterations and is updated each consolidation step.
+
+### Update optimization log
+
+```bash
+cat >> tmp/optimization-log.md << 'EOF'
+### Iteration <N> Consolidation
+**Proven edits**: [list]
+**Persistent failures**: [list]
+**Effective patterns**: [categories]
+**Failed patterns**: [categories]
+**Strategy next**: [what to try differently]
+EOF
+```
+
+## Step 8: Iterate or Report
+
+If failures remain and iterations < max: go back to Step 2. Each iteration targets different failures or tries different approaches. The edit count is chosen adaptively each iteration — it may increase or decrease based on evidence quality.
+
+If all judges pass on train + selection:
+- Run the **test split** to confirm generalization:
+  ```text
+  Use the Skill tool to invoke /eval-run --run-id <id>-final-test --config <config> [--model <model>] --case <test_cases>
+  ```
+- Good test scores: report success with generalization confirmed
+- Low test scores: warn about overfitting
 
 If max iterations reached with failures remaining:
 - Report what was fixed and what couldn't be fixed
-- For persistent failures, explain what you tried and why it didn't work
-- Suggest `/eval-review --run-id <final-id>` for human assessment of the remaining issues
-- Suggest `/eval-dataset --strategy expand` if failures suggest missing test coverage
+- Include optimization log summary
+- If patch mode plateaued, suggest re-running with `--update-mode rewrite`
+- Suggest `/eval-review --run-id <final-id>` for human assessment
+- Suggest `/eval-dataset --strategy expand` if failures suggest missing coverage
 
-In all cases (include `--config <config>` if a non-default config was used):
-- Suggest `/eval-mlflow --run-id <final-id>` to log the optimization results to MLflow for tracking.
+Always suggest `/eval-mlflow --run-id <final-id>` to log results.
 
 ## Rules
 
-- **Never make broad, generic changes** — every edit must be grounded in a specific failure with evidence from judges and transcripts
-- **Check for regressions after every edit** — a fix that breaks other cases is not a fix
+- **Every edit must be grounded in evidence** — cite judge, cases, transcript evidence, support count. Never make broad, generic changes.
+- **Respect the edit budget ceiling** — choose the edit count adaptively but never exceed `--edit-budget`. State your reasoning.
+- **Respect the validation gate** — reject edits that don't improve selection scores. Record rejections.
+- **Don't modify protected regions** — content between SLOW_UPDATE markers can only be changed by consolidation.
+- **Read the step context** — rejected-edit buffer + failure patterns + meta-skill before proposing edits.
+- **Check for regressions** — a fix that breaks other cases is not a fix.
 - **Stop after max iterations** — don't loop forever. Report what couldn't be fixed.
-- **Don't modify test cases or judges** — the eval harness is the ground truth. If you think a judge is wrong, report it but don't change it. Builtin judges (from `agent_eval/judges/`) are versioned and shared — never edit their code. If a builtin judge's behavior needs adjustment, suggest changing its `arguments:` in eval.yaml instead. For inline check or LLM prompt judges, suggest improvements to the user but don't edit eval.yaml yourself.
-- **Don't modify eval.yaml** — your job is to improve the skill, not the evaluation config. If judges or arguments need updating, suggest it to the user.
-- **Try different approaches** — if the same type of edit fails twice, try a fundamentally different framing. Explain why instead of adding more rules.
+- **Don't modify test cases, judges, or eval.yaml** — the eval harness is the ground truth. Builtin judges (from `agent_eval/judges/`) are versioned and shared — never edit their code; if a builtin judge's behavior needs adjustment, suggest changing its `arguments:` in eval.yaml. For inline check or LLM prompt judges, suggest improvements to the user but don't edit eval.yaml yourself.
+- **Try different approaches** — if the same edit category fails twice, try a fundamentally different framing. Explain why instead of adding more rules.
 
 $ARGUMENTS

--- a/skills/eval-optimize/prompts/consolidation.md
+++ b/skills/eval-optimize/prompts/consolidation.md
@@ -1,0 +1,90 @@
+# Cross-Iteration Consolidation
+
+You are performing a longitudinal review after iteration N of skill optimization. This is a two-phase process — do it in two separate analyses to keep each focused.
+
+## Phase 1: Cross-Iteration Comparison
+
+Compare results across ALL iterations to identify patterns.
+
+### Input
+
+- Summary results from every iteration (iter-0 through iter-N)
+- The optimization log (what was tried, what worked, what failed)
+- The rejected-edit buffer
+
+### Categorize each edit
+
+For every edit applied across all iterations, classify it:
+
+1. **Stable improvement**: improved scores when introduced AND held across all subsequent iterations. These are proven.
+2. **Regression**: initially helped but scores degraded in later iterations (a later edit may have conflicted).
+3. **Neutral**: no measurable effect on scores. May be dead weight — consider removing.
+
+### Categorize persistent failures
+
+Failures surviving 2+ iterations of attempted fixes:
+- **Structural**: the skill's architecture can't address this — needs rewrite mode
+- **Input-dependent**: specific case types the skill isn't designed for — needs dataset expansion
+- **Judge mismatch**: the judge may be testing something unreasonable — flag for user review
+
+### Analyze edit patterns
+
+Which edit categories have been effective for THIS skill?
+- Track: "removed_ambiguity", "added_example", "clarified_instruction", "added_constraint", "changed_framing", "bundled_script"
+- Note which categories were accepted vs rejected, and for which skill sections
+
+### Output (Phase 1)
+
+```yaml
+comparison:
+  iteration: <N>
+  stable_improvements:
+    - edit: "description"
+      introduced: iter-1
+      judges_improved: [list]
+  regressions:
+    - edit: "description"
+      introduced: iter-2
+      regressed_in: iter-3
+  persistent_failures:
+    - judge: name
+      type: structural | input-dependent | judge-mismatch
+      attempts: N
+  edit_patterns:
+    effective: [categories]
+    ineffective: [categories]
+    untried: [categories]
+```
+
+## Phase 2: Write Consolidation Artifacts
+
+Using the Phase 1 analysis, produce three artifacts:
+
+### Slow-update guidance (goes into the skill)
+
+Write concise longitudinal guidance (5-15 lines) capturing stable procedural lessons. This is injected into the skill document between `<!-- SLOW_UPDATE_START/END -->` markers and is immune to step-level edits.
+
+Focus on:
+- Stable patterns that should be preserved across future iterations
+- Warnings about fragile sections (sections where edits have regressed)
+- Procedural insights that are more durable than specific rules
+
+### Meta-skill update (optimizer-side only, NOT shipped)
+
+Write updated optimizer-side guidance about what works for this skill:
+- Which edit categories to prefer and avoid
+- Which skill sections are resilient vs fragile
+- Strategic recommendations for the next iteration
+
+### Optimization log entry
+
+Record the consolidation findings for the iteration history:
+
+```
+### Iteration <N> Consolidation
+**Proven edits**: [list]
+**Persistent failures**: [list with type classification]
+**Effective patterns**: [categories]
+**Failed patterns**: [categories]
+**Strategy next**: [what to try differently]
+```

--- a/skills/eval-optimize/prompts/failure-analysis.md
+++ b/skills/eval-optimize/prompts/failure-analysis.md
@@ -1,0 +1,70 @@
+# Failure Minibatch Analysis
+
+You are analyzing a minibatch of **failing** test cases to identify **common patterns** — not individual quirks.
+
+## Input
+
+You will receive:
+- The skill's SKILL.md (what the skill is supposed to do)
+- Transcripts or outputs from several failing cases (the minibatch)
+- Judge names and rationale for each failure
+- Step context: rejected-edit buffer (what was already tried and failed) + failure patterns from previous steps
+- Meta-skill context: guidance about which edit patterns have historically worked or failed for this skill
+
+## Analysis Framework
+
+For EACH case in the minibatch, answer:
+1. Did the skill follow its own instructions? Which steps were unclear or skipped?
+2. Did it take roundabout paths or try multiple approaches before succeeding/failing?
+3. Did sub-skills or sub-agents behave unexpectedly?
+4. Were there errors that were silently recovered but led to degraded output?
+
+Then, across ALL cases, identify:
+
+### Common Patterns (most valuable)
+- What failure mode appears in 3+ cases? This is a systematic skill issue.
+- Is there a specific SKILL.md instruction that was misinterpreted consistently?
+- Is there a missing instruction that would have prevented the failures?
+
+### Case-Specific Issues (lower value)
+- Failures that appear in only 1 case — these are likely input-dependent, not skill issues.
+- Mark these as "case-specific" so the optimizer can filter them out.
+
+## Output Format
+
+```yaml
+common_patterns:
+  - pattern: "Step 4 skipped because 'optionally' was interpreted as 'skip'"
+    affected_cases: [case-003, case-007, case-012, case-015]
+    judges: [content_quality]
+    proposed_edit:
+      location: "Step 4, line 'optionally add acceptance criteria'"
+      change: "Remove 'optionally' — acceptance criteria are required"
+      rationale: "6/8 cases skipped this step; the word 'optionally' signals it's unimportant"
+    category: "removed_ambiguity"
+
+  - pattern: "Output format missing headers"
+    affected_cases: [case-003, case-012]
+    judges: [format_check]
+    proposed_edit:
+      location: "Output section"
+      change: "Add explicit format template with required headers"
+      rationale: "Skill describes format in prose but never shows an example"
+    category: "added_example"
+
+case_specific:
+  - case: case-007
+    issue: "Input had unusual encoding that confused the parser"
+    recommendation: "Not a skill issue — may need test case fix"
+
+preserve:
+  - "Step 2 (validation) works well — all cases passed validation judges"
+  - "The error handling in Step 5 correctly caught and reported issues"
+```
+
+## Rules
+
+- Focus on COMMON patterns, not individual edge cases
+- Every proposed edit must include a `category` (e.g., "removed_ambiguity", "added_example", "clarified_instruction", "added_constraint", "changed_framing")
+- The category is used to match against the rejected-edit buffer — if a "added_constraint" edit to the same section was already rejected, try "changed_framing" instead
+- Propose edits that are general enough to help unseen cases, not just the minibatch

--- a/skills/eval-optimize/prompts/merge-proposals.md
+++ b/skills/eval-optimize/prompts/merge-proposals.md
@@ -1,0 +1,73 @@
+# Hierarchical Proposal Merge
+
+You are merging edit proposals from multiple minibatch analyses into a single ranked list. This is NOT a simple dedup — it's a structured merge that resolves conflicts, tracks support counts, and applies failure priority.
+
+## Input
+
+You will receive:
+- Proposals from failure minibatches (each with `common_patterns`, `case_specific`, `preserve`)
+- Proposals from the success minibatch (`preserve`, `fragile`, `reinforcement`)
+- The rejected-edit buffer (edits to avoid re-proposing)
+
+## Merge Process
+
+### Stage 1: Merge failure proposals
+
+For each pair of proposals from different failure minibatches:
+
+1. **Identical edits** (same location + same change): merge into one, sum the `affected_cases`, increment **support count**
+2. **Similar edits** (same location, different change): keep both as alternatives, note the conflict
+3. **Complementary edits** (different locations, both corrective): keep both, check they don't contradict
+4. **Contradictory edits** (one says add X, another says remove X): keep the one with higher support count, flag the other as conflicted
+
+### Stage 2: Merge success proposals
+
+Consolidate all "preserve" and "reinforcement" signals into a protection list — sections of the skill that are working well.
+
+### Stage 3: Final merge (failure priority)
+
+Combine failure edits and success preservation:
+
+1. **No conflict**: failure edit targets a section not flagged by success → keep the edit
+2. **Conflict**: failure edit modifies a section that success flagged as "strong" → keep the edit BUT flag it as **high-risk for regression**. The validation gate will catch regressions, but flagging helps the optimizer be cautious.
+3. **Fragile sections**: if a failure edit targets a section marked "fragile" by success analysis → apply with extra care; consider testing this edit in isolation
+
+### Stage 4: Filter
+
+- Discard edits with support count of 1 AND fewer than 3 affected cases — likely case-specific. Exception: if there is only 1 failure minibatch (small dataset), skip this filter — all edits have support count 1 by definition.
+- Discard edits whose `category` + `location` match a rejected edit in the buffer
+- Discard `case_specific` entries (these are for logging, not for edits)
+
+## Output Format
+
+```yaml
+merged_edits:
+  - edit:
+      location: "Step 4, line 'optionally add acceptance criteria'"
+      change: "Remove 'optionally' — acceptance criteria are required"
+      category: "removed_ambiguity"
+    support_count: 3
+    affected_cases: [case-003, case-007, case-012, case-015, case-018, case-020]
+    judges: [content_quality]
+    risk: "low"  # no conflict with success signals
+
+  - edit:
+      location: "Output section"
+      change: "Add explicit format template with required headers"
+      category: "added_example"
+    support_count: 2
+    affected_cases: [case-003, case-012, case-018]
+    judges: [format_check]
+    risk: "medium"  # conflicts with success signal on output section (fragile)
+
+protection_list:
+  - section: "Step 3 (validation)"
+    strength: "high"
+    reason: "All success cases follow this correctly"
+
+conflicts:
+  - location: "Step 5"
+    failure_proposal: "Add explicit error format requirement"
+    success_signal: "Step 5 error handling works well as-is"
+    resolution: "Apply failure edit, monitor for regression"
+```

--- a/skills/eval-optimize/prompts/rewrite-skill.md
+++ b/skills/eval-optimize/prompts/rewrite-skill.md
@@ -1,0 +1,53 @@
+# Skill Rewrite from Proposals
+
+You are rewriting a complete SKILL.md based on accumulated edit proposals from multiple optimization iterations. This is a **last resort** — used when surgical patch edits have plateaued and the skill needs structural changes.
+
+## Input
+
+You will receive:
+- The current SKILL.md (with all accumulated patches)
+- Ranked edit proposals from the merge step (with support counts)
+- Success-preservation signals (what works and must be kept)
+- The optimization log (what was tried across iterations)
+- The meta-skill (which edit patterns work for this skill)
+
+## Rewrite Principles
+
+### 1. Preserve what works
+
+Read the success-analysis signals carefully. Sections flagged as "high strength" must survive the rewrite intact — reword if needed for flow, but don't change the substance. If a section is marked `<!-- SLOW_UPDATE_START -->`, copy it verbatim.
+
+### 2. Integrate proposals structurally
+
+Don't just apply the proposals as patches to the old text. Rethink the skill's organization to naturally accommodate the needed changes. For example, if multiple proposals say "add output format guidance," don't add it as an afterthought — integrate it into the relevant workflow step.
+
+### 3. Explain the why
+
+The most common reason patch edits plateau is that they add rules ("MUST do X") without explaining why. The rewrite is an opportunity to replace accumulated rules with explanations that help the model understand the intent.
+
+### 4. Keep it lean
+
+A rewrite should be shorter than or equal to the original — not longer. The current skill may have accumulated redundant patches. The rewrite consolidates them.
+
+### 5. Maintain the voice
+
+The rewrite should feel like the same skill, not a different one. Preserve the overall structure (step numbering, argument format, tool references), the terminology, and the tone.
+
+## Output
+
+Write the complete new SKILL.md. Include:
+- The same YAML frontmatter (name, description, allowed-tools)
+- All steps, renumbered if needed
+- All script/prompt/reference file references (paths must stay valid)
+- The slow-update protected region (copied verbatim)
+- The $ARGUMENTS placeholder at the end
+
+## Validation checklist
+
+Before finalizing, verify:
+- [ ] Every script reference path is still valid
+- [ ] Every prompt file reference is still valid
+- [ ] The slow-update region is preserved verbatim
+- [ ] Success-preservation sections are intact
+- [ ] The skill is shorter than or equal to the original
+- [ ] All proposals with support count > 1 are addressed

--- a/skills/eval-optimize/prompts/success-analysis.md
+++ b/skills/eval-optimize/prompts/success-analysis.md
@@ -1,0 +1,57 @@
+# Success Minibatch Analysis
+
+You are analyzing a minibatch of **passing** test cases to identify what the skill does well and what should be preserved during optimization.
+
+## Input
+
+You will receive:
+- The skill's SKILL.md
+- Transcripts or outputs from several passing cases (the minibatch)
+- Judge names and scores for each case
+
+## Analysis Framework
+
+For EACH passing case, identify:
+1. Which SKILL.md instructions did the model follow effectively?
+2. Were there any close calls — steps where the model almost went wrong but recovered?
+3. What about the skill's framing or structure made it work well for this case?
+
+Then, across ALL cases, identify:
+
+### Working Patterns
+- Which sections of the SKILL.md are consistently followed?
+- Which instructions produce the highest-quality output?
+- Are there patterns in how the model interprets the skill that should be reinforced?
+
+### Fragile Successes
+- Cases that passed but barely — the model struggled before arriving at the right answer
+- Instructions that the model followed correctly but seemed to misunderstand initially
+
+## Output Format
+
+```yaml
+preserve:
+  - section: "Step 3 (validation)"
+    reason: "All 6 cases followed this step correctly — clear, unambiguous instructions"
+    strength: "high"
+
+  - section: "Output format template"
+    reason: "5/6 cases produced correctly formatted output matching the template"
+    strength: "high"
+
+fragile:
+  - section: "Step 5 (error handling)"
+    reason: "2 cases initially skipped error handling, then self-corrected on re-read"
+    risk: "If Step 5 is modified by failure fixes, these cases might break"
+
+reinforcement:
+  - "The 'why' explanation in Step 4 is effective — cases that followed it produced better output"
+  - "The example in the Output section is referenced in 4/6 transcripts — it drives correct behavior"
+```
+
+## Rules
+
+- Your job is PRESERVATION, not correction — identify what works and flag it
+- "Preserve" signals will be merged with failure-analysis edits, with failure taking priority — but your signals help prevent regressions
+- Focus on the SKILL.md sections, not the individual cases — what about the instructions makes them work?
+- If a section is strong, say so — this prevents the failure analyst from accidentally weakening it

--- a/skills/eval-optimize/references/optimization-controls.md
+++ b/skills/eval-optimize/references/optimization-controls.md
@@ -1,0 +1,109 @@
+# Optimization Controls Reference
+
+Controls that prevent overfitting, over-editing, or retrying failed approaches.
+
+## 1. Data Splitting
+
+| Split | Default % | Purpose | When used |
+|-------|-----------|---------|-----------|
+| Train | 40% | Generate edit candidates | Steps 2-4 |
+| Selection | 20% | Validation gate | Step 5 |
+| Test | 40% | Final measurement only | Step 8 |
+
+Splitting is deterministic (seed 42). Use `scripts/split_dataset.py`. Tiny datasets (< 3 cases): all cases used in all splits. Small datasets (3-9 cases): train and selection overlap.
+
+## 2. Edit Budget (Adaptive)
+
+The `--edit-budget` argument (default 4) is a **ceiling**, not a fixed count. The LLM chooses how many edits to apply each iteration based on evidence:
+
+| Signal | More edits | Fewer edits |
+|--------|-----------|-------------|
+| Support counts | High (3/3 minibatches) | Low (1/3) |
+| Conflict with success signals | No conflicts | Conflicts flagged |
+| Previous rejections | Few or none | Many in recent iterations |
+| Failure pattern | Systematic (many cases) | Sporadic (1-2 cases) |
+| Proven edits to protect | Few | Many |
+
+The LLM must state its reasoning when choosing the count: which signals it considered and why it chose N edits. This makes the decision auditable and helps future iterations calibrate.
+
+Minimum: 1 edit per iteration (otherwise the iteration is wasted). Maximum: `--edit-budget` ceiling.
+
+## 3. Validation Gate
+
+Selection-split score must **strictly improve**. Ties rejected. On rejection: record edit + delta in `tmp/rejected-edits.yaml`, revert, return to Step 3. Second rejection reduces budget by 1.
+
+## 4. Rejected-Edit Buffer
+
+File: `tmp/rejected-edits.yaml`. Records rejected edits with `category`, `score_before`, `score_after`, `reason`. The optimizer reads this before proposing edits — if the same `category` + `location` was rejected, try a different category.
+
+## 5. Minibatch Reflection
+
+Groups of 5-8 cases analyzed in parallel. **Failure and success analyzed separately** with different prompts:
+
+- `prompts/failure-analysis.md` — identifies failure patterns, proposes corrective edits with categories
+- `prompts/success-analysis.md` — identifies working patterns, flags fragile sections
+
+Why separate? Failure analysis needs hypothesis formation ("why did this break?"). Success analysis needs preservation reasoning ("why does this work?"). Combining them produces muddled output.
+
+## 6. Hierarchical Merge
+
+After minibatch analysis, proposals are merged in stages — not flat dedup:
+
+1. **Merge failure proposals** — track support count (how many minibatches independently proposed each edit)
+2. **Merge success proposals** — consolidate preservation signals
+3. **Final merge with failure priority** — failure edits take precedence over preservation, but conflicts are flagged
+4. **Filter** — discard support-1 edits and edits matching rejected-edit buffer
+
+See `prompts/merge-proposals.md` for the full framework.
+
+## 7. Protected Slow-Update Region
+
+The skill document can contain a protected region:
+
+```markdown
+<!-- SLOW_UPDATE_START -->
+[Longitudinal guidance from cross-iteration consolidation]
+<!-- SLOW_UPDATE_END -->
+```
+
+**Step-level edits (Step 4) must NOT modify content between these markers.** Only the consolidation step (Step 7) can update this region. This separates fast intra-iteration learning from slower cross-iteration consolidation.
+
+The slow-update captures stable procedural lessons that have proven effective across multiple iterations — the "long-term memory" of the optimization process.
+
+## 8. Meta-Skill (Optimizer-Side Learning)
+
+File: `tmp/meta-skill.md`. Captures what edit patterns work best for THIS specific skill — meta-level learning about the optimization process itself.
+
+**Key difference from the optimization log**: the log records events (what happened). The meta-skill extracts strategies (what to do next time). The meta-skill is injected into analyst prompts so they can make better proposals.
+
+**Not shipped with the skill** — it's optimizer-side context only. Keeps the deployed skill compact.
+
+Updated at each consolidation step (Step 7).
+
+## 9. Update Modes
+
+| Mode | When to use | How it works |
+|------|-------------|--------------|
+| **patch** (default) | Most iterations | Surgical edits: append, insert, replace, delete. Respects protected regions. |
+| **rewrite** | Persistent failures after 3+ iterations | Full skill rewrite conditioned on accumulated proposals. Risks undoing proven edits — use as last resort. |
+
+Controlled by `--update-mode`. If patch mode plateaus (persistent failures not improving), suggest switching to rewrite for the next iteration.
+
+## 10. Cost Tracking
+
+After each iteration, report cumulative cost from `run_result.json`. If cumulative exceeds 5× single-run cost, warn the user.
+
+```
+Iteration 1: $2.30 (cumulative: $2.30)
+Iteration 2: $2.15 (cumulative: $4.45)
+Iteration 3: $1.90 (cumulative: $6.35) ⚠️ 2.8× single-run cost
+```
+
+## 11. Edit Ranking Criteria
+
+When ranking edits for clipping to the budget, score each on:
+
+1. **Systematic impact** — support count from minibatches + number of affected cases
+2. **Complementarity** — does this edit reinforce or conflict with other selected edits?
+3. **Generality** — will this help unseen cases? (edits affecting diverse case types rank higher)
+4. **Actionability** — is the edit concrete, unambiguous, and testable?

--- a/skills/eval-optimize/references/optimization-controls.md
+++ b/skills/eval-optimize/references/optimization-controls.md
@@ -2,6 +2,26 @@
 
 Controls that prevent overfitting, over-editing, or retrying failed approaches.
 
+## 0. Strategy Selection
+
+`/eval-optimize --strategy` selects how much of this machinery runs:
+
+| Strategy | When | What runs |
+|----------|------|-----------|
+| `lite` | Small datasets / quick fixes | Linear flow + always-on controls only |
+| `skillopt` | Larger datasets, many iterations | Everything below |
+| `auto` (default) | — | `lite` if the dataset has **< 20 cases**, else `skillopt` |
+
+The 20-case threshold matches `split_dataset.py`'s degenerate-split handling — below it, train/selection/test splits and minibatches are statistical noise, so the lightweight flow is cheaper and more reliable.
+
+**Always-on (both strategies):**
+- Evidence-grounded edits
+- Regression check after edits
+- Rejected-edit buffer (control 4)
+- Judge-type awareness (`builtin`/`check`/`llm`/`code`)
+
+**SkillOpt-only (gated controls):** everything else below — data splitting (1), edit budget (2), validation gate (3), minibatch reflection (5), hierarchical merge (6), protected slow-update region (7), meta-skill (8), rewrite mode (9), cost tracking (10), edit ranking (11).
+
 ## 1. Data Splitting
 
 | Split | Default % | Purpose | When used |

--- a/skills/eval-optimize/scripts/split_dataset.py
+++ b/skills/eval-optimize/scripts/split_dataset.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Split a dataset into train/selection/test partitions for optimization.
+
+Deterministic splitting with a fixed seed ensures reproducibility across
+iterations. The split ratio is specified as train:selection:test (e.g., 40:20:40).
+
+Usage:
+    python3 split_dataset.py --dataset <path> --ratio 40:20:40 --output tmp/splits.yaml
+"""
+
+import argparse
+import random
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def split_cases(case_ids, ratio_str, seed=42):
+    """Split case IDs into train/selection/test according to ratio.
+
+    For small datasets (< 10 cases), train and selection overlap to ensure
+    the validation gate has enough signal.
+    """
+    parts = [int(x) for x in ratio_str.split(":")]
+    if len(parts) != 3:
+        print(f"ERROR: ratio must be train:sel:test (got {ratio_str})",
+              file=sys.stderr)
+        sys.exit(1)
+
+    total_ratio = sum(parts)
+    n = len(case_ids)
+
+    rng = random.Random(seed)
+    shuffled = list(case_ids)
+    rng.shuffle(shuffled)
+
+    if n < 3:
+        # Tiny dataset: use all cases in all splits
+        train = list(shuffled)
+        selection = list(shuffled)
+        test = list(shuffled)
+    elif n < 10:
+        # Small dataset: overlap train and selection, ensure non-empty
+        n_test = max(1, round(n * parts[2] / total_ratio))
+        n_train_sel = max(1, n - n_test)
+        train = shuffled[:n_train_sel]
+        selection = list(train)  # overlap
+        test = shuffled[n_train_sel:]
+    else:
+        n_train = max(1, round(n * parts[0] / total_ratio))
+        n_sel = max(1, round(n * parts[1] / total_ratio))
+        train = shuffled[:n_train]
+        selection = shuffled[n_train:n_train + n_sel]
+        test = shuffled[n_train + n_sel:]
+
+    return {
+        "train": sorted(train),
+        "selection": sorted(selection),
+        "test": sorted(test),
+        "ratio": ratio_str,
+        "seed": seed,
+        "total_cases": n,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Split dataset for optimization")
+    parser.add_argument("--dataset", required=True, help="Path to dataset/cases dir")
+    parser.add_argument("--ratio", default="40:20:40", help="train:sel:test ratio")
+    parser.add_argument("--output", default="tmp/splits.yaml", help="Output file")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    args = parser.parse_args()
+
+    dataset_path = Path(args.dataset)
+    if not dataset_path.is_dir():
+        print(f"ERROR: dataset path does not exist: {dataset_path}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    case_ids = sorted(
+        d.name for d in dataset_path.iterdir()
+        if d.is_dir() and not d.name.startswith(".")
+    )
+
+    if not case_ids:
+        print(f"ERROR: no case directories found in {dataset_path}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    splits = split_cases(case_ids, args.ratio, args.seed)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        yaml.dump(splits, f, default_flow_style=False)
+
+    print(f"Split {splits['total_cases']} cases ({args.ratio}):")
+    print(f"  train ({len(splits['train'])}): {', '.join(splits['train'])}")
+    print(f"  selection ({len(splits['selection'])}): {', '.join(splits['selection'])}")
+    print(f"  test ({len(splits['test'])}): {', '.join(splits['test'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_split_dataset.py
+++ b/tests/test_split_dataset.py
@@ -1,0 +1,80 @@
+"""Tests for split_dataset.py edge cases."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills/eval-optimize/scripts"))
+
+from split_dataset import split_cases
+
+
+def test_single_case_all_splits_populated():
+    result = split_cases(["a"], "40:20:40")
+    assert len(result["train"]) >= 1
+    assert len(result["selection"]) >= 1
+    assert len(result["test"]) >= 1
+
+
+def test_two_cases_all_splits_populated():
+    result = split_cases(["a", "b"], "40:20:40")
+    assert len(result["train"]) >= 1
+    assert len(result["selection"]) >= 1
+    assert len(result["test"]) >= 1
+
+
+def test_tiny_dataset_uses_all_cases_everywhere():
+    result = split_cases(["a", "b"], "40:20:40")
+    assert set(result["train"]) == {"a", "b"}
+    assert set(result["selection"]) == {"a", "b"}
+    assert set(result["test"]) == {"a", "b"}
+
+
+def test_small_dataset_train_selection_overlap():
+    cases = [f"case-{i:03d}" for i in range(5)]
+    result = split_cases(cases, "40:20:40")
+    assert len(result["train"]) >= 1
+    assert result["selection"] == result["train"]
+    assert len(result["test"]) >= 1
+
+
+def test_normal_dataset_no_overlap():
+    cases = [f"case-{i:03d}" for i in range(20)]
+    result = split_cases(cases, "40:20:40")
+    train_set = set(result["train"])
+    sel_set = set(result["selection"])
+    test_set = set(result["test"])
+    assert train_set.isdisjoint(sel_set)
+    assert train_set.isdisjoint(test_set)
+    assert sel_set.isdisjoint(test_set)
+    assert train_set | sel_set | test_set == set(cases)
+
+
+def test_deterministic_with_same_seed():
+    cases = [f"case-{i:03d}" for i in range(20)]
+    r1 = split_cases(cases, "40:20:40", seed=42)
+    r2 = split_cases(cases, "40:20:40", seed=42)
+    assert r1["train"] == r2["train"]
+    assert r1["selection"] == r2["selection"]
+    assert r1["test"] == r2["test"]
+
+
+def test_different_seed_different_split():
+    cases = [f"case-{i:03d}" for i in range(20)]
+    r1 = split_cases(cases, "40:20:40", seed=42)
+    r2 = split_cases(cases, "40:20:40", seed=99)
+    assert r1["train"] != r2["train"]
+
+
+def test_ratio_respected_approximately():
+    cases = [f"case-{i:03d}" for i in range(100)]
+    result = split_cases(cases, "40:20:40")
+    assert 35 <= len(result["train"]) <= 45
+    assert 15 <= len(result["selection"]) <= 25
+    assert 35 <= len(result["test"]) <= 45
+
+
+def test_all_cases_accounted_for():
+    cases = [f"case-{i:03d}" for i in range(20)]
+    result = split_cases(cases, "40:20:40")
+    all_assigned = result["train"] + result["selection"] + result["test"]
+    assert sorted(all_assigned) == sorted(cases)


### PR DESCRIPTION
## Summary

Makes the `/eval-optimize` strategy **selectable** instead of forcing one approach on every run. Adds a SkillOpt-style control set — inspired by [SkillOpt](https://arxiv.org/abs/2605.23904) (Microsoft, 2026), which treats skill documents as trainable external state — for larger datasets, while keeping a lightweight linear flow as the default for the common small-eval case.

Originally this PR *replaced* the simple optimize loop wholesale. Based on review, it now layers the heavy machinery behind a `--strategy` flag that auto-selects by dataset size — so small evals stay cheap and simple, and only larger ones pay for splitting / minibatches / consolidation.

## `--strategy lite|skillopt|auto` (default `auto`)

- **`lite`** — lightweight linear flow: identify failures → analyze → edit → re-run/verify → check regressions → iterate. The pre-overhaul behavior; best for small datasets and quick fixes.
- **`skillopt`** — the full control set below.
- **`auto`** (default) — `lite` for datasets with **< 20 cases**, `skillopt` for ≥ 20. Below ~20 cases the train/selection/test splits and minibatches are statistical noise, so the lightweight flow is cheaper and more reliable.

**One flow, conditional depth:** `lite` is the spine of `SKILL.md`; the SkillOpt machinery is gated behind clearly-marked **"SkillOpt mode"** callouts, so the two paths can't drift apart. Both strategies share always-on safeguards — evidence-grounded edits, regression checks after each edit, and a rejected-edit buffer that prevents retrying failed approaches.

## SkillOpt-mode controls

**Core**
- Data splitting with a validation gate (default `40:20:40`, deterministic seed; small/tiny datasets handled gracefully)
- Bounded, adaptive edit budget (ceiling default 4; the count is chosen per-iteration from the evidence, not a fixed formula)
- Edit ranking by expected utility (systematic impact, complementarity, generality, actionability)

**Reflection & merge**
- Minibatch reflection (parallel sub-agents, groups of 5–8)
- Separate failure vs. success analysis prompts (different cognitive tasks)
- Hierarchical merge with support counts and conflict tracking

**Longitudinal learning**
- Protected slow-update region (`<!-- SLOW_UPDATE_START/END -->`)
- Meta-skill (optimizer-side learning about effective edit patterns; not shipped with the skill)
- Two-phase cross-iteration consolidation + optimization log

**Operational**
- Cumulative cost tracking with a 5× warning threshold
- Rewrite mode as a fallback when patches plateau
- Test-split generalization check
- Early-exit fast path for case-specific-only failures

## Structure

```
skills/eval-optimize/
├── SKILL.md                            # orchestration — lite spine + SkillOpt callouts
├── prompts/
│   ├── failure-analysis.md
│   ├── success-analysis.md
│   ├── merge-proposals.md
│   ├── consolidation.md
│   └── rewrite-skill.md
├── references/optimization-controls.md # control reference + strategy selection
└── scripts/split_dataset.py            # deterministic splitting
tests/test_split_dataset.py
```

## Integration with current main

Rebased onto `main` (1.10.0). The merge preserves main's recent eval-optimize improvements alongside the new flow:
- Config auto-discovery (`--config` optional)
- `$AGENT_EVAL_RUNS_DIR/<eval-name>/<id>` run-path scheme
- Builtin judge-type awareness (`builtin` / `check` / `llm` / `code`)

## What eval-optimize already had that SkillOpt doesn't

- Human feedback integration (`review.yaml` + MLflow annotations)
- Sub-agent delegation for large transcript analysis
- Explicit regression handling with revert capability
- Pipeline composition with `/eval-run`, `/eval-review`, `/eval-mlflow`

## Test plan

- [ ] `/eval-optimize --strategy lite` on a small eval (e.g. rfe-creator dedup, 4 cases) — confirm no splits/minibatches/gate engage
- [ ] `/eval-optimize --strategy skillopt` — full loop: validation gate, consolidation, test split
- [ ] `/eval-optimize` (auto) picks `lite` for < 20 cases and `skillopt` for ≥ 20
- [ ] `split_dataset.py` produces deterministic, reproducible splits; handles `< 3` and `< 10` cases
- [ ] Validation gate rejects neutral edits (ties); rejected-edit buffer prevents retry loops

Ref: https://arxiv.org/abs/2605.23904

🤖 Generated with [Claude Code](https://claude.com/claude-code)
