### PR TITLE
Add CI lint workflow with skillsaw

### DIFF
--- a/.github/workflows/lint-review.yml
+++ b/.github/workflows/lint-review.yml
@@ -1,0 +1,21 @@
+name: Lint Review
+
+on:
+  workflow_run:
+    workflows: ["Lint"]
+    types: [completed]
+
+jobs:
+  review:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+
+    - name: Post skillsaw review comments
+      uses: stbenjam/skillsaw/review@d252498eb6260e197c9c395a650643d9c49ae37b # v0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+
+    - name: Run skillsaw
+      uses: stbenjam/skillsaw@d252498eb6260e197c9c395a650643d9c49ae37b # v0
+      with:
+        strict: 'true'
+

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -1,0 +1,19 @@
+# skillsaw configuration
+# https://github.com/stbenjam/skillsaw
+
+version: "0.11.4"
+
+rules:
+  context-budget:
+    enabled: true
+    severity: warning
+    limits:
+      skill:
+        warn: 4500
+        error: 8000
+
+  content-critical-position:
+    enabled: true
+    severity: info
+
+strict: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate install uninstall test test-e2e test-all help
+.PHONY: validate install uninstall test test-e2e test-all help skillsaw skillsaw-fix lint
 
 MARKETPLACE := agent-eval-harness-dev
 PLUGIN := agent-eval-harness@$(MARKETPLACE)
@@ -27,11 +27,33 @@ test-e2e:
 test-all:
 	python3 -m pytest tests/ -v -s -m ""
 
+skillsaw: ## Run skillsaw linter on skills and plugins
+	@echo "Running skillsaw..."
+	@if [ -n "$${SKILLSAW_BIN:-}" ]; then \
+		"$${SKILLSAW_BIN}"; \
+	else \
+		uvx skillsaw; \
+	fi
+
+skillsaw-fix: ## Auto-fix fixable skillsaw issues
+	@echo "Fixing skillsaw issues..."
+	@if [ -n "$${SKILLSAW_BIN:-}" ]; then \
+		"$${SKILLSAW_BIN}" fix; \
+	else \
+		uvx skillsaw fix; \
+	fi
+
+lint: ## Run all linters
+	@$(MAKE) skillsaw
+
 help:
 	@echo "Available targets:"
-	@echo "  validate   - Validate plugin manifest"
-	@echo "  install    - Install plugin persistently via local marketplace"
-	@echo "  uninstall  - Remove plugin and local marketplace"
-	@echo "  test       - Run unit tests"
-	@echo "  test-e2e   - Run e2e tests (requires ANTHROPIC_API_KEY)"
-	@echo "  test-all   - Run all tests"
+	@echo "  validate    - Validate plugin manifest"
+	@echo "  install     - Install plugin persistently via local marketplace"
+	@echo "  uninstall   - Remove plugin and local marketplace"
+	@echo "  test        - Run unit tests"
+	@echo "  test-e2e    - Run e2e tests (requires ANTHROPIC_API_KEY)"
+	@echo "  test-all    - Run all tests"
+	@echo "  skillsaw    - Run skillsaw linter on skills"
+	@echo "  skillsaw-fix - Auto-fix fixable skillsaw issues"
+	@echo "  lint        - Run all linters"

--- a/skills/eval-dataset/SKILL.md
+++ b/skills/eval-dataset/SKILL.md
@@ -169,7 +169,7 @@ known_issues:
 ```
 
 Check the eval.yaml `judges` section for:
-- Any `check` snippets that access `outputs.get("annotations", {})` — those fields must exist in annotations.yaml for the judge to work correctly.
+- Any `check` snippets that access `outputs.get("annotations", {})` — those fields must exist in annotations.yaml for the judge to work.
 - Any `if` conditions (e.g., `if: "annotations.get('dedup_is_duplicate')"`) — these control which judges run per case based on annotation values. Create cases that exercise **both branches** of each conditional judge: some cases where the condition is true (judge runs) and some where it's false (judge is skipped). If all cases have the same annotation value, a conditional judge either always runs or never runs — both are gaps in coverage.
 
 **Companion files**: If eval.md lists `companion_files` (files the skill reads from disk at runtime — e.g., `strategy.md`, `adr.md`), each test case must include them. In `case` mode, the harness copies all case files into the workspace, so the skill will find them at their expected relative paths. Generate realistic content for these files appropriate to each case's scenario.

--- a/skills/eval-mlflow/SKILL.md
+++ b/skills/eval-mlflow/SKILL.md
@@ -33,7 +33,7 @@ print(f'MLFLOW_TRACKING_URI={os.environ.get(\"MLFLOW_TRACKING_URI\", \"not set\"
 "
 ```
 
-If not configured, suggest running `/eval-setup` first. The scripts resolve the tracking URI from `mlflow.tracking_uri` in eval.yaml first, then `MLFLOW_TRACKING_URI` env var, then default to `http://127.0.0.1:5000`. If the server is unreachable but a remote URI is set, proceed — the scripts handle connectivity errors gracefully.
+If not configured, suggest running `/eval-setup` first. The scripts resolve the tracking URI from `mlflow.tracking_uri` in eval.yaml first, then `MLFLOW_TRACKING_URI` env var, then default to `http://127.0.0.1:5000`. If the server is unreachable but a remote URI is set, proceed — the scripts handle connectivity errors by logging warnings and exiting cleanly.
 
 ## Step 2: Read Configuration
 
@@ -161,10 +161,10 @@ Suggest next steps (include `--config <config>` if a non-default config was used
 
 ## Rules
 
-- **Read the schema** — understand `dataset.schema` to build the mapping correctly. The mapping is the critical step — everything downstream depends on it.
+- **Read the schema** — understand `dataset.schema` to build the mapping accurately. The mapping is the critical step — everything downstream depends on it.
 - **No hardcoded fields** — determine inputs vs expectations by reading the schema descriptions, not by assuming field names.
 - **Graceful degradation** — if MLflow is not available, scripts exit 0 and the skill reports "MLflow not available, skipping."
 - **Idempotent** — safe to run multiple times. `merge_records` deduplicates, `log_feedback` overwrites.
-- **Don't block on traces** — trace feedback is optional. If no traces exist, skip and note that tracing is configured automatically by `/eval-run`.
+- **Don't block on traces** — trace feedback is optional. If no traces exist, skip and state that tracing is configured automatically by `/eval-run`.
 
 $ARGUMENTS

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -182,7 +182,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/collect.py \
   --output $AGENT_EVAL_RUNS_DIR/<id>
 ```
 
-Read the collection summary (JSON file — do not use `state.py` on it):
+Read the collection summary (JSON file — read it with `cat` or `jq`, not `state.py`):
 
 ```bash
 cat $AGENT_EVAL_RUNS_DIR/<id>/collection.json


### PR DESCRIPTION
## Summary
- Add `.skillsaw.yaml` configuration and skillsaw/lint Makefile targets
- Add GitHub Actions `lint.yml` workflow for CI and `lint-review.yml` for inline PR review comments
- Fix skillsaw content warnings in skills

## Test plan
- [ ] `make skillsaw` passes locally
- [ ] `make lint` passes locally
- [ ] CI lint workflow runs on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified annotation requirements and artifact collection guidance
  * Updated MLflow verification guidance for unreachable servers

* **Chores**
  * Added automated linting workflows, including a PR review job that posts automated review comments
  * Introduced strict linting configuration and new local make targets for running/fixing linters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->