### PR TITLE
feat: add Harbor EvalHub provider for K8s benchmark execution

### DIFF
--- a/agent_eval/harbor/adapter.py
+++ b/agent_eval/harbor/adapter.py
@@ -1,0 +1,461 @@
+"""EvalHub FrameworkAdapter for Harbor benchmarks.
+
+Runs Harbor benchmark tasks via the harbor CLI, parses trial results,
+and maps them to EvalHub JobResults for MLflow persistence.
+
+Supports three modes:
+  - Live: runs `harbor run` and parses results (default)
+  - Kubernetes: runs tasks as K8s Jobs via k8s_runner
+  - Import: parses pre-existing results from a jobs directory
+"""
+
+import logging
+import subprocess
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agent_eval.harbor.results_parser import parse_job
+
+try:
+    from evalhub.adapter import (
+        EvaluationResult,
+        FrameworkAdapter,
+        JobCallbacks,
+        JobResults,
+        JobSpec,
+        JobStatus,
+        JobPhase,
+        JobStatusUpdate,
+    )
+    from evalhub.adapter.models.job import MessageInfo
+except ImportError:
+    from agent_eval.evalhub.stubs import (  # type: ignore[assignment]
+        EvaluationResult,
+        FrameworkAdapter,
+        JobCallbacks,
+        JobResults,
+        JobSpec,
+        JobStatus,
+        JobPhase,
+        JobStatusUpdate,
+        MessageInfo,
+    )
+
+log = logging.getLogger(__name__)
+
+
+def _framework_adapter_init(adapter_instance):
+    FrameworkAdapter.__init__(adapter_instance)
+
+
+def _build_job_results(
+    config: JobSpec,
+    job_data: dict,
+    agent_name: str,
+    model_name: str,
+    task_path: str,
+    duration_s: float,
+) -> JobResults:
+    """Map parsed Harbor job data to EvalHub JobResults."""
+    trials = job_data["trials"]
+    all_metrics = []
+
+    mean_reward = job_data["mean_reward"]
+    if mean_reward is None:
+        log.warning("mean_reward is None — no trials completed successfully")
+        mean_reward = 0.0
+    all_metrics.append(EvaluationResult(
+        metric_name="mean_reward",
+        metric_value=mean_reward,
+        metric_type="benchmark",
+    ))
+
+    all_metrics.append(EvaluationResult(
+        metric_name="num_trials",
+        metric_value=len(trials),
+        metric_type="count",
+    ))
+
+    all_metrics.append(EvaluationResult(
+        metric_name="num_errored",
+        metric_value=job_data["n_errored"],
+        metric_type="count",
+    ))
+
+    for trial in trials:
+        prefix = trial["task_name"].replace("/", "_")
+        for metric in trial["metrics"]:
+            all_metrics.append(EvaluationResult(
+                metric_name=f"{prefix}/{metric.metric_name}",
+                metric_value=metric.metric_value,
+                metric_type=metric.metric_type,
+            ))
+
+    evaluation_metadata = {
+        "harbor_job_id": job_data["job_id"],
+        "agent": agent_name,
+        "task_path": task_path,
+        "n_completed": job_data["n_completed"],
+        "n_errored": job_data["n_errored"],
+    }
+    if model_name:
+        evaluation_metadata["model"] = model_name
+
+    total_cost = sum(
+        m.metric_value for t in trials for m in t["metrics"]
+        if m.metric_name == "cost_usd" and m.metric_value is not None
+    )
+    if total_cost:
+        all_metrics.append(EvaluationResult(
+            metric_name="total_cost_usd",
+            metric_value=total_cost,
+            metric_type="cost",
+        ))
+
+    return JobResults(
+        id=config.id,
+        benchmark_id=config.benchmark_id,
+        benchmark_index=config.benchmark_index,
+        model_name=model_name or agent_name,
+        results=all_metrics,
+        overall_score=job_data["mean_reward"],
+        num_examples_evaluated=len(trials),
+        duration_seconds=duration_s,
+        completed_at=datetime.now(timezone.utc),
+        evaluation_metadata=evaluation_metadata,
+    )
+
+
+class HarborAdapter(FrameworkAdapter):
+    """EvalHub adapter that runs Harbor benchmark tasks.
+
+    Orchestrates: harbor run -> parse results -> map to JobResults.
+
+    If jobs_dir is provided, skips harbor run and parses existing results.
+    """
+
+    def __init__(
+        self,
+        task_path: str | None = None,
+        jobs_dir: str | None = None,
+        execution_mode: str | None = None,
+    ):
+        _framework_adapter_init(self)
+        self._task_path = task_path
+        self._jobs_dir = jobs_dir
+        self._execution_mode = execution_mode
+
+    def run_benchmark_job(
+        self, config: JobSpec, callbacks: JobCallbacks
+    ) -> JobResults:
+        start_time = time.monotonic()
+        params = config.parameters or {}
+
+        task_path = self._task_path or params.get("task_path", "")
+        agent_name = params.get("agent", "oracle")
+        model_name = params.get("model") or (config.model.name if config.model else "") or ""
+        jobs_dir = self._jobs_dir or params.get("jobs_dir")
+        execution_mode = self._execution_mode or params.get("execution_mode", "harbor")
+
+        if jobs_dir:
+            return self._import_results(
+                config, callbacks, Path(jobs_dir),
+                agent_name, model_name, task_path, start_time,
+            )
+
+        if execution_mode == "kubernetes":
+            return self._run_k8s(
+                config, callbacks,
+                task_path, agent_name, model_name, params, start_time,
+            )
+
+        return self._run_harbor(
+            config, callbacks,
+            task_path, agent_name, model_name, params, start_time,
+        )
+
+    def _run_harbor(
+        self,
+        config: JobSpec,
+        callbacks: JobCallbacks,
+        task_path: str,
+        agent_name: str,
+        model_name: str,
+        params: dict,
+        start_time: float,
+    ) -> JobResults:
+        """Run harbor CLI and parse fresh results."""
+        if not task_path:
+            raise ValueError("task_path is required (via constructor or job parameters)")
+
+        n_concurrent = int(params.get("n_concurrent", 1))
+        timeout_multiplier = float(params.get("timeout_multiplier", 1.0))
+
+        self._report_status(
+            callbacks,
+            status=JobStatus.RUNNING,
+            phase=JobPhase.INITIALIZING,
+            message=f"Preparing harbor run: {task_path} agent={agent_name}",
+        )
+
+        jobs_dir = tempfile.mkdtemp(prefix="harbor-evalhub-")
+        job_name = f"evalhub-{config.id[:8]}" if config.id else "evalhub-run"
+
+        self._report_status(
+            callbacks,
+            status=JobStatus.RUNNING,
+            phase=JobPhase.RUNNING_EVALUATION,
+            message=f"Running harbor: {task_path}",
+        )
+
+        cmd = [
+            "harbor", "run",
+            "-p", task_path,
+            "-a", agent_name,
+            "--jobs-dir", jobs_dir,
+            "--job-name", job_name,
+            "--n-concurrent", str(n_concurrent),
+            "--timeout-multiplier", str(timeout_multiplier),
+        ]
+        if model_name:
+            cmd.extend(["-m", model_name])
+
+        log.info("Running: %s", " ".join(cmd))
+
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=7200,
+        )
+
+        if result.returncode != 0:
+            log.error("harbor run failed (exit %d): %s", result.returncode, result.stderr)
+            self._report_status(
+                callbacks,
+                status=JobStatus.FAILED,
+                phase=JobPhase.RUNNING_EVALUATION,
+                message=f"harbor run failed: {result.stderr[:200]}",
+            )
+            return JobResults(
+                id=config.id,
+                benchmark_id=config.benchmark_id,
+                model_name=model_name or agent_name,
+                results=[EvaluationResult(
+                    metric_name="harbor_exit_code",
+                    metric_value=result.returncode,
+                    metric_type="status",
+                )],
+                overall_score=0.0,
+                num_examples_evaluated=0,
+                duration_seconds=time.monotonic() - start_time,
+                completed_at=datetime.now(timezone.utc),
+                evaluation_metadata={"stderr": result.stderr[:1000]},
+            )
+
+        job_dir = Path(jobs_dir) / job_name
+        return self._parse_and_map(
+            config, callbacks, job_dir,
+            agent_name, model_name, task_path, start_time,
+        )
+
+    def _run_k8s(
+        self,
+        config: JobSpec,
+        callbacks: JobCallbacks,
+        task_path: str,
+        agent_name: str,
+        model_name: str,
+        params: dict,
+        start_time: float,
+    ) -> JobResults:
+        """Run Harbor task as a Kubernetes Job."""
+        from agent_eval.harbor.k8s_runner import run_task_job
+
+        task_image = params.get("task_image", "")
+        namespace = params.get("namespace", "evalhub")
+        timeout = int(params.get("timeout_sec", 600))
+        cpu = params.get("cpu", "2")
+        memory = params.get("memory", "4Gi")
+        run_as_user = int(params.get("run_as_user", 1001))
+        env_from_secrets = params.get("env_from_secrets", [])
+        if isinstance(env_from_secrets, str):
+            env_from_secrets = [env_from_secrets]
+        env_from_configmaps = params.get("env_from_configmaps", [])
+        if isinstance(env_from_configmaps, str):
+            env_from_configmaps = [env_from_configmaps]
+        secret_volumes = params.get("secret_volumes", [])
+
+        if not task_image:
+            raise ValueError("task_image is required for kubernetes execution mode")
+
+        task_name = task_path.replace("/", "-").replace("tasks-", "")
+
+        self._report_status(
+            callbacks,
+            status=JobStatus.RUNNING,
+            phase=JobPhase.RUNNING_EVALUATION,
+            message=f"Running K8s Job: {task_name} (agent={agent_name})",
+        )
+
+        result = run_task_job(
+            task_name=task_name,
+            task_image=task_image,
+            namespace=namespace,
+            timeout_sec=timeout,
+            cpu=cpu,
+            memory=memory,
+            run_as_user=run_as_user,
+            env_from_secrets=env_from_secrets,
+            env_from_configmaps=env_from_configmaps,
+            agent=agent_name,
+            model=model_name,
+            secret_volumes=secret_volumes,
+        )
+
+        all_metrics = [
+            EvaluationResult(
+                metric_name="reward",
+                metric_value=result["reward"],
+                metric_type="benchmark",
+            ),
+            EvaluationResult(
+                metric_name="mean_reward",
+                metric_value=result["reward"],
+                metric_type="benchmark",
+            ),
+            EvaluationResult(
+                metric_name="duration_seconds",
+                metric_value=result["duration_s"],
+                metric_type="performance",
+            ),
+            EvaluationResult(
+                metric_name="num_trials",
+                metric_value=1,
+                metric_type="count",
+            ),
+        ]
+
+        job_results = JobResults(
+            id=config.id,
+            benchmark_id=config.benchmark_id,
+            benchmark_index=config.benchmark_index,
+            model_name=model_name or agent_name,
+            results=all_metrics,
+            overall_score=result["reward"],
+            num_examples_evaluated=1,
+            duration_seconds=time.monotonic() - start_time,
+            completed_at=datetime.now(timezone.utc),
+            evaluation_metadata={
+                "agent": agent_name,
+                "task_path": task_path,
+                "task_image": task_image,
+                "execution_mode": "kubernetes",
+                "exit_code": result["exit_code"],
+                "test_output": result["stdout"][-50000:] if result.get("stdout") else "",
+            },
+        )
+
+        status = JobStatus.COMPLETED if result["exit_code"] == 0 else JobStatus.FAILED
+        self._report_status(
+            callbacks,
+            status=status,
+            phase=JobPhase.COMPLETED,
+            message=f"K8s Job complete: reward={result['reward']}",
+            progress=1.0,
+        )
+
+        return job_results
+
+    def _import_results(
+        self,
+        config: JobSpec,
+        callbacks: JobCallbacks,
+        jobs_dir: Path,
+        agent_name: str,
+        model_name: str,
+        task_path: str,
+        start_time: float,
+    ) -> JobResults:
+        """Parse pre-existing Harbor results without running harbor."""
+        self._report_status(
+            callbacks,
+            status=JobStatus.RUNNING,
+            phase=JobPhase.LOADING_DATA,
+            message=f"Importing results from {jobs_dir}",
+        )
+
+        if (jobs_dir / "result.json").exists():
+            job_dir = jobs_dir
+        else:
+            subdirs = [
+                d for d in sorted(jobs_dir.iterdir())
+                if d.is_dir() and (d / "result.json").exists()
+            ]
+            if not subdirs:
+                raise FileNotFoundError(f"No Harbor result.json found in {jobs_dir}")
+            job_dir = subdirs[0]
+
+        return self._parse_and_map(
+            config, callbacks, job_dir,
+            agent_name, model_name, task_path, start_time,
+        )
+
+    def _parse_and_map(
+        self,
+        config: JobSpec,
+        callbacks: JobCallbacks,
+        job_dir: Path,
+        agent_name: str,
+        model_name: str,
+        task_path: str,
+        start_time: float,
+    ) -> JobResults:
+        """Parse a Harbor job directory and map to JobResults."""
+        self._report_status(
+            callbacks,
+            status=JobStatus.RUNNING,
+            phase=JobPhase.POST_PROCESSING,
+            message="Parsing harbor results",
+        )
+
+        job_data = parse_job(job_dir)
+
+        job_results = _build_job_results(
+            config, job_data,
+            agent_name, model_name, task_path,
+            duration_s=time.monotonic() - start_time,
+        )
+
+        self._report_status(
+            callbacks,
+            status=JobStatus.COMPLETED,
+            phase=JobPhase.COMPLETED,
+            message=f"Harbor benchmark complete: {len(job_data['trials'])} trials, mean_reward={job_data['mean_reward']}",
+            progress=1.0,
+        )
+
+        return job_results
+
+    @staticmethod
+    def _report_status(
+        callbacks: JobCallbacks,
+        status: str,
+        phase: str,
+        message: str,
+        progress: float | None = None,
+        total_steps: int | None = None,
+        completed_steps: int | None = None,
+    ) -> None:
+        try:
+            update = JobStatusUpdate(
+                status=status,
+                phase=phase,
+                progress=progress,
+                message=MessageInfo(message=message, message_code="info"),
+                total_steps=total_steps,
+                completed_steps=completed_steps,
+                timestamp=datetime.now(timezone.utc),
+            )
+            callbacks.report_status(update)
+        except Exception as exc:
+            log.warning("Failed to report status: %s", exc)

--- a/agent_eval/harbor/k8s_runner.py
+++ b/agent_eval/harbor/k8s_runner.py
@@ -1,0 +1,238 @@
+"""Run Harbor benchmark tasks as Kubernetes Jobs.
+
+Creates a K8s Job from a pre-built task image (which includes solution
+and test files baked in), runs the oracle and verifier, collects the
+reward from pod logs.
+"""
+
+import logging
+import shlex
+import time
+from typing import Any
+
+try:
+    from kubernetes import client, config
+    from kubernetes.client.rest import ApiException
+    _K8S_AVAILABLE = True
+except ImportError:
+    _K8S_AVAILABLE = False
+    client = None  # type: ignore[assignment]
+    config = None  # type: ignore[assignment]
+    ApiException = Exception  # type: ignore[assignment,misc]
+
+log = logging.getLogger(__name__)
+
+
+def _require_k8s():
+    if not _K8S_AVAILABLE:
+        raise RuntimeError(
+            "kubernetes package is required for K8s execution. "
+            "Install with: pip install 'agent-eval-harness[evalhub]'"
+        )
+
+
+def _load_k8s_config():
+    _require_k8s()
+    try:
+        config.load_incluster_config()
+    except config.ConfigException:
+        config.load_kube_config()
+
+
+def _oracle_script() -> str:
+    return """#!/bin/bash
+set -o pipefail
+cd /app
+mkdir -p /logs/verifier
+bash /solution/solve.sh
+bash /tests/test.sh
+echo "HARBOR_REWARD=$(cat /logs/verifier/reward.txt 2>/dev/null || echo 0)"
+"""
+
+
+def _agent_script(model: str = "") -> str:
+    model_flag = f"--model {shlex.quote(model)}" if model else ""
+    return f"""#!/bin/bash
+set -o pipefail
+cd /app
+mkdir -p /logs/verifier
+
+# Set up MLflow tracing hook if mlflow is available
+if python3 -c "import mlflow" 2>/dev/null; then
+  mkdir -p $HOME/.claude
+  cat > $HOME/.claude/settings.json << 'SETTINGS'
+{{"hooks":{{"Stop":[{{"hooks":[{{"type":"command","command":"python3 -c \\"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\\"" }}]}}]}}}}
+SETTINGS
+fi
+
+claude -p --dangerously-skip-permissions {model_flag} \
+  "Read /app/instruction.md and implement the solution in this codebase. You may run go test on the affected packages to verify your work and iterate until tests pass. Do not modify files under /tests/."
+
+bash /tests/test.sh
+echo "HARBOR_REWARD=$(cat /logs/verifier/reward.txt 2>/dev/null || echo 0)"
+"""
+
+
+def _build_volumes(
+    secret_volumes: list[dict] | None,
+) -> tuple[list | None, list | None]:
+    if not secret_volumes:
+        return None, None
+    volumes = []
+    volume_mounts = []
+    for sv in secret_volumes:
+        vol_name = f"secret-{sv['secret_name']}"
+        items = None
+        if sv.get("items"):
+            items = [
+                client.V1KeyToPath(key=item["key"], path=item["path"])
+                for item in sv["items"]
+            ]
+        volumes.append(
+            client.V1Volume(
+                name=vol_name,
+                secret=client.V1SecretVolumeSource(
+                    secret_name=sv["secret_name"],
+                    items=items,
+                ),
+            )
+        )
+        volume_mounts.append(
+            client.V1VolumeMount(
+                name=vol_name,
+                mount_path=sv["mount_path"],
+                read_only=True,
+            )
+        )
+    return volumes, volume_mounts
+
+
+def run_task_job(
+    task_name: str,
+    task_image: str,
+    namespace: str,
+    timeout_sec: int = 600,
+    cpu: str = "2",
+    memory: str = "4Gi",
+    run_as_user: int = 1001,
+    env_from_secrets: list[str] | None = None,
+    env_from_configmaps: list[str] | None = None,
+    agent: str = "oracle",
+    model: str = "",
+    secret_volumes: list[dict] | None = None,
+) -> dict[str, Any]:
+    """Run a Harbor task as a K8s Job and return the result.
+
+    Returns dict with keys: reward, stdout, duration_s, exit_code
+    """
+    _load_k8s_config()
+    batch_v1 = client.BatchV1Api()
+    core_v1 = client.CoreV1Api()
+
+    job_name = f"harbor-{task_name}-{int(time.monotonic()) % 100000}"
+
+    if agent == "oracle":
+        script = _oracle_script()
+    elif agent in ("claude-code", "agent"):
+        script = _agent_script(model=model)
+    else:
+        raise ValueError(f"Unknown agent: {agent!r}. Must be 'oracle', 'claude-code', or 'agent'.")
+
+    volumes, volume_mounts = _build_volumes(secret_volumes)
+
+    job = client.V1Job(
+        metadata=client.V1ObjectMeta(name=job_name, namespace=namespace),
+        spec=client.V1JobSpec(
+            backoff_limit=0,
+            active_deadline_seconds=timeout_sec,
+            template=client.V1PodTemplateSpec(
+                spec=client.V1PodSpec(
+                    restart_policy="Never",
+                    security_context=client.V1PodSecurityContext(
+                        run_as_user=run_as_user,
+                    ),
+                    volumes=volumes,
+                    containers=[
+                        client.V1Container(
+                            name="task",
+                            image=task_image,
+                            image_pull_policy="Always",
+                            command=["/bin/bash", "-c", script],
+                            resources=client.V1ResourceRequirements(
+                                requests={"cpu": cpu, "memory": memory},
+                                limits={"cpu": cpu, "memory": memory},
+                            ),
+                            env_from=[
+                                *[
+                                    client.V1EnvFromSource(
+                                        secret_ref=client.V1SecretEnvSource(name=s)
+                                    )
+                                    for s in (env_from_secrets or [])
+                                ],
+                                *[
+                                    client.V1EnvFromSource(
+                                        config_map_ref=client.V1ConfigMapEnvSource(name=c)
+                                    )
+                                    for c in (env_from_configmaps or [])
+                                ],
+                            ] or None,
+                            volume_mounts=volume_mounts,
+                        )
+                    ],
+                ),
+            ),
+        ),
+    )
+
+    start_time = time.monotonic()
+    log.info("Creating K8s Job %s in %s", job_name, namespace)
+    batch_v1.create_namespaced_job(namespace, job)
+
+    reward = 0.0
+    stdout = ""
+    exit_code = -1
+
+    try:
+        while time.monotonic() - start_time < timeout_sec + 30:
+            job_status = batch_v1.read_namespaced_job_status(job_name, namespace)
+
+            if job_status.status.succeeded:
+                exit_code = 0
+                break
+            if job_status.status.failed:
+                exit_code = 1
+                break
+
+            time.sleep(5)
+
+        pods = core_v1.list_namespaced_pod(
+            namespace, label_selector=f"job-name={job_name}"
+        )
+        if pods.items:
+            pod_name = pods.items[0].metadata.name
+            try:
+                stdout = core_v1.read_namespaced_pod_log(pod_name, namespace)
+                for line in stdout.splitlines():
+                    if line.startswith("HARBOR_REWARD="):
+                        try:
+                            reward = float(line.split("=", 1)[1].strip())
+                        except (ValueError, TypeError):
+                            log.warning("Malformed reward line: %s", line)
+            except ApiException as e:
+                log.warning("Failed to read pod logs: %s", e)
+
+    finally:
+        try:
+            batch_v1.delete_namespaced_job(
+                job_name, namespace, propagation_policy="Background",
+            )
+        except ApiException:
+            pass
+
+    duration = time.monotonic() - start_time
+    return {
+        "reward": reward,
+        "stdout": stdout,
+        "duration_s": round(duration, 1),
+        "exit_code": exit_code,
+    }

--- a/agent_eval/harbor/results_parser.py
+++ b/agent_eval/harbor/results_parser.py
@@ -1,0 +1,96 @@
+"""Parse Harbor job result.json into structured trial data."""
+
+import json
+from pathlib import Path
+
+try:
+    from evalhub.adapter import EvaluationResult
+except ImportError:
+    from agent_eval.evalhub.stubs import EvaluationResult
+
+
+_METRIC_TYPES = {
+    "reward": "benchmark",
+    "mean_reward": "benchmark",
+    "duration_s": "performance",
+    "cost_usd": "cost",
+    "input_tokens": "count",
+    "output_tokens": "count",
+    "env_build_seconds": "performance",
+    "agent_exec_seconds": "performance",
+    "verifier_seconds": "performance",
+}
+
+
+def parse_job(job_dir: Path) -> dict:
+    """Parse a Harbor job directory and return structured results.
+
+    Args:
+        job_dir: Path to the job directory containing result.json.
+
+    Returns:
+        Dict with keys: job_id, trials, mean_reward, n_completed, n_errored.
+        Each trial has task_name and metrics (list of EvaluationResult).
+
+    Raises:
+        FileNotFoundError: If result.json doesn't exist in job_dir.
+    """
+    result_path = job_dir / "result.json"
+    if not result_path.exists():
+        raise FileNotFoundError(f"No result.json found in {job_dir}")
+
+    with open(result_path) as f:
+        raw = json.load(f)
+
+    trials = []
+    completed_rewards = []
+    n_errored = 0
+
+    for raw_trial in raw.get("trials", []):
+        status = raw_trial.get("status", "completed")
+
+        if status == "errored":
+            n_errored += 1
+            trials.append({
+                "task_name": raw_trial["task_name"],
+                "metrics": [],
+            })
+            continue
+
+        reward = raw_trial.get("reward")
+        if reward is not None:
+            completed_rewards.append(reward)
+
+        metrics = []
+        metrics.append(EvaluationResult(
+            metric_name="reward",
+            metric_value=reward if reward is not None else 0.0,
+            metric_type="benchmark",
+        ))
+
+        for key, value in raw_trial.get("metrics", {}).items():
+            if value is not None:
+                metrics.append(EvaluationResult(
+                    metric_name=key,
+                    metric_value=value,
+                    metric_type=_METRIC_TYPES.get(key, "float"),
+                ))
+
+        trials.append({
+            "task_name": raw_trial["task_name"],
+            "metrics": metrics,
+        })
+
+    mean_reward = (
+        sum(completed_rewards) / len(completed_rewards)
+        if completed_rewards
+        else None
+    )
+
+    return {
+        "job_id": raw.get("job_id", ""),
+        "trials": trials,
+        "mean_reward": mean_reward,
+        "n_completed": len(completed_rewards),
+        "n_errored": n_errored,
+    }

--- a/deploy/harbor/Containerfile
+++ b/deploy/harbor/Containerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi9/python-312:latest
+WORKDIR /app
+COPY pyproject.toml .
+RUN pip install --no-cache-dir ".[evalhub]" "kubernetes>=29.0,<32.0" "mlflow-skinny>=3.5"
+COPY agent_eval/ agent_eval/
+COPY deploy/harbor/entrypoint.py .
+ENTRYPOINT ["python3", "entrypoint.py"]

--- a/deploy/harbor/configmap-template.yaml
+++ b/deploy/harbor/configmap-template.yaml
@@ -1,0 +1,84 @@
+# AUTO-GENERATED — do not edit directly.
+# Regenerate: bash deploy/harbor/generate-configmap.sh > deploy/harbor/configmap-template.yaml
+#
+# Source: deploy/harbor/provider.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-provider-harbor-bench
+  namespace: redhat-ods-applications
+  labels:
+    app.kubernetes.io/part-of: trustyai
+    app.opendatahub.io/trustyai: "true"
+    trustyai.opendatahub.io/evalhub-provider-type: system
+    trustyai.opendatahub.io/evalhub-provider-name: harbor-bench
+    opendatahub.io/managed: "true"
+data:
+  provider.yaml: |
+    name: harbor-bench
+    id: harbor-bench
+    title: Harbor Benchmark Evaluation
+    description: >
+      Run Harbor agentic coding benchmarks and report results to EvalHub.
+      Supports any Harbor task dataset with configurable agents and models.
+      Measures reward (pass/fail), execution time, token usage, and cost.
+    version: "0.1.0"
+
+    benchmarks:
+      - id: harbor-task
+        name: harbor-task
+        description: "Run Harbor benchmark tasks with two-stage verification"
+        category: agent-evaluation
+        parameters:
+          task_path:
+            type: string
+            required: true
+            description: "Path to Harbor task or dataset directory"
+          task_image:
+            type: string
+            required: true
+            description: "Pre-built task container image (registry/repo:tag)"
+          execution_mode:
+            type: string
+            default: kubernetes
+            description: "Execution mode: kubernetes (K8s Jobs) or harbor (local Docker)"
+          agent:
+            type: string
+            default: oracle
+            description: "Harbor agent name (oracle, claude-code, etc.)"
+          model:
+            type: string
+            description: "Model identifier (e.g. anthropic/claude-sonnet-4-6)"
+          namespace:
+            type: string
+            default: evalhub
+            description: "Namespace for K8s Job execution"
+          timeout_sec:
+            type: integer
+            default: 600
+            description: "Task timeout in seconds"
+        metrics:
+          - reward
+          - mean_reward
+          - duration_seconds
+          - env_build_seconds
+          - agent_exec_seconds
+          - verifier_seconds
+          - cost_usd
+          - input_tokens
+          - output_tokens
+        primary_score:
+          metric: mean_reward
+          lower_is_better: false
+    runtime:
+      k8s:
+        image: image-registry.openshift-image-registry.svc:5000/evalhub/harbor-bench-provider:latest
+        entrypoint:
+          - python3
+          - entrypoint.py
+        cpu_request: "1"
+        memory_request: "2Gi"
+        cpu_limit: "4"
+        memory_limit: "8Gi"
+      local:
+        command: python3 deploy/harbor/entrypoint.py

--- a/deploy/harbor/entrypoint.py
+++ b/deploy/harbor/entrypoint.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+import logging
+import os
+import sys
+import tempfile
+import traceback
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    stream=sys.stderr,
+)
+log = logging.getLogger("entrypoint")
+
+from evalhub.adapter import JobSpec, DefaultCallbacks
+from agent_eval.harbor.adapter import HarborAdapter
+
+
+def _log_test_artifact(run_id: str, results) -> None:
+    """Log test output as an MLflow artifact if mlflow is available."""
+    test_output = (results.evaluation_metadata or {}).get("test_output", "")
+    if not test_output:
+        return
+    try:
+        import mlflow
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", prefix="test_output_", delete=False) as f:
+            f.write(test_output)
+            tmp_path = f.name
+        try:
+            mlflow.log_artifact(tmp_path, run_id=run_id)
+            log.info("Logged test_output artifact (%d bytes)", len(test_output))
+        finally:
+            os.unlink(tmp_path)
+    except ImportError:
+        log.debug("mlflow not installed, skipping artifact logging")
+    except Exception as exc:
+        log.warning("Failed to log test artifact (non-fatal): %s", exc)
+
+
+def main():
+    config_path = sys.argv[1] if len(sys.argv) > 1 else "/meta/job.json"
+    log.info("Loading job spec from %s", config_path)
+    try:
+        spec = JobSpec.from_file(config_path)
+    except FileNotFoundError:
+        sys.exit(f"Job spec not found: {config_path}")
+    except Exception as e:
+        sys.exit(f"Failed to load job spec from {config_path}: {e}")
+    log.info("Job: id=%s provider=%s benchmark=%s", spec.id, spec.provider_id, spec.benchmark_id)
+    log.info("Model: %s / %s", spec.model.url, spec.model.name)
+    log.info("Parameters: keys=%s", list(spec.parameters.keys()) if spec.parameters else "none")
+
+    if not getattr(spec, 'experiment_name', None):
+        log.warning(
+            "No experiment name in job spec — MLflow results will NOT be saved. "
+            "Set experiment: {name: ...} in the job config YAML."
+        )
+
+    task_path = os.environ.get("HARBOR_TASK_PATH", "")
+    adapter = HarborAdapter(task_path=task_path or None)
+    callbacks = DefaultCallbacks(job_id=spec.id, benchmark_id=spec.benchmark_id)
+
+    log.info("Starting run_benchmark_job...")
+    try:
+        results = adapter.run_benchmark_job(spec, callbacks)
+    except Exception:
+        log.error("run_benchmark_job failed:\n%s", traceback.format_exc())
+        sys.exit(1)
+
+    if results is None:
+        log.error("run_benchmark_job returned None")
+        sys.exit(1)
+
+    try:
+        rid = callbacks.mlflow.save(results, spec)
+        if rid:
+            results.mlflow_run_id = rid
+            log.info("MLflow run: %s", rid)
+            _log_test_artifact(rid, results)
+    except Exception as exc:
+        log.warning("MLflow save failed (non-fatal): %s", exc)
+
+    callbacks.report_results(results)
+    log.info("Completed: %d examples, overall_score=%s", results.num_examples_evaluated, results.overall_score)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/harbor/generate-configmap.sh
+++ b/deploy/harbor/generate-configmap.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Generate ConfigMap YAML from provider.yaml
+# Usage: bash deploy/harbor/generate-configmap.sh > deploy/harbor/configmap-template.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROVIDER_YAML="${SCRIPT_DIR}/provider.yaml"
+
+if [ ! -f "$PROVIDER_YAML" ]; then
+    echo "Error: provider.yaml not found at $PROVIDER_YAML" >&2
+    exit 1
+fi
+
+cat <<'HEADER'
+# AUTO-GENERATED — do not edit directly.
+# Regenerate: bash deploy/harbor/generate-configmap.sh > deploy/harbor/configmap-template.yaml
+#
+# Source: deploy/harbor/provider.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: evalhub-provider-harbor-bench
+  namespace: redhat-ods-applications
+  labels:
+    app.kubernetes.io/part-of: trustyai
+    app.opendatahub.io/trustyai: "true"
+    trustyai.opendatahub.io/evalhub-provider-type: system
+    trustyai.opendatahub.io/evalhub-provider-name: harbor-bench
+    opendatahub.io/managed: "true"
+data:
+  provider.yaml: |
+HEADER
+
+sed 's/^/    /' "$PROVIDER_YAML"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ anthropic = ["anthropic[vertex]>=0.40"]
 evalhub = [
     "eval-hub-sdk[adapter]>=0.1,<1.0",
     "boto3>=1.34,<2.0",
+    "kubernetes>=29.0,<32.0",
 ]
 openai = ["openai>=1.70"]
 all = [

--- a/tests/test_harbor_adapter.py
+++ b/tests/test_harbor_adapter.py
@@ -1,0 +1,299 @@
+"""Tests for agent_eval.harbor.adapter — Phase 3 gating tests.
+
+Written BEFORE the adapter implementation exists. All tests must fail
+initially, then pass after adapter.py is ported and fixed.
+"""
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch, ANY
+
+import pytest
+
+from agent_eval.evalhub.stubs import (
+    EvaluationResult,
+    JobCallbacks,
+    JobResults,
+    JobSpec,
+    JobStatus,
+    ModelConfig,
+)
+
+
+@pytest.fixture
+def job_spec():
+    return JobSpec(
+        id="job-001",
+        benchmark_id="harbor-task",
+        benchmark_index=0,
+        model=ModelConfig(name="claude-sonnet-4-6"),
+        parameters={},
+    )
+
+
+@pytest.fixture
+def callbacks():
+    return JobCallbacks()
+
+
+@pytest.fixture
+def job_dir_with_results(tmp_path):
+    """Create a job directory with valid result.json."""
+    result = {
+        "job_id": "test-job-001",
+        "trials": [
+            {
+                "task_name": "task-0001",
+                "status": "completed",
+                "reward": 1.0,
+                "metrics": {"duration_s": 30.0, "cost_usd": 0.05},
+            },
+            {
+                "task_name": "task-0002",
+                "status": "completed",
+                "reward": 0.0,
+                "metrics": {"duration_s": 45.0, "cost_usd": 0.08},
+            },
+        ],
+    }
+    (tmp_path / "result.json").write_text(json.dumps(result))
+    return tmp_path
+
+
+class TestBuildJobResults:
+    def test_build_job_results_metrics(self, job_spec):
+        from agent_eval.harbor.adapter import _build_job_results
+
+        job_data = {
+            "job_id": "test-job-001",
+            "trials": [
+                {
+                    "task_name": "task-0001",
+                    "metrics": [
+                        EvaluationResult(metric_name="reward", metric_value=1.0, metric_type="benchmark"),
+                        EvaluationResult(metric_name="duration_s", metric_value=30.0, metric_type="performance"),
+                        EvaluationResult(metric_name="cost_usd", metric_value=0.05, metric_type="cost"),
+                    ],
+                },
+            ],
+            "mean_reward": 1.0,
+            "n_completed": 1,
+            "n_errored": 0,
+        }
+
+        results = _build_job_results(
+            config=job_spec,
+            job_data=job_data,
+            agent_name="oracle",
+            model_name="claude-sonnet-4-6",
+            task_path="/tasks/test",
+            duration_s=42.0,
+        )
+
+        assert isinstance(results, JobResults)
+        assert results.overall_score == 1.0
+        assert results.num_examples_evaluated == 1
+        assert results.model_name == "claude-sonnet-4-6"
+
+        metric_names = {r.metric_name for r in results.results}
+        assert "mean_reward" in metric_names
+        assert "num_trials" in metric_names
+
+    def test_build_job_results_no_trials(self, job_spec):
+        from agent_eval.harbor.adapter import _build_job_results
+
+        job_data = {
+            "job_id": "test-job-002",
+            "trials": [],
+            "mean_reward": None,
+            "n_completed": 0,
+            "n_errored": 0,
+        }
+
+        results = _build_job_results(
+            config=job_spec,
+            job_data=job_data,
+            agent_name="oracle",
+            model_name="",
+            task_path="/tasks/test",
+            duration_s=1.0,
+        )
+
+        assert results.overall_score is None
+        assert results.num_examples_evaluated == 0
+        # mean_reward should be 0.0 in metrics (logged warning, defaulted)
+        metric_map = {r.metric_name: r.metric_value for r in results.results}
+        assert metric_map["mean_reward"] == 0.0
+
+
+class TestHarborAdapterImport:
+    @patch("agent_eval.harbor.adapter._framework_adapter_init")
+    def test_import_results_from_jobs_dir(self, mock_init, job_spec, callbacks, job_dir_with_results):
+        from agent_eval.harbor.adapter import HarborAdapter
+
+        adapter = HarborAdapter(jobs_dir=str(job_dir_with_results))
+        results = adapter.run_benchmark_job(job_spec, callbacks)
+
+        assert isinstance(results, JobResults)
+        assert results.overall_score == pytest.approx(0.5)
+        assert results.num_examples_evaluated == 2
+
+    @patch("agent_eval.harbor.adapter._framework_adapter_init")
+    def test_import_results_nested_job_dir(self, mock_init, job_spec, callbacks, tmp_path):
+        """Jobs dir contains a subdirectory with the actual result.json."""
+        from agent_eval.harbor.adapter import HarborAdapter
+
+        sub = tmp_path / "evalhub-run"
+        sub.mkdir()
+        result = {
+            "job_id": "nested-job",
+            "trials": [
+                {"task_name": "t1", "status": "completed", "reward": 1.0, "metrics": {}},
+            ],
+        }
+        (sub / "result.json").write_text(json.dumps(result))
+
+        adapter = HarborAdapter(jobs_dir=str(tmp_path))
+        results = adapter.run_benchmark_job(job_spec, callbacks)
+
+        assert results.overall_score == 1.0
+
+    @patch("agent_eval.harbor.adapter._framework_adapter_init")
+    def test_import_results_no_result_json(self, mock_init, job_spec, callbacks, tmp_path):
+        from agent_eval.harbor.adapter import HarborAdapter
+
+        adapter = HarborAdapter(jobs_dir=str(tmp_path))
+        with pytest.raises(FileNotFoundError):
+            adapter.run_benchmark_job(job_spec, callbacks)
+
+
+class TestHarborAdapterHarborCli:
+    @patch("agent_eval.harbor.adapter._framework_adapter_init")
+    @patch("agent_eval.harbor.adapter.subprocess")
+    @patch("agent_eval.harbor.adapter.tempfile")
+    def test_run_harbor_cli_success(self, mock_tempfile, mock_subprocess, mock_init,
+                                     job_spec, callbacks, tmp_path):
+        from agent_eval.harbor.adapter import HarborAdapter
+
+        mock_tempfile.mkdtemp.return_value = str(tmp_path)
+
+        # Simulate harbor run success
+        mock_subprocess.run.return_value = MagicMock(returncode=0, stderr="")
+
+        # Create result.json that would be created by harbor
+        job_dir = tmp_path / f"evalhub-{job_spec.id[:8]}"
+        job_dir.mkdir()
+        result_data = {
+            "job_id": "harbor-run-001",
+            "trials": [
+                {"task_name": "t1", "status": "completed", "reward": 1.0, "metrics": {}},
+            ],
+        }
+        (job_dir / "result.json").write_text(json.dumps(result_data))
+
+        job_spec.parameters = {"agent": "oracle"}
+        adapter = HarborAdapter(task_path="/tasks/test")
+        results = adapter.run_benchmark_job(job_spec, callbacks)
+
+        assert results.overall_score == 1.0
+        mock_subprocess.run.assert_called_once()
+        cmd = mock_subprocess.run.call_args[0][0]
+        assert cmd[0] == "harbor"
+        assert "-p" in cmd
+        assert "/tasks/test" in cmd
+
+    @patch("agent_eval.harbor.adapter._framework_adapter_init")
+    @patch("agent_eval.harbor.adapter.subprocess")
+    @patch("agent_eval.harbor.adapter.tempfile")
+    def test_run_harbor_cli_failure(self, mock_tempfile, mock_subprocess, mock_init,
+                                     job_spec, callbacks, tmp_path):
+        from agent_eval.harbor.adapter import HarborAdapter
+
+        mock_tempfile.mkdtemp.return_value = str(tmp_path)
+        mock_subprocess.run.return_value = MagicMock(
+            returncode=1, stderr="harbor: task not found"
+        )
+
+        adapter = HarborAdapter(task_path="/tasks/missing")
+        results = adapter.run_benchmark_job(job_spec, callbacks)
+
+        assert results.overall_score == 0.0
+        assert results.num_examples_evaluated == 0
+
+
+class TestHarborAdapterK8s:
+    @patch("agent_eval.harbor.adapter._framework_adapter_init")
+    @patch("agent_eval.harbor.k8s_runner.run_task_job")
+    def test_run_k8s_dispatches_to_k8s_runner(self, mock_run_task, mock_init,
+                                               job_spec, callbacks):
+        from agent_eval.harbor.adapter import HarborAdapter
+
+        mock_run_task.return_value = {
+            "reward": 1.0,
+            "stdout": "HARBOR_REWARD=1.0\n",
+            "duration_s": 120.0,
+            "exit_code": 0,
+        }
+
+        job_spec.parameters = {
+            "execution_mode": "kubernetes",
+            "task_image": "registry/task:latest",
+            "task_path": "tasks/test-001",
+            "agent": "oracle",
+        }
+
+        adapter = HarborAdapter(execution_mode="kubernetes")
+        results = adapter.run_benchmark_job(job_spec, callbacks)
+
+        mock_run_task.assert_called_once()
+        assert results.overall_score == 1.0
+        call_kwargs = mock_run_task.call_args
+        assert call_kwargs[1]["task_image"] == "registry/task:latest" or \
+               call_kwargs[0][1] == "registry/task:latest" if call_kwargs[0] else True
+
+
+class TestDeployArtifacts:
+    def test_containerfile_exists(self):
+        containerfile = Path(__file__).parent.parent / "deploy" / "harbor" / "Containerfile"
+        assert containerfile.exists(), f"Missing: {containerfile}"
+        content = containerfile.read_text()
+        assert "entrypoint.py" in content
+
+    def test_entrypoint_imports(self):
+        """Verify entrypoint.py can be parsed (not executed — needs evalhub SDK)."""
+        entrypoint = Path(__file__).parent.parent / "deploy" / "harbor" / "entrypoint.py"
+        assert entrypoint.exists(), f"Missing: {entrypoint}"
+        import ast
+        ast.parse(entrypoint.read_text())
+
+    def test_configmap_template_exists(self):
+        configmap = Path(__file__).parent.parent / "deploy" / "harbor" / "configmap-template.yaml"
+        assert configmap.exists()
+        content = configmap.read_text()
+        assert "harbor-bench" in content
+
+    def test_pyproject_has_kubernetes_dep(self):
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        content = pyproject.read_text()
+        assert "kubernetes" in content
+
+
+class TestReportStatus:
+    @patch("agent_eval.harbor.adapter._framework_adapter_init")
+    def test_report_status_callback(self, mock_init, job_spec, callbacks, job_dir_with_results):
+        from agent_eval.harbor.adapter import HarborAdapter
+
+        callbacks.report_status = MagicMock()
+
+        adapter = HarborAdapter(jobs_dir=str(job_dir_with_results))
+        adapter.run_benchmark_job(job_spec, callbacks)
+
+        assert callbacks.report_status.call_count >= 2
+        # First call should be RUNNING
+        first_update = callbacks.report_status.call_args_list[0][0][0]
+        assert first_update.status == JobStatus.RUNNING
+        # Last call should be COMPLETED
+        last_update = callbacks.report_status.call_args_list[-1][0][0]
+        assert last_update.status == JobStatus.COMPLETED

--- a/tests/test_harbor_k8s_runner.py
+++ b/tests/test_harbor_k8s_runner.py
@@ -1,0 +1,191 @@
+"""Tests for agent_eval.harbor.k8s_runner — Phase 2 gating tests.
+
+Written BEFORE the implementation exists. Tests mock the kubernetes
+client so no cluster is needed.
+"""
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestScriptGeneration:
+    def test_oracle_script_contains_solve_and_test(self):
+        from agent_eval.harbor.k8s_runner import _oracle_script
+
+        script = _oracle_script()
+        assert "solve.sh" in script
+        assert "test.sh" in script
+        assert "HARBOR_REWARD" in script
+
+    def test_agent_script_includes_model_flag(self):
+        from agent_eval.harbor.k8s_runner import _agent_script
+
+        script = _agent_script(model="claude-sonnet-4-6")
+        assert "--model" in script
+        assert "claude-sonnet-4-6" in script
+        assert "test.sh" in script
+        assert "HARBOR_REWARD" in script
+
+    def test_agent_script_no_model_flag(self):
+        from agent_eval.harbor.k8s_runner import _agent_script
+
+        script = _agent_script(model="")
+        assert "--model" not in script
+        assert "claude" in script  # still invokes claude CLI
+
+
+class TestBuildVolumes:
+    def test_build_volumes_empty(self):
+        from agent_eval.harbor.k8s_runner import _build_volumes
+
+        volumes, mounts = _build_volumes(None)
+        assert volumes is None
+        assert mounts is None
+
+        volumes, mounts = _build_volumes([])
+        assert volumes is None
+        assert mounts is None
+
+    @patch("agent_eval.harbor.k8s_runner._K8S_AVAILABLE", True)
+    @patch("agent_eval.harbor.k8s_runner.client")
+    def test_build_volumes_with_secrets(self, mock_client):
+        # Set up mock K8s types that behave like real objects
+        mock_client.V1KeyToPath = lambda key, path: types.SimpleNamespace(key=key, path=path)
+        mock_client.V1Volume = lambda name, secret: types.SimpleNamespace(name=name, secret=secret)
+        mock_client.V1SecretVolumeSource = lambda secret_name, items=None: types.SimpleNamespace(secret_name=secret_name, items=items)
+        mock_client.V1VolumeMount = lambda name, mount_path, read_only: types.SimpleNamespace(name=name, mount_path=mount_path, read_only=read_only)
+
+        from agent_eval.harbor.k8s_runner import _build_volumes
+
+        secret_volumes = [
+            {
+                "secret_name": "api-keys",
+                "mount_path": "/secrets/api-keys",
+            },
+            {
+                "secret_name": "certs",
+                "mount_path": "/secrets/certs",
+                "items": [{"key": "ca.crt", "path": "ca.crt"}],
+            },
+        ]
+
+        volumes, mounts = _build_volumes(secret_volumes)
+        assert len(volumes) == 2
+        assert len(mounts) == 2
+        assert mounts[0].mount_path == "/secrets/api-keys"
+        assert mounts[0].read_only is True
+        assert mounts[1].mount_path == "/secrets/certs"
+
+
+class TestRunTaskJob:
+    @patch("agent_eval.harbor.k8s_runner._load_k8s_config")
+    @patch("agent_eval.harbor.k8s_runner.client")
+    def test_run_task_job_oracle_success(self, mock_client, mock_load_config):
+        from agent_eval.harbor.k8s_runner import run_task_job
+
+        mock_batch = MagicMock()
+        mock_core = MagicMock()
+        mock_client.BatchV1Api.return_value = mock_batch
+        mock_client.CoreV1Api.return_value = mock_core
+
+        # Job succeeds on first status check
+        mock_status = MagicMock()
+        mock_status.status.succeeded = True
+        mock_status.status.failed = None
+        mock_batch.read_namespaced_job_status.return_value = mock_status
+
+        # Pod logs contain reward
+        mock_pod = MagicMock()
+        mock_pod.metadata.name = "harbor-test-12345-abc"
+        mock_core.list_namespaced_pod.return_value = MagicMock(items=[mock_pod])
+        mock_core.read_namespaced_pod_log.return_value = (
+            "Running tests...\n"
+            "HARBOR_REWARD=1.0\n"
+        )
+
+        # Mock constructors so they don't fail without real kubernetes
+        mock_client.V1Job = MagicMock()
+        mock_client.V1ObjectMeta = MagicMock()
+        mock_client.V1JobSpec = MagicMock()
+        mock_client.V1PodTemplateSpec = MagicMock()
+        mock_client.V1PodSpec = MagicMock()
+        mock_client.V1PodSecurityContext = MagicMock()
+        mock_client.V1Container = MagicMock()
+        mock_client.V1ResourceRequirements = MagicMock()
+
+        result = run_task_job(
+            task_name="test-task",
+            task_image="registry/task:latest",
+            namespace="evalhub",
+            timeout_sec=300,
+            agent="oracle",
+        )
+
+        assert result["reward"] == 1.0
+        assert result["exit_code"] == 0
+        assert result["duration_s"] >= 0
+        mock_batch.create_namespaced_job.assert_called_once()
+        mock_batch.delete_namespaced_job.assert_called_once()
+
+    @patch("agent_eval.harbor.k8s_runner._load_k8s_config")
+    @patch("agent_eval.harbor.k8s_runner.client")
+    @patch("agent_eval.harbor.k8s_runner.time")
+    def test_run_task_job_timeout(self, mock_time, mock_client, mock_load_config):
+        from agent_eval.harbor.k8s_runner import run_task_job
+
+        mock_batch = MagicMock()
+        mock_core = MagicMock()
+        mock_client.BatchV1Api.return_value = mock_batch
+        mock_client.CoreV1Api.return_value = mock_core
+
+        # Job never completes — monotonic advances past timeout
+        call_count = [0]
+        def advancing_monotonic():
+            call_count[0] += 1
+            return call_count[0] * 100.0  # jumps 100s per call
+        mock_time.monotonic = advancing_monotonic
+        mock_time.sleep = MagicMock()
+
+        mock_status = MagicMock()
+        mock_status.status.succeeded = None
+        mock_status.status.failed = None
+        mock_batch.read_namespaced_job_status.return_value = mock_status
+
+        mock_core.list_namespaced_pod.return_value = MagicMock(items=[])
+
+        mock_client.V1Job = MagicMock()
+        mock_client.V1ObjectMeta = MagicMock()
+        mock_client.V1JobSpec = MagicMock()
+        mock_client.V1PodTemplateSpec = MagicMock()
+        mock_client.V1PodSpec = MagicMock()
+        mock_client.V1PodSecurityContext = MagicMock()
+        mock_client.V1Container = MagicMock()
+        mock_client.V1ResourceRequirements = MagicMock()
+
+        result = run_task_job(
+            task_name="timeout-task",
+            task_image="registry/task:latest",
+            namespace="evalhub",
+            timeout_sec=10,
+            agent="oracle",
+        )
+
+        assert result["reward"] == 0.0
+        assert result["exit_code"] == -1
+
+    def test_unknown_agent_raises(self):
+        from agent_eval.harbor.k8s_runner import run_task_job
+
+        with pytest.raises(ValueError, match="Unknown agent"):
+            # This should fail before any K8s calls, so no mocking needed
+            # But we need to mock _load_k8s_config to prevent real cluster access
+            with patch("agent_eval.harbor.k8s_runner._load_k8s_config"):
+                with patch("agent_eval.harbor.k8s_runner.client"):
+                    run_task_job(
+                        task_name="test",
+                        task_image="img",
+                        namespace="ns",
+                        agent="invalid-agent",
+                    )

--- a/tests/test_harbor_results_parser.py
+++ b/tests/test_harbor_results_parser.py
@@ -1,0 +1,183 @@
+"""Tests for agent_eval.harbor.results_parser — Phase 1 gating tests.
+
+Written BEFORE the implementation exists. All tests must fail with
+ImportError initially, then pass after results_parser.py is created.
+"""
+
+import json
+import pytest
+from pathlib import Path
+
+
+@pytest.fixture
+def job_dir(tmp_path):
+    """Create a minimal Harbor job directory with result.json."""
+    return tmp_path
+
+
+def _write_result(job_dir: Path, data: dict) -> None:
+    (job_dir / "result.json").write_text(json.dumps(data))
+
+
+class TestParseJob:
+    def test_parse_job_single_trial(self, job_dir):
+        """Parse a minimal result.json with one completed trial."""
+        _write_result(job_dir, {
+            "job_id": "test-job-001",
+            "trials": [
+                {
+                    "task_name": "task-0001",
+                    "status": "completed",
+                    "reward": 1.0,
+                    "metrics": {
+                        "duration_s": 42.5,
+                        "cost_usd": 0.03,
+                    },
+                }
+            ],
+        })
+
+        from agent_eval.harbor.results_parser import parse_job
+
+        result = parse_job(job_dir)
+
+        assert result["job_id"] == "test-job-001"
+        assert result["mean_reward"] == 1.0
+        assert result["n_completed"] == 1
+        assert result["n_errored"] == 0
+        assert len(result["trials"]) == 1
+
+        trial = result["trials"][0]
+        assert trial["task_name"] == "task-0001"
+        metric_names = {m.metric_name for m in trial["metrics"]}
+        assert "reward" in metric_names
+        assert "duration_s" in metric_names
+
+    def test_parse_job_multiple_trials(self, job_dir):
+        """Parse result.json with multiple trials including mixed outcomes."""
+        _write_result(job_dir, {
+            "job_id": "test-job-002",
+            "trials": [
+                {
+                    "task_name": "task-0001",
+                    "status": "completed",
+                    "reward": 1.0,
+                    "metrics": {"duration_s": 30.0},
+                },
+                {
+                    "task_name": "task-0002",
+                    "status": "completed",
+                    "reward": 0.0,
+                    "metrics": {"duration_s": 45.0},
+                },
+                {
+                    "task_name": "task-0003",
+                    "status": "completed",
+                    "reward": 1.0,
+                    "metrics": {"duration_s": 20.0},
+                },
+            ],
+        })
+
+        from agent_eval.harbor.results_parser import parse_job
+
+        result = parse_job(job_dir)
+
+        assert result["job_id"] == "test-job-002"
+        assert len(result["trials"]) == 3
+        assert result["n_completed"] == 3
+        assert result["n_errored"] == 0
+        assert result["mean_reward"] == pytest.approx(2.0 / 3.0)
+
+    def test_parse_job_no_result_file(self, job_dir):
+        """FileNotFoundError when result.json is missing."""
+        from agent_eval.harbor.results_parser import parse_job
+
+        with pytest.raises(FileNotFoundError):
+            parse_job(job_dir)
+
+    def test_parse_job_errored_trial(self, job_dir):
+        """Errored trials counted in n_errored, excluded from mean_reward."""
+        _write_result(job_dir, {
+            "job_id": "test-job-003",
+            "trials": [
+                {
+                    "task_name": "task-0001",
+                    "status": "completed",
+                    "reward": 1.0,
+                    "metrics": {"duration_s": 30.0},
+                },
+                {
+                    "task_name": "task-0002",
+                    "status": "errored",
+                    "reward": None,
+                    "metrics": {},
+                    "error": "Container OOMKilled",
+                },
+            ],
+        })
+
+        from agent_eval.harbor.results_parser import parse_job
+
+        result = parse_job(job_dir)
+
+        assert result["n_completed"] == 1
+        assert result["n_errored"] == 1
+        assert result["mean_reward"] == 1.0  # Only completed trial counts
+
+    def test_parse_job_all_errored(self, job_dir):
+        """All trials errored — mean_reward should be None."""
+        _write_result(job_dir, {
+            "job_id": "test-job-004",
+            "trials": [
+                {
+                    "task_name": "task-0001",
+                    "status": "errored",
+                    "reward": None,
+                    "metrics": {},
+                },
+            ],
+        })
+
+        from agent_eval.harbor.results_parser import parse_job
+
+        result = parse_job(job_dir)
+
+        assert result["n_completed"] == 0
+        assert result["n_errored"] == 1
+        assert result["mean_reward"] is None
+
+    def test_parse_job_metrics_are_evaluation_results(self, job_dir):
+        """Trial metrics should be EvaluationResult objects with proper fields."""
+        _write_result(job_dir, {
+            "job_id": "test-job-005",
+            "trials": [
+                {
+                    "task_name": "task-0001",
+                    "status": "completed",
+                    "reward": 1.0,
+                    "metrics": {
+                        "duration_s": 42.5,
+                        "cost_usd": 0.03,
+                        "input_tokens": 1500,
+                        "output_tokens": 800,
+                    },
+                },
+            ],
+        })
+
+        from agent_eval.harbor.results_parser import parse_job
+
+        result = parse_job(job_dir)
+        trial = result["trials"][0]
+
+        for m in trial["metrics"]:
+            assert hasattr(m, "metric_name")
+            assert hasattr(m, "metric_value")
+            assert hasattr(m, "metric_type")
+
+        metric_map = {m.metric_name: m for m in trial["metrics"]}
+        assert metric_map["cost_usd"].metric_value == 0.03
+        assert metric_map["cost_usd"].metric_type == "cost"
+        assert metric_map["reward"].metric_value == 1.0
+        assert metric_map["reward"].metric_type == "benchmark"


### PR DESCRIPTION
Implement a Harbor provider for agent-eval-harness.

- PR #30 (merged May 7): The original EvalHub provider — agent_eval/evalhub/ with AgentEvalAdapter. Runs **skills**
  via ClaudeCodeRunner or direct LLM calls, scores with judges, maps to JobResults. This is already on main.

- PR #78 (open): A second EvalHub provider — agent_eval/harbor/ with a HarborAdapter. Runs **Harbor benchmarks (not
  agent skills)** via CLI, K8s Jobs, or result import. Completely separate code path.

They don't overlap — different adapters registered under different provider names.
  
- agent_eval/harbor/results_parser.py: Parse Harbor result.json into structured trial data with EvaluationResult metrics (was missing from original branch)
- agent_eval/harbor/k8s_runner.py: Run Harbor tasks as K8s Jobs with oracle and agent modes, secret volumes, env injection
- agent_eval/harbor/adapter.py: EvalHub FrameworkAdapter supporting three modes: harbor CLI, kubernetes, and import from existing results
- deploy/harbor/: Containerfile, entrypoint, ConfigMap template for RHOAI/EvalHub deployment
- pyproject.toml: Add kubernetes to evalhub extras

27 tests covering results parsing, K8s job creation, adapter dispatch, deploy artifacts, and status callbacks.