### PR TITLE
fix(ci): bump Node.js to 22 for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install semantic-release
         run: >-


### PR DESCRIPTION
## Summary

Bump Node.js from 20 to 22 in the release workflow. semantic-release@25.0.3 requires `^22.14.0 || >= 24.10.0` and fails on Node.js 20:

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.
```

See: https://github.com/opendatahub-io/agent-eval-harness/actions/runs/26524529544/job/78124692104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js runtime version used in the release build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->