### PR TITLE
feat(eval-analyze): update skills for builtin judges and add list_builtins script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Skills projects create an `eval.yaml` config file with:
 - `inputs.tools` — tool interception: `match` describes what to intercept, `prompt` how to handle it. AskUserQuestion uses 3-tier answering: exact `case_overrides` → LLM call (`models.hook`) with case context (`input.yaml` + `answers.yaml`) → fallback
 - `outputs` — list of artifact dirs (`path`) and/or tool calls (`tool`) with natural language schemas. Optional `batch_pattern` maps output files to cases in batch mode using `{n}` as a 1-based index
 - `traces` — execution data to capture: stdout/stderr, events, metrics (exit code, tokens, cost)
-- `judges` — inline `check` scripts, LLM `prompt`/`prompt_file`, external `module`/`function`. Optional `if` condition to skip judges per case based on annotations. Judges receive `outputs["annotations"]` from dataset `annotations.yaml`.
+- `judges` — `builtin` reusable judges (from `agent_eval/judges/`), inline `check` scripts, LLM `prompt`/`prompt_file` (Jinja2 rendered), external `module`/`function`. Optional `arguments` dict for parameterization. Optional `if` condition to skip judges per case based on annotations. Judges receive `outputs["annotations"]` from dataset `annotations.yaml`.
 - `thresholds` — per-judge regression detection. Valid keys: `min_mean`, `min_pass_rate`, `min_win_rate`
 
 Runs are stored in `$AGENT_EVAL_RUNS_DIR` (default `eval/runs`), configured during `/eval-setup`.
@@ -123,7 +123,7 @@ E2E tests invoke real Claude API calls against a fake Jira skill fixture to veri
 
 1. **Schema-driven** — dataset and output structures described in natural language in eval.yaml; agents and judges interpret them, scripts just move files
 2. **Agent-agnostic runner** — `EvalRunner` ABC with `--agent` flag on execute.py; Claude Code included, extensible to OpenCode/Agent SDK
-3. **Three judge types** — inline `check` scripts, LLM `prompt`/`prompt_file`, external `module`/`function`
+3. **Four judge types** — `builtin` reusable judges, inline `check` scripts, LLM `prompt`/`prompt_file`, external `module`/`function`
 4. **MLflow as separate skill** — `/eval-mlflow` handles dataset sync, result logging, trace feedback; eval-run works without it
 
 ## Brainstorms

--- a/eval.yaml
+++ b/eval.yaml
@@ -97,7 +97,18 @@ traces:
   metrics: true   # Capture exit code, tokens, cost, duration
 
 # Judges — evaluate output quality
+# Four types: builtin (library), check (inline Python), prompt/prompt_file (LLM),
+# module/function (external code). All support arguments: for parameterization.
 judges:
+  # Builtin judge (ships with the harness — no inline code needed)
+  # - name: budget_check
+  #   builtin: cost_budget
+  #   arguments:
+  #     max_cost_usd: 5.0
+
+  # - name: safety_check
+  #   builtin: no_harmful_content
+
   # Inline code check
   - name: has_content
     description: |

--- a/skills/eval-analyze/SKILL.md
+++ b/skills/eval-analyze/SKILL.md
@@ -92,7 +92,7 @@ ls <dataset_path>/ 2>/dev/null | head -20
 If not set or doesn't exist, search the project for test case directories using the Glob tool:
 
 ```
-Glob: **/cases/ or **/test-cases/ or **/fixtures/ or **/examples/
+Glob: **/cases/ or **/test-cases/ or **/fixtures/ or **/examples/ or **/dataset/ or **/eval/ or **/tests/data/
 ```
 
 Exclude `.venv/`, `.git/`, `node_modules/` from results.
@@ -125,8 +125,10 @@ Key points:
 - **Environment variables**: if the skill needs external service credentials (e.g., `JIRA_SERVER` for a jira-emulator, API keys for test instances), add `execution.env` entries. Use `$VAR` syntax for values that should be resolved from the caller's environment (e.g., `$JIRA_TOKEN`), or literal values for test-only endpoints (e.g., `http://localhost:8080`).
 - If the skill uses AskUserQuestion, calls external services (MCP tools), or runs scripts that interact with APIs, add `inputs.tools` entries. Use `match` to describe what to intercept in natural language (e.g., "any Jira interaction via MCP or scripts"), and `prompt` for how to handle it. The AskUserQuestion hook uses 3-tier answer resolution: exact match from `case_overrides`, then an LLM call (using `models.hook`) with the case's `input.yaml` and `answers.yaml` as context, then fallback to the first option. If the skill asks domain-specific questions (e.g., "is this a duplicate?"), suggest the user create `answers.yaml` files per case with guidance for the LLM answerer.
 - **Annotation-aware judges**: judges receive `outputs["annotations"]` — the parsed `annotations.yaml` from the dataset case. Use this for outcome-aware scoring where the expected result depends on the test case (e.g., `annotations.get("dedup_is_duplicate")` determines whether producing no output is correct).
-- Aim for 2-4 inline `check` judges + 1-2 LLM `prompt` judges. Start lean.
-- If `--update`: preserve everything already in the file, only add missing top-level keys (e.g., add a `models:` block if the user is upgrading from an older config that lacked it)
+- **Prefer builtin judges for common patterns** — the harness ships reusable judges in `agent_eval/judges/`. Use `builtin:` instead of writing inline code. Discover available builtins: `python3 ${CLAUDE_SKILL_DIR}/scripts/list_builtins.py`. See the template for examples.
+- **Parameterize with `arguments:`** — all judge types support an `arguments:` dict. Use it instead of hardcoding values in check code or prompt text. For inline checks, `arguments` is passed as the second parameter. For LLM prompts, use `{{ arguments.key }}` (Jinja2 rendered).
+- Aim for 1-2 `builtin` judges + 2-3 inline `check` judges + 1-2 LLM `prompt` judges. Start lean.
+- If `--update`: preserve everything already in the file, only add missing top-level keys (e.g., add a `models:` block if the user is upgrading from an older config that lacked it). Check existing inline check judges — if any use the old `(outputs)` signature (single parameter), update them to `(outputs, arguments)` (the current contract). Also check LLM judge prompts for literal `{{ }}` that isn't a template variable — all prompts are now Jinja2 rendered.
 
 ## Step 5b: Validate Generated Config
 

--- a/skills/eval-analyze/prompts/analyze-skill.md
+++ b/skills/eval-analyze/prompts/analyze-skill.md
@@ -35,12 +35,18 @@ outputs:
   # IMPORTANT: path must be a named subdirectory (e.g., "output", "artifacts"),
   # never "." — the harness cleans output dirs between runs.
   # For stdout-only skills, use "output" as a conventional empty directory.
+  #
+  # Stdout-only skills: if the skill produces output via conversation text
+  # rather than files, note this explicitly. Judges for stdout-only skills
+  # should use {{ conversation }} (root-level assistant text) instead of
+  # {{ outputs }} (file artifacts). The outputs entry should describe what
+  # the conversation output contains rather than file structure.
   - path: "<named subdirectory for outputs, e.g. 'output' or 'artifacts'>"
     schema: |
       <what is produced here — file types, naming patterns, content
        structure. Describe what you actually observed, not generic patterns.
-       If the skill writes to stdout rather than files, note that judges
-       should read outputs["stdout"] instead of outputs["files"].>
+       For stdout-only skills: describe the conversation output structure
+       and note that judges should use {{ conversation }} template variable.>
   # Tool call side effects (if the skill calls external APIs)
   # - tool: "<tool name pattern, e.g. mcp__atlassian__create_issue>"
   #   schema: |
@@ -102,18 +108,26 @@ quality_criteria:
     - "<things that need LLM assessment — quality, completeness, accuracy>"
 
 suggested_judges:
+  # Prefer builtin judges for common patterns — they're tested, versioned,
+  # and require no inline code. Each is a .py or .md file in agent_eval/judges/{category}/.
+  # List available: python3 ${CLAUDE_SKILL_DIR}/scripts/list_builtins.py
   - name: "<judge name>"
-    type: "<check|llm>"
+    type: "<builtin|check|llm>"
     description: |
       <what this judge evaluates and how>
+    # For builtin type, reference a builtin judge by name:
+    builtin: "<builtin name>"
+    arguments:              # optional parameterization
+      <key>: <value>
     # For check type, include a working inline script:
     check: |
-      <python snippet that takes outputs dict, returns (bool, str)>
+      <python snippet — receives (outputs, arguments) dicts, returns (bool|number, str)>
     # For llm type, include evaluation instructions.
-    # Template variables available in LLM judge prompts:
-    #   {{ outputs }} — renders file artifacts and modified files as markdown
-    #   {{ conversation }} — renders root-level assistant text (excludes subagent text)
-    #   {{ annotations }} — renders dataset annotations
+    # All LLM prompts are Jinja2 templates. Available variables:
+    #   {{ outputs }} — file artifacts and modified files as markdown
+    #   {{ conversation }} — root-level assistant text (excludes subagent text)
+    #   {{ annotations }} — dataset annotations
+    #   {{ arguments }} — judge arguments from eval.yaml
     prompt: |
       <what to evaluate and how to score>
 ```
@@ -128,5 +142,6 @@ After the YAML block, explain:
 5. Which sub-skill's outputs are the ones that matter for scoring
 6. Whether the skill edits input files in-place (e.g., uses the Edit tool on `source.md`) rather than writing to an output directory. If so, note this explicitly. The harness automatically collects in-place edits into `outputs["modified_files"]`, so judges should be written against that dict (e.g., `outputs.get("modified_files", {}).get("source.md")`) rather than expecting files in an output directory.
 7. Which tools and scripts interact with external services — look for AskUserQuestion (needs auto-answers), MCP tools calling external APIs (Jira, Slack, etc.), AND Python scripts that import API clients or call external URLs. These all need `inputs.tools` entries in eval.yaml so headless eval can intercept them. Also identify which **input fields** reference real external state (e.g., a Jira project key that must exist on the target instance, a GitHub repo URL that must be accessible, a Slack channel ID). These fields cannot be synthesized by eval-dataset — list them so eval-analyze can mark them with `[EXTERNAL: System]` in the dataset schema.
+8. Whether the skill reads files from specific paths in its working directory (not from arguments) — e.g., source code files at `src/main.py`, config files at `config/settings.json`. These files need to be present in each test case directory so the harness can copy them into the workspace. List the expected paths and what they should contain.
 
 Be thorough but concise. Reference actual file paths and field names you observed — don't invent generic examples.

--- a/skills/eval-analyze/prompts/generate-eval-md.md
+++ b/skills/eval-analyze/prompts/generate-eval-md.md
@@ -29,8 +29,9 @@ dry_run: <true/false>
 # Suggested judges (summary from analysis)
 suggested_judges:
   - name: <judge_name>
-    type: <check|llm>
+    type: <builtin|check|llm>
     description: "<what this judge checks>"
+    # arguments: {key: value}   # if parameterized
 ---
 ```
 

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -158,19 +158,45 @@ traces:
   metrics: true          # Capture exit code, tokens, cost, duration
 
 # Judges — evaluate output quality
+# Four judge types (determined by which field is set):
+#   builtin:     reusable judge from the harness library
+#   check:       inline Python snippet
+#   prompt/prompt_file: LLM judge (Jinja2 rendered)
+#   module/function:   external Python module
+# All judge types support optional `arguments:` for parameterization.
 judges:
+  # Builtin judge: reusable judge from the harness library
+  # List available: python3 ${CLAUDE_SKILL_DIR}/scripts/list_builtins.py
+  # Each builtin is a .py (Python) or .md (LLM) file in agent_eval/judges/{category}/
+  - name: budget_check
+    builtin: cost_budget
+    arguments:
+      max_cost_usd: 5.0
+
+  # - name: safety_check
+  #   builtin: no_harmful_content
+
+  # - name: completeness
+  #   builtin: output_completeness
+  #   model: claude-sonnet-4-6        # optional model override
+  #   arguments:
+  #     strictness: high              # low, medium, high
+
   # Inline check: validate structure with code
   - name: <descriptive_name>
     description: |
       <what this judge checks and why it matters>
     check: |
-      <python snippet — receives outputs dict, returns (bool, str)>
+      <python snippet — receives (outputs, arguments) dicts, returns (bool|number, str)>
+    # arguments:                      # optional, available as arguments dict in check
+    #   max_chars: 10000
 
   # LLM judge: assess quality with a prompt
-  # Template variables:
-  #   {{ outputs }} — renders file artifacts and modified files as markdown
-  #   {{ conversation }} — renders root-level assistant text (excludes subagent text)
-  #   {{ annotations }} — renders dataset annotations
+  # All LLM prompts are rendered with Jinja2. Available template variables:
+  #   {{ outputs }}      — file artifacts and modified files as markdown
+  #   {{ conversation }} — root-level assistant text (excludes subagent text)
+  #   {{ annotations }}  — dataset annotations
+  #   {{ arguments }}    — judge arguments from eval.yaml (dict)
   - name: <descriptive_name>
     description: |
       <what this judge evaluates>
@@ -179,14 +205,17 @@ judges:
       {{ outputs }}
       {{ conversation }}
       <scoring criteria — define what each score level means>
-    # Optional: supplementary context files
-    # context:
+    # arguments:                      # optional, available as {{ arguments }} in prompt
+    #   focus: completeness
+    # context:                        # optional supplementary files
     #   - eval/prompts/scoring-rubric.md
 
-  # LLM judge with external prompt file
+  # LLM judge with external prompt file (Jinja2 rendered)
   # - name: <name>
   #   description: <what it checks>
   #   prompt_file: eval/prompts/quality-judge.md
+  #   arguments:
+  #     strictness: high
   #   context:
   #     - eval/prompts/domain-guidelines.md
 
@@ -195,6 +224,8 @@ judges:
   #   description: <what it checks>
   #   module: eval.judges.my_checker
   #   function: check_quality
+  #   arguments:                      # optional, passed as **kwargs to function
+  #     threshold: 0.8
 
   # Pairwise comparison (used with score.py pairwise --baseline <id>)
   # - name: pairwise
@@ -205,7 +236,7 @@ judges:
 # Thresholds for regression detection
 thresholds:
   <judge_name>:
-    min_pass_rate: 1.0     # for boolean judges (check)
+    min_pass_rate: 1.0     # for boolean judges (check, builtin)
     # min_mean: 3.5        # for numeric judges (llm)
 ```
 

--- a/skills/eval-analyze/scripts/list_builtins.py
+++ b/skills/eval-analyze/scripts/list_builtins.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""List available builtin judges from the harness registry."""
+
+import agent_eval._bootstrap  # noqa: F401
+
+from agent_eval.judges import BuiltinJudgeRegistry
+
+
+def main():
+    registry = BuiltinJudgeRegistry()
+    registry.discover()
+    for name in registry.list_names():
+        entry = registry.get(name)
+        print(f"  {name} ({entry.category}/{entry.kind})")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/eval-optimize/SKILL.md
+++ b/skills/eval-optimize/SKILL.md
@@ -160,7 +160,7 @@ In all cases (include `--config <config>` if a non-default config was used):
 - **Never make broad, generic changes** — every edit must be grounded in a specific failure with evidence from judges and transcripts
 - **Check for regressions after every edit** — a fix that breaks other cases is not a fix
 - **Stop after max iterations** — don't loop forever. Report what couldn't be fixed.
-- **Don't modify test cases or judges** — the eval harness is the ground truth. If you think a judge is wrong, report it but don't change it.
+- **Don't modify test cases or judges** — the eval harness is the ground truth. If you think a judge is wrong, report it but don't change it. Builtin judges (from `agent_eval/judges/`) are versioned and shared — never edit their code. If a builtin judge's behavior needs adjustment, suggest changing its `arguments:` in eval.yaml instead.
 - **Don't modify eval.yaml** — your job is to improve the skill, not the evaluation config. If judges need updating, suggest it to the user.
 - **Try different approaches** — if the same type of edit fails twice, try a fundamentally different framing. Explain why instead of adding more rules.
 

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -188,7 +188,7 @@ Report per-case counts. If any case has 0 artifacts, warn — the skill may not 
 
 ## Step 6: Score
 
-Run all configured judges against the collected outputs. Skip this step if `--no-judge` was specified.
+Run all configured judges against the collected outputs. Skip this step if `--no-judge` was specified. Four judge types are supported: `builtin` (reusable from the harness library), inline `check` (Python snippets), LLM `prompt`/`prompt_file` (Jinja2 rendered), and external `module`/`function`. All support optional `arguments:` for parameterization.
 
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/score.py judges \

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -184,34 +184,45 @@ Skills that modify input files using the Edit tool (rather than writing to an ou
 }
 ```
 
-**Note on `{{ outputs }}` in LLM judges**: The `{{ outputs }}` template variable renders ALL entries in `files`, including `_modified/` entries. Each file appears as a markdown section with its path as the heading. Modified files will appear as `### _modified/source.md` followed by the edited content.
+**Template variables in LLM judges**: All LLM judge prompts (both `prompt`/`prompt_file` and `builtin` LLM judges) are rendered with Jinja2. Available variables:
+- `{{ outputs }}` — renders ALL file entries including `_modified/` as markdown sections
+- `{{ conversation }}` — root-level assistant text from the JSONL event stream (excludes subagent text)
+- `{{ annotations }}` — dataset annotations from `annotations.yaml`
+- `{{ arguments }}` — judge arguments from eval.yaml's `arguments:` field (dict)
 
-**Note on `{{ stdout }}` in LLM judges**: The `{{ stdout }}` template variable extracts assistant conversation text from the JSONL stdout log. It filters for top-level assistant text blocks (skipping subagent messages, tool calls, system events, and user input), then concatenates the extracted text. For non-JSONL stdout (e.g., from non-Claude runners), the raw content is passed through. If stdout is empty or missing, it renders as `(no stdout captured)`. Use `{{ stdout }}` for skills that produce their primary output via conversation text rather than file artifacts.
+Use `{{ arguments.key }}` to parameterize prompts without editing the prompt text. For example, `{{ arguments.strictness | default('medium') }}` lets users control judge behavior via eval.yaml.
 
 **Key naming convention for convenience keys**: for an output with `path: "artifacts/rfe-tasks"`, the convenience key is `rfe-tasks_content` (the last directory component + `_content`). For `path: "."`, the key is `main_content`.
 
 ## 5. Scoring → Judges
 
-### Three judge types
+### Four judge types
+
+**Builtin judge** (`builtin` field in eval.yaml):
+- Resolves via `BuiltinJudgeRegistry` from `agent_eval/judges/` package
+- Python builtins (`.py`): receive `(outputs, **arguments)`, return `(bool|number, str)`
+- LLM builtins (`.md`): Jinja2 prompt templates, rendered with `arguments` and `outputs`
+- Auto-discovered from `agent_eval/judges/{category}/` directories
+- Parameterized via `arguments:` field in eval.yaml
 
 **Inline check** (`check` field in eval.yaml):
 - Python snippet wrapped in a function by `score.py`
-- Receives the full record dict as `outputs` parameter
-- Must return `(bool, str)` — pass/fail + rationale
+- Receives `(outputs, arguments)` — full record dict + arguments from eval.yaml
+- Must return `(bool|number, str)` — pass/fail + rationale, or score + rationale
 - Example accessing file content: `outputs["artifacts_content"]`
 - Example accessing traces: `outputs.get("cost_usd", 0)`
-- Example accessing tool calls: `outputs.get("tool_calls", [])`
+- Example with arguments: `limit = arguments.get("max_chars", 10000)`
 
 **LLM judge** (`prompt` or `prompt_file` field):
-- Created via `mlflow.genai.judges.make_judge()`
-- Receives the record as `outputs` kwarg
+- All prompts are Jinja2 rendered with variables: `{{ outputs }}`, `{{ conversation }}`, `{{ annotations }}`, `{{ arguments }}`
 - `context` files are appended to the prompt
-- `feedback_type` is optional — MLflow infers from response
+- `arguments:` field makes prompts parameterizable without editing the prompt text
+- Returns `{"score": N, "rationale": "..."}` or `{"passed": bool, "rationale": "..."}`
 
 **External code judge** (`module` + `function` field):
 - Imported via `importlib` from the project
-- Receives the record as `outputs` kwarg
-- Can return `Feedback` object, `(bool, str)` tuple, or primitive
+- Receives `(outputs=dict, **arguments)` when `arguments:` is set
+- Must return `(bool|number, str)` tuple
 
 ### How aggregation works
 


### PR DESCRIPTION
## Summary

Follow-up to PR #66 (v1.1.0). Updates all skills and documentation that generate, consume, or explain judges to account for the new `builtin:` field, `arguments:` parameterization, and Jinja2 template rendering.

## Changes (8 files)

**eval-analyze** (generates eval.yaml):
- `eval-yaml-template.md`: add builtin judge examples, `arguments:` on all judge types, Jinja2 template variable docs, registry discovery command
- `analyze-skill.md`: update `suggested_judges` schema with `builtin` and `arguments` fields, pointer to registry
- `SKILL.md`: prefer builtin judges with registry discovery command

**eval-run** (executes judges):
- `SKILL.md`: document 4 judge types (was 3), note `arguments:` field
- `data-pipeline.md`: rewrite judge types section (3→4), document Jinja2 rendering and `{{ arguments }}` template variable

**eval-optimize** (edits skills based on judge failures):
- `SKILL.md`: don't edit builtin judge code, adjust `arguments:` instead

**Project-level**:
- `CLAUDE.md`: update judge types (3→4), add builtin + arguments
- `eval.yaml`: add commented builtin judge examples

Judge return type documented as `(bool|number, str)` across all references.
No hardcoded builtin names — all point to registry for discovery.

## Test plan
- [x] 243 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated evaluation configuration guides to document builtin judges as a reusable judge type from system defaults.
  * Added comprehensive documentation for judge parameterization using arguments and Jinja2 template variables.
  * Expanded judge schema reference to reflect four judge types with detailed specifications on accepted inputs and expected outputs.
  * Enhanced scoring pipeline documentation with clarity on template variable usage across judge categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->