### PR TITLE
feat: add execution lifecycle hooks to eval.yaml

### DIFF
--- a/agent_eval/agent/base.py
+++ b/agent_eval/agent/base.py
@@ -62,6 +62,7 @@ class EvalRunner(ABC):
         system_prompt: Optional[str] = None,
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
+        extra_env: Optional[dict] = None,
     ) -> RunResult:
         """Invoke a skill in an isolated workspace.
 
@@ -76,6 +77,8 @@ class EvalRunner(ABC):
                 (e.g. --append-system-prompt for Claude Code).
             max_budget_usd: Maximum API spend for this invocation.
             timeout_s: Timeout in seconds.
+            extra_env: Additional env vars to inject (e.g. from hook outputs).
+                Merged after execution.env, so hook env overrides static config.
 
         Returns:
             RunResult with exit code, output, timing, and optional usage stats.

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -104,6 +104,7 @@ class ClaudeCodeRunner(EvalRunner):
         system_prompt: Optional[str] = None,
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
+        extra_env: Optional[dict] = None,
     ) -> RunResult:
         cmd = [
             "claude",
@@ -160,7 +161,7 @@ class ClaudeCodeRunner(EvalRunner):
                 stderr=subprocess.PIPE,
                 cwd=str(workspace),
                 text=True,
-                env=self._build_env(),
+                env=self._build_env(extra_env=extra_env),
             )
 
             proc.stdin.write(prompt)
@@ -343,7 +344,7 @@ class ClaudeCodeRunner(EvalRunner):
         "AGENT_EVAL_RUNS_DIR",
     }
 
-    def _build_env(self):
+    def _build_env(self, extra_env=None):
         """Build subprocess environment with allowlisted keys only."""
         env = {k: v for k, v in os.environ.items() if k in self._SAFE_ENV_KEYS}
         for k, v in self._env.items():
@@ -354,6 +355,9 @@ class ClaudeCodeRunner(EvalRunner):
                 if resolved is not None:
                     env[k] = resolved
             else:
+                env[k] = str(v)
+        if extra_env:
+            for k, v in extra_env.items():
                 env[k] = str(v)
         if self._subagent_model:
             env["CLAUDE_CODE_SUBAGENT_MODEL"] = self._subagent_model

--- a/agent_eval/agent/cli_runner.py
+++ b/agent_eval/agent/cli_runner.py
@@ -131,7 +131,7 @@ class CliRunner(EvalRunner):
             with _print_lock:
                 print(f"  {self._log_prefix} | Running: {cmd_str[:120]}", flush=True)
 
-        env = self._build_env()
+        env = self._build_env(settings_path=settings_path)
         start = time.monotonic()
 
         try:
@@ -218,8 +218,12 @@ class CliRunner(EvalRunner):
             return [_sub(part) for part in self._command]
         return _sub(self._command)
 
-    def _build_env(self) -> dict:
-        """Build subprocess environment: inherit env, add extras."""
+    def _build_env(self, settings_path: Optional[Path] = None) -> dict:
+        """Build subprocess environment: inherit env, apply strip list, add extras.
+
+        If settings_path is provided, also merges env vars from the
+        settings.json ``env`` block (written by hook output injection).
+        """
         env = os.environ.copy()
         for k, v in self._extra_env.items():
             if isinstance(v, str) and v.startswith("$"):
@@ -228,6 +232,14 @@ class CliRunner(EvalRunner):
                     env[k] = resolved
             else:
                 env[k] = str(v)
+        # Merge env vars from settings.json (hook outputs, MLflow tracing, etc.)
+        if settings_path and settings_path.exists():
+            try:
+                settings = json.loads(settings_path.read_text())
+                for k, v in (settings.get("env") or {}).items():
+                    env[k] = str(v)
+            except (json.JSONDecodeError, OSError):
+                pass
         return env
 
     @staticmethod

--- a/agent_eval/agent/cli_runner.py
+++ b/agent_eval/agent/cli_runner.py
@@ -87,6 +87,7 @@ class CliRunner(EvalRunner):
         system_prompt: Optional[str] = None,
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
+        extra_env: Optional[dict] = None,
     ) -> RunResult:
         workspace = workspace.resolve()
         output_dir = workspace / "output"
@@ -131,7 +132,7 @@ class CliRunner(EvalRunner):
             with _print_lock:
                 print(f"  {self._log_prefix} | Running: {cmd_str[:120]}", flush=True)
 
-        env = self._build_env(settings_path=settings_path)
+        env = self._build_env(extra_env=extra_env)
         start = time.monotonic()
 
         try:
@@ -218,12 +219,8 @@ class CliRunner(EvalRunner):
             return [_sub(part) for part in self._command]
         return _sub(self._command)
 
-    def _build_env(self, settings_path: Optional[Path] = None) -> dict:
-        """Build subprocess environment: inherit env, apply strip list, add extras.
-
-        If settings_path is provided, also merges env vars from the
-        settings.json ``env`` block (written by hook output injection).
-        """
+    def _build_env(self, extra_env=None) -> dict:
+        """Build subprocess environment: inherit env, add extras."""
         env = os.environ.copy()
         for k, v in self._extra_env.items():
             if isinstance(v, str) and v.startswith("$"):
@@ -232,14 +229,9 @@ class CliRunner(EvalRunner):
                     env[k] = resolved
             else:
                 env[k] = str(v)
-        # Merge env vars from settings.json (hook outputs, MLflow tracing, etc.)
-        if settings_path and settings_path.exists():
-            try:
-                settings = json.loads(settings_path.read_text())
-                for k, v in (settings.get("env") or {}).items():
-                    env[k] = str(v)
-            except (json.JSONDecodeError, OSError):
-                pass
+        if extra_env:
+            for k, v in extra_env.items():
+                env[k] = str(v)
         return env
 
     @staticmethod

--- a/agent_eval/agent/responses_api.py
+++ b/agent_eval/agent/responses_api.py
@@ -263,6 +263,7 @@ class ResponsesAPIRunner(EvalRunner):
         system_prompt: Optional[str] = None,
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
+        extra_env: Optional[dict] = None,
     ) -> RunResult:
         client = None
         effective_model = model or self._default_model

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -543,6 +543,20 @@ class EvalConfig:
                 ))
             setattr(config.hooks, phase, entries)
 
+        if config.execution.mode == "batch":
+            per_case = []
+            if config.hooks.before_each:
+                per_case.append("before_each")
+            if config.hooks.after_each:
+                per_case.append("after_each")
+            if per_case:
+                import warnings
+                warnings.warn(
+                    f"hooks.{', '.join(per_case)} ignored in batch mode "
+                    f"(per-case hooks only run in case/prompt mode)",
+                    stacklevel=2,
+                )
+
         if config.skill and not _is_valid_eval_name(config.skill):
             raise ValueError(
                 f"Invalid skill name in {path}: {config.skill!r}")

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -524,11 +524,21 @@ class EvalConfig:
         for phase in phases:
             entries = []
             for h in (hooks_raw.get(phase) or []):
+                on_failure_val = h.get("on_failure", "fail")
+                if on_failure_val not in ("fail", "continue"):
+                    raise ValueError(
+                        f"hooks.{phase}: on_failure must be 'fail' or "
+                        f"'continue', got '{on_failure_val}'")
+                timeout_val = h.get("timeout", 120)
+                if not isinstance(timeout_val, int) or timeout_val <= 0:
+                    raise ValueError(
+                        f"hooks.{phase}: timeout must be a positive "
+                        f"integer, got {timeout_val}")
                 entries.append(HookEntry(
                     command=h.get("command", ""),
-                    timeout=h.get("timeout", 120),
+                    timeout=timeout_val,
                     description=h.get("description", ""),
-                    on_failure=h.get("on_failure", "fail"),
+                    on_failure=on_failure_val,
                     condition=h.get("condition", ""),
                 ))
             setattr(config.hooks, phase, entries)

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -125,6 +125,26 @@ class InputsConfig:
 
 
 @dataclass
+class HookEntry:
+    """A single lifecycle hook command."""
+    command: str = ""
+    timeout: int = 120
+    description: str = ""
+    on_failure: str = "fail"  # "fail" | "continue"
+    condition: str = ""
+
+
+@dataclass
+class HooksConfig:
+    """Lifecycle hooks that run at defined points in the eval pipeline."""
+    before_all: list = field(default_factory=list)
+    before_each: list = field(default_factory=list)
+    after_each: list = field(default_factory=list)
+    before_scoring: list = field(default_factory=list)
+    after_all: list = field(default_factory=list)
+
+
+@dataclass
 class ExecutionConfig:
     """How the skill is invoked against test cases.
 
@@ -266,6 +286,9 @@ class EvalConfig:
     description: str = ""
     skill: str = ""
     permissions: dict = field(default_factory=dict)
+
+    # Lifecycle hooks — shell commands at defined pipeline points
+    hooks: HooksConfig = field(default_factory=HooksConfig)
 
     # Execution — how the skill is invoked (mode, arguments, timeout, budget)
     execution: ExecutionConfig = field(default_factory=ExecutionConfig)
@@ -493,6 +516,22 @@ class EvalConfig:
 
         # Thresholds
         config.thresholds = raw.get("thresholds", {})
+
+        # Hooks
+        hooks_raw = raw.get("hooks", {}) or {}
+        phases = ["before_all", "before_each", "after_each",
+                  "before_scoring", "after_all"]
+        for phase in phases:
+            entries = []
+            for h in (hooks_raw.get(phase) or []):
+                entries.append(HookEntry(
+                    command=h.get("command", ""),
+                    timeout=h.get("timeout", 120),
+                    description=h.get("description", ""),
+                    on_failure=h.get("on_failure", "fail"),
+                    condition=h.get("condition", ""),
+                ))
+            setattr(config.hooks, phase, entries)
 
         if config.skill and not _is_valid_eval_name(config.skill):
             raise ValueError(

--- a/agent_eval/hooks.py
+++ b/agent_eval/hooks.py
@@ -4,7 +4,6 @@ Runs user-defined shell commands at well-defined points in the eval
 lifecycle (before_all, before_each, after_each, before_scoring, after_all).
 """
 
-import json
 import os
 import signal
 import subprocess
@@ -250,24 +249,6 @@ def collect_hook_outputs(cwd: Path) -> dict:
                 pass
             return content
     return {}
-
-
-def inject_hook_env(workspace_path, env_vars):
-    """Merge hook-output env vars into workspace .claude/settings.json."""
-    if not env_vars:
-        return
-    settings_path = Path(workspace_path) / ".claude" / "settings.json"
-    settings = {}
-    if settings_path.exists():
-        try:
-            settings = json.loads(settings_path.read_text())
-        except (json.JSONDecodeError, OSError):
-            pass
-    env_block = settings.setdefault("env", {})
-    for key, value in env_vars.items():
-        env_block[key] = str(value)
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
-    settings_path.write_text(json.dumps(settings, indent=2))
 
 
 def save_hook_data(output_dir, data):

--- a/agent_eval/hooks.py
+++ b/agent_eval/hooks.py
@@ -45,13 +45,13 @@ class HookResult:
 
 
 def _kill_process(proc: subprocess.Popen):
-    """Send SIGTERM, wait 5s, then SIGKILL if still alive."""
+    """Send SIGTERM to the process group, then SIGKILL if needed."""
     try:
-        proc.terminate()
+        os.killpg(proc.pid, signal.SIGTERM)
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            proc.kill()
+            os.killpg(proc.pid, signal.SIGKILL)
             proc.wait()
     except OSError:
         pass
@@ -69,6 +69,11 @@ def _run_condition(condition: str, env: dict, cwd: Path) -> bool:
         return result.returncode == 0
     except (subprocess.TimeoutExpired, OSError):
         return False
+
+
+def _safe_log_component(value: str) -> str:
+    """Sanitize a string for use in log filenames (CWE-22)."""
+    return "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in value)
 
 
 def run_hooks(
@@ -103,7 +108,7 @@ def run_hooks(
 
     for i, hook in enumerate(entries):
         label = hook.description or hook.command.split("\n")[0][:60]
-        suffix = f".{case_id}" if case_id else ""
+        suffix = f".{_safe_log_component(case_id)}" if case_id else ""
         log_file = log_dir / f"{phase_name}{suffix}.{i}.log"
 
         if hook.condition:

--- a/agent_eval/hooks.py
+++ b/agent_eval/hooks.py
@@ -1,0 +1,290 @@
+"""Lifecycle hook executor for eval pipelines.
+
+Runs user-defined shell commands at well-defined points in the eval
+lifecycle (before_all, before_each, after_each, before_scoring, after_all).
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from agent_eval.config import HookEntry
+
+
+class HookError(Exception):
+    """Raised when a hook fails and on_failure is 'fail'."""
+
+    def __init__(self, hook: HookEntry, phase: str, exit_code: int,
+                 case_id: Optional[str] = None, timed_out: bool = False):
+        self.hook = hook
+        self.phase = phase
+        self.exit_code = exit_code
+        self.case_id = case_id
+        self.timed_out = timed_out
+        label = hook.description or hook.command[:60]
+        detail = "timed out" if timed_out else f"exit code {exit_code}"
+        super().__init__(f"Hook failed in {phase}: {label} ({detail})")
+
+
+@dataclass
+class HookResult:
+    """Result of a single hook execution."""
+    hook: HookEntry
+    phase: str
+    case_id: Optional[str]
+    exit_code: int
+    duration_s: float
+    skipped: bool
+    timed_out: bool
+    log_file: Optional[Path]
+
+
+def _kill_process(proc: subprocess.Popen):
+    """Send SIGTERM, wait 5s, then SIGKILL if still alive."""
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    except OSError:
+        pass
+
+
+def _run_condition(condition: str, env: dict, cwd: Path) -> bool:
+    """Check a hook condition. Returns True if the hook should run."""
+    try:
+        result = subprocess.run(
+            ["bash", "-c", condition],
+            env=env, cwd=str(cwd),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def run_hooks(
+    entries: list[HookEntry],
+    env: dict[str, str],
+    cwd: Path,
+    log_dir: Path,
+    phase_name: str,
+    case_id: Optional[str] = None,
+) -> list[HookResult]:
+    """Run hooks sequentially. Returns results. Raises HookError on failure.
+
+    Args:
+        entries: Hook entries to run in order.
+        env: Environment variables for the hook process.
+        cwd: Working directory for the hook.
+        log_dir: Directory to write hook log files.
+        phase_name: Hook phase name (e.g., "before_all").
+        case_id: Case ID for per-case hooks (used in log filenames).
+
+    Returns:
+        List of HookResult for each hook.
+
+    Raises:
+        HookError: If a hook fails and on_failure is "fail".
+    """
+    if not entries:
+        return []
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    results = []
+
+    for i, hook in enumerate(entries):
+        label = hook.description or hook.command.split("\n")[0][:60]
+        suffix = f".{case_id}" if case_id else ""
+        log_file = log_dir / f"{phase_name}{suffix}.{i}.log"
+
+        if hook.condition:
+            if not _run_condition(hook.condition, env, cwd):
+                print(f"  hook: {label} ... SKIP (condition)", file=sys.stderr)
+                results.append(HookResult(
+                    hook=hook, phase=phase_name, case_id=case_id,
+                    exit_code=0, duration_s=0.0, skipped=True,
+                    timed_out=False, log_file=None,
+                ))
+                continue
+
+        start = time.monotonic()
+        timed_out = False
+        exit_code = -1
+
+        try:
+            with open(log_file, "w") as log_fh:
+                proc = subprocess.Popen(
+                    ["bash", "-c", hook.command],
+                    env=env, cwd=str(cwd),
+                    stdout=log_fh, stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+                try:
+                    proc.wait(timeout=hook.timeout)
+                    exit_code = proc.returncode
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+                    _kill_process(proc)
+                    exit_code = -1
+        except OSError as e:
+            with open(log_file, "a") as log_fh:
+                log_fh.write(f"\nHook failed to start: {e}\n")
+            exit_code = -1
+
+        duration = round(time.monotonic() - start, 1)
+
+        if timed_out:
+            status = f"TIMEOUT ({hook.timeout}s)"
+        elif exit_code == 0:
+            status = "OK"
+        else:
+            status = f"FAIL (exit {exit_code})"
+        print(f"  hook: {label} ... {status}", file=sys.stderr)
+
+        results.append(HookResult(
+            hook=hook, phase=phase_name, case_id=case_id,
+            exit_code=exit_code, duration_s=duration,
+            skipped=False, timed_out=timed_out, log_file=log_file,
+        ))
+
+        failed = timed_out or exit_code != 0
+        if failed and hook.on_failure == "fail":
+            raise HookError(hook, phase_name, exit_code,
+                            case_id=case_id, timed_out=timed_out)
+
+    return results
+
+
+def run_hooks_safe(
+    entries: list[HookEntry],
+    env: dict[str, str],
+    cwd: Path,
+    log_dir: Path,
+    phase_name: str,
+    case_id: Optional[str] = None,
+) -> list[HookResult]:
+    """Like run_hooks but never raises — all failures use continue semantics.
+
+    Used for after_all hooks which are guaranteed to run even on failure.
+    """
+    if not entries:
+        return []
+
+    override = []
+    for hook in entries:
+        patched = HookEntry(
+            command=hook.command,
+            timeout=hook.timeout,
+            description=hook.description,
+            on_failure="continue",
+            condition=hook.condition,
+        )
+        override.append(patched)
+
+    return run_hooks(override, env, cwd, log_dir, phase_name, case_id)
+
+
+def build_hook_env(
+    workspace: str,
+    run_id: str,
+    config_path: str,
+    project_root: str,
+    model: str,
+    case_id: Optional[str] = None,
+    case_workspace: Optional[str] = None,
+    case_source_dir: Optional[str] = None,
+    case_input: Optional[str] = None,
+) -> dict[str, str]:
+    """Build environment dict with harness-injected variables."""
+    env = dict(os.environ)
+    env["AGENT_EVAL_WORKSPACE"] = workspace
+    env["AGENT_EVAL_RUN_ID"] = run_id
+    env["AGENT_EVAL_CONFIG"] = config_path
+    env["AGENT_EVAL_PROJECT_ROOT"] = project_root
+    env["AGENT_EVAL_MODEL"] = model
+
+    if case_id is not None:
+        env["CASE_ID"] = case_id
+    if case_workspace is not None:
+        env["CASE_WORKSPACE"] = case_workspace
+    if case_source_dir is not None:
+        env["CASE_SOURCE_DIR"] = case_source_dir
+    if case_input is not None:
+        env["CASE_INPUT"] = case_input
+
+    return env
+
+
+def main():
+    """CLI entry point for standalone hook invocation."""
+    import argparse
+    from agent_eval.config import EvalConfig
+
+    parser = argparse.ArgumentParser(
+        description="Run lifecycle hooks from eval.yaml")
+    parser.add_argument("--config", default="eval.yaml",
+                        help="Path to eval.yaml")
+    parser.add_argument("--phase", required=True,
+                        choices=["before_all", "before_each", "after_each",
+                                 "before_scoring", "after_all"],
+                        help="Hook phase to run")
+    parser.add_argument("--workspace", required=True,
+                        help="Workspace root path")
+    parser.add_argument("--run-id", required=True, help="Run ID")
+    parser.add_argument("--model", required=True, help="Skill model")
+    parser.add_argument("--output", required=True,
+                        help="Output/run directory for hook logs")
+    parser.add_argument("--case-id", default=None,
+                        help="Case ID (for per-case hooks)")
+    parser.add_argument("--case-workspace", default=None,
+                        help="Case workspace path (for per-case hooks)")
+    parser.add_argument("--case-source-dir", default=None,
+                        help="Case source directory (for per-case hooks)")
+    args = parser.parse_args()
+
+    config = EvalConfig.from_yaml(args.config)
+    entries = getattr(config.hooks, args.phase, [])
+
+    if not entries:
+        return
+
+    env = build_hook_env(
+        workspace=args.workspace,
+        run_id=args.run_id,
+        config_path=str(Path(args.config).resolve()),
+        project_root=str(Path.cwd()),
+        model=args.model,
+        case_id=args.case_id,
+        case_workspace=args.case_workspace,
+        case_source_dir=args.case_source_dir,
+        case_input=(str(Path(args.case_workspace) / "input.yaml")
+                    if args.case_workspace else None),
+    )
+
+    cwd = Path(args.case_workspace) if args.case_workspace else Path.cwd()
+    log_dir = Path(args.output) / "hooks"
+
+    phase = args.phase
+    if phase == "after_all":
+        run_hooks_safe(entries, env, cwd, log_dir, phase,
+                       case_id=args.case_id)
+    else:
+        try:
+            run_hooks(entries, env, cwd, log_dir, phase,
+                      case_id=args.case_id)
+        except HookError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent_eval/hooks.py
+++ b/agent_eval/hooks.py
@@ -4,6 +4,7 @@ Runs user-defined shell commands at well-defined points in the eval
 lifecycle (before_all, before_each, after_each, before_scoring, after_all).
 """
 
+import json
 import os
 import signal
 import subprocess
@@ -12,6 +13,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
+import yaml
 
 from agent_eval.config import HookEntry
 
@@ -227,6 +230,54 @@ def build_hook_env(
         env["CASE_INPUT"] = case_input
 
     return env
+
+
+def collect_hook_outputs(cwd: Path) -> dict:
+    """Read and remove .hook-outputs.yaml/.json from cwd.
+
+    Returns the parsed dict (with 'env' and/or 'data' keys) or {}.
+    """
+    for name in (".hook-outputs.yaml", ".hook-outputs.json"):
+        path = cwd / name
+        if path.exists():
+            try:
+                content = yaml.safe_load(path.read_text()) or {}
+            except (yaml.YAMLError, OSError):
+                content = {}
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            return content
+    return {}
+
+
+def inject_hook_env(workspace_path, env_vars):
+    """Merge hook-output env vars into workspace .claude/settings.json."""
+    if not env_vars:
+        return
+    settings_path = Path(workspace_path) / ".claude" / "settings.json"
+    settings = {}
+    if settings_path.exists():
+        try:
+            settings = json.loads(settings_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    env_block = settings.setdefault("env", {})
+    for key, value in env_vars.items():
+        env_block[key] = str(value)
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(settings, indent=2))
+
+
+def save_hook_data(output_dir, data):
+    """Save hook output data dict for judges to read later."""
+    if not data:
+        return
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "hook_outputs.yaml").write_text(
+        yaml.dump(data, default_flow_style=False))
 
 
 def main():

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -133,6 +133,8 @@ Write the resolved handlers back to `tool_handlers.yaml`.
 
 Run the skill headlessly against test cases. In `case` mode (default), execute.py runs the skill once per case with case-specific arguments and workspace — each case gets its own stdout.log and subagent transcripts. In `batch` mode, all cases run in a single invocation via batch.yaml.
 
+If `hooks:` is configured in eval.yaml, execute.py automatically runs lifecycle hooks at the appropriate points: `before_all` before any case executes, `before_each`/`after_each` around each case execution, and `after_all` after all cases complete (guaranteed, even on failure). Hook logs are written to `$AGENT_EVAL_RUNS_DIR/<id>/hooks/`.
+
 The execute script handles CLI construction, streaming progress, and result capture:
 
 ```bash
@@ -143,6 +145,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
   --skill-args "<skill arguments>" \
   --model <model> \
   --output $AGENT_EVAL_RUNS_DIR/<eval-name>/<id> \
+  --run-id <id> \
   [--agent <runner>] \
   [--subagent-model <model>] \
   [--mlflow-experiment <name>] \
@@ -217,8 +220,12 @@ If `--no-llm-judges` was specified, skip judges that make LLM API calls (prompt,
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/score.py judges \
   --run-id <id> \
-  --config <config>
+  --config <config> \
+  --workspace <workspace_path> \
+  --model <model>
 ```
+
+If `hooks.before_scoring` is configured in eval.yaml, score.py runs those hooks before judge execution. Pass `--workspace` and `--model` so hook environment variables are populated.
 
 Judges receive a record dict with:
 - **File contents**: `outputs["files"]`, `outputs["<dir>_content"]`

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -315,43 +315,46 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
     print(f"  [{index}/{total_cases}] {case_id}: /{skill_name} {case_args}",
           file=sys.stderr)
 
-    # Per-case hooks: build case-specific env and run before_each
+    # Per-case hooks: build case-specific env, run before_each/after_each.
+    # The entire block is wrapped in try/finally so that after_each cleanup
+    # hooks fire even if before_each or run_skill raises.
     case_hook_env = None
     merged_hook_data = {}
-    if config and config.hooks and hook_env:
-        dataset_path = config.dataset_path
-        case_source_dir = str(Path(dataset_path).resolve() / case_id) if dataset_path else ""
-        case_hook_env = {
-            **hook_env,
-            "CASE_ID": case_id,
-            "CASE_WORKSPACE": str(case_ws.resolve()),
-            "CASE_SOURCE_DIR": case_source_dir,
-            "CASE_INPUT": str((case_ws / "input.yaml").resolve()),
-        }
-        log_dir = output_dir / "hooks"
-        if config.hooks.before_each:
-            run_hooks(config.hooks.before_each, env=case_hook_env,
-                      cwd=case_ws, log_dir=log_dir,
-                      phase_name="before_each", case_id=case_id)
-
-        # Collect hook outputs and merge with global
-        case_outputs = collect_hook_outputs(case_ws)
-        global_env = (global_hook_outputs or {}).get("env", {})
-        case_env = case_outputs.get("env", {})
-        merged_env = {**global_env, **case_env}
-
-        if merged_env:
-            inject_hook_env(case_ws, merged_env)
-            # Re-check settings_path since we may have just created it
-            settings_path = case_settings if case_settings.exists() else settings_path
-            # Forward-propagate to after_each hooks
-            case_hook_env.update({k: str(v) for k, v in merged_env.items()})
-
-        global_data = (global_hook_outputs or {}).get("data", {})
-        case_data_out = case_outputs.get("data", {})
-        merged_hook_data = {**global_data, **case_data_out}
-
+    result = None
     try:
+        if config and config.hooks and hook_env:
+            dataset_path = config.dataset_path
+            case_source_dir = str(Path(dataset_path).resolve() / case_id) if dataset_path else ""
+            case_hook_env = {
+                **hook_env,
+                "CASE_ID": case_id,
+                "CASE_WORKSPACE": str(case_ws.resolve()),
+                "CASE_SOURCE_DIR": case_source_dir,
+                "CASE_INPUT": str((case_ws / "input.yaml").resolve()),
+            }
+            log_dir = output_dir / "hooks"
+            if config.hooks.before_each:
+                run_hooks(config.hooks.before_each, env=case_hook_env,
+                          cwd=case_ws, log_dir=log_dir,
+                          phase_name="before_each", case_id=case_id)
+
+            # Collect hook outputs and merge with global
+            case_outputs = collect_hook_outputs(case_ws)
+            global_env = (global_hook_outputs or {}).get("env", {})
+            case_env = case_outputs.get("env", {})
+            merged_env = {**global_env, **case_env}
+
+            if merged_env:
+                inject_hook_env(case_ws, merged_env)
+                # Re-check settings_path since we may have just created it
+                settings_path = case_settings if case_settings.exists() else settings_path
+                # Forward-propagate to after_each hooks
+                case_hook_env.update({k: str(v) for k, v in merged_env.items()})
+
+            global_data = (global_hook_outputs or {}).get("data", {})
+            case_data_out = case_outputs.get("data", {})
+            merged_hook_data = {**global_data, **case_data_out}
+
         result = runner.run_skill(
             skill_name=skill_name,
             args=case_args,

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 from agent_eval.agent import RUNNERS
 from agent_eval.hooks import (
-    HookError, build_hook_env, collect_hook_outputs, inject_hook_env,
+    HookError, build_hook_env, collect_hook_outputs,
     run_hooks, run_hooks_safe, save_hook_data,
 )
 
@@ -185,8 +185,6 @@ def main():
                       phase_name="before_all")
             global_hook_outputs = collect_hook_outputs(Path(args.workspace))
 
-        # Inject hook-output env vars into workspace settings.json
-        inject_hook_env(args.workspace, global_hook_outputs.get("env"))
         save_hook_data(output_dir, global_hook_outputs.get("data"))
 
         # Set MLflow environment in the workspace settings
@@ -208,6 +206,7 @@ def main():
             system_prompt=system_prompt,
             max_budget_usd=max_budget,
             timeout_s=timeout_s,
+            extra_env=global_hook_outputs.get("env") or None,
         )
 
         _save_result(result, args, output_dir, runner, model, eval_params=eval_params)
@@ -320,12 +319,13 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
     # hooks fire even if before_each or run_skill raises.
     case_hook_env = None
     merged_hook_data = {}
+    merged_env = {}
     result = None
     error_msg = ""
     try:
         if config and config.hooks and hook_env:
-            dataset_path = config.dataset_path
-            case_source_dir = str(Path(dataset_path).resolve() / case_id) if dataset_path else ""
+            dataset_path = config.dataset.path
+            case_source_dir = str(config.resolve_path(dataset_path) / case_id) if dataset_path else ""
             case_hook_env = {
                 **hook_env,
                 "CASE_ID": case_id,
@@ -346,10 +346,6 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
             merged_env = {**global_env, **case_env}
 
             if merged_env:
-                inject_hook_env(case_ws, merged_env)
-                # Re-check settings_path since we may have just created it
-                settings_path = case_settings if case_settings.exists() else settings_path
-                # Forward-propagate to after_each hooks
                 case_hook_env.update({k: str(v) for k, v in merged_env.items()})
 
             global_data = (global_hook_outputs or {}).get("data", {})
@@ -365,6 +361,7 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
             system_prompt=system_prompt,
             max_budget_usd=max_budget,
             timeout_s=timeout_s,
+            extra_env=merged_env or None,
         )
     except Exception as exc:
         print(f"    → {case_id}: ERROR ({exc})", file=sys.stderr)

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -174,14 +174,14 @@ def main():
     )
     log_dir = output_dir / "hooks"
 
-    # Run before_all hooks
-    if config.hooks.before_all:
-        print("Running before_all hooks...", file=sys.stderr)
-        run_hooks(config.hooks.before_all, env=hook_env,
-                  cwd=Path.cwd(), log_dir=log_dir,
-                  phase_name="before_all")
-
     try:
+        # Run before_all hooks
+        if config.hooks.before_all:
+            print("Running before_all hooks...", file=sys.stderr)
+            run_hooks(config.hooks.before_all, env=hook_env,
+                      cwd=Path.cwd(), log_dir=log_dir,
+                      phase_name="before_all")
+
         # Set MLflow environment in the workspace settings
         if mlflow_experiment:
             from agent_eval.mlflow.experiment import inject_tracing_env
@@ -419,17 +419,17 @@ def _execute_per_case(args, config, runner, runner_cls,
     )
     log_dir = output_dir / "hooks"
 
-    # Run before_all hooks
-    if config.hooks.before_all:
-        print("Running before_all hooks...", file=sys.stderr)
-        run_hooks(config.hooks.before_all, env=hook_env,
-                  cwd=Path.cwd(), log_dir=log_dir,
-                  phase_name="before_all")
-
     case_results = {}
     wall_clock_start = time.monotonic()
 
     try:
+        # Run before_all hooks (inside try so after_all runs on failure)
+        if config.hooks.before_all:
+            print("Running before_all hooks...", file=sys.stderr)
+            run_hooks(config.hooks.before_all, env=hook_env,
+                      cwd=Path.cwd(), log_dir=log_dir,
+                      phase_name="before_all")
+
         if effective_parallelism > 1:
             from concurrent.futures import ThreadPoolExecutor, as_completed
 

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -351,23 +351,30 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
         case_data_out = case_outputs.get("data", {})
         merged_hook_data = {**global_data, **case_data_out}
 
-    result = runner.run_skill(
-        skill_name=skill_name,
-        args=case_args,
-        workspace=case_ws,
-        model=model,
-        settings_path=settings_path,
-        system_prompt=system_prompt,
-        max_budget_usd=max_budget,
-        timeout_s=timeout_s,
-    )
+    try:
+        result = runner.run_skill(
+            skill_name=skill_name,
+            args=case_args,
+            workspace=case_ws,
+            model=model,
+            settings_path=settings_path,
+            system_prompt=system_prompt,
+            max_budget_usd=max_budget,
+            timeout_s=timeout_s,
+        )
+    except Exception as exc:
+        print(f"    → {case_id}: ERROR ({exc})", file=sys.stderr)
+        result = None
+    finally:
+        # Run after_each hooks (guaranteed, like after_all)
+        if config and config.hooks and config.hooks.after_each and case_hook_env:
+            log_dir = output_dir / "hooks"
+            run_hooks_safe(config.hooks.after_each, env=case_hook_env,
+                           cwd=case_ws, log_dir=log_dir,
+                           phase_name="after_each", case_id=case_id)
 
-    # Run after_each hooks
-    if config and config.hooks and config.hooks.after_each and case_hook_env:
-        log_dir = output_dir / "hooks"
-        run_hooks(config.hooks.after_each, env=case_hook_env,
-                  cwd=case_ws, log_dir=log_dir,
-                  phase_name="after_each", case_id=case_id)
+    if result is None:
+        return case_id, None
 
     case_output = output_dir / "cases" / case_id
     case_output.mkdir(parents=True, exist_ok=True)

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -321,6 +321,7 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
     case_hook_env = None
     merged_hook_data = {}
     result = None
+    error_msg = ""
     try:
         if config and config.hooks and hook_env:
             dataset_path = config.dataset_path
@@ -368,6 +369,7 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
     except Exception as exc:
         print(f"    → {case_id}: ERROR ({exc})", file=sys.stderr)
         result = None
+        error_msg = str(exc)
     finally:
         # Run after_each hooks (guaranteed, like after_all)
         if config and config.hooks and config.hooks.after_each and case_hook_env:
@@ -377,7 +379,22 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
                            phase_name="after_each", case_id=case_id)
 
     if result is None:
-        return case_id, None
+        case_output = output_dir / "cases" / case_id
+        case_output.mkdir(parents=True, exist_ok=True)
+        failed_result = {
+            "exit_code": 1,
+            "duration_s": 0,
+            "token_usage": None,
+            "cost_usd": None,
+            "num_turns": None,
+            "per_model_usage": None,
+            "per_model_turns": None,
+            "error": error_msg,
+        }
+        with open(case_output / "run_result.json", "w") as f:
+            json.dump(failed_result, f, indent=2)
+            f.write("\n")
+        return case_id, failed_result
 
     case_output = output_dir / "cases" / case_id
     case_output.mkdir(parents=True, exist_ok=True)

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -30,7 +30,8 @@ from pathlib import Path
 
 from agent_eval.agent import RUNNERS
 from agent_eval.hooks import (
-    HookError, build_hook_env, run_hooks, run_hooks_safe,
+    HookError, build_hook_env, collect_hook_outputs, inject_hook_env,
+    run_hooks, run_hooks_safe, save_hook_data,
 )
 
 _HARNESS_SYSTEM_PROMPT = (
@@ -175,12 +176,18 @@ def main():
     log_dir = output_dir / "hooks"
 
     try:
-        # Run before_all hooks
+        # Run before_all hooks and collect outputs
+        global_hook_outputs = {}
         if config.hooks.before_all:
             print("Running before_all hooks...", file=sys.stderr)
             run_hooks(config.hooks.before_all, env=hook_env,
                       cwd=Path.cwd(), log_dir=log_dir,
                       phase_name="before_all")
+            global_hook_outputs = collect_hook_outputs(Path(args.workspace))
+
+        # Inject hook-output env vars into workspace settings.json
+        inject_hook_env(args.workspace, global_hook_outputs.get("env"))
+        save_hook_data(output_dir, global_hook_outputs.get("data"))
 
         # Set MLflow environment in the workspace settings
         if mlflow_experiment:
@@ -275,7 +282,8 @@ def _build_eval_params(args, config, skill_args, max_budget, timeout_s, effort=N
 def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
                      skill_args_template, model, mlflow_experiment,
                      mlflow_tracking_uri, system_prompt, max_budget, timeout_s,
-                     total_cases, index, config=None, hook_env=None):
+                     total_cases, index, config=None, hook_env=None,
+                     global_hook_outputs=None):
     """Execute and collect results for a single test case.
 
     Thread-safe: all I/O is to case-specific directories.
@@ -309,6 +317,7 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
 
     # Per-case hooks: build case-specific env and run before_each
     case_hook_env = None
+    merged_hook_data = {}
     if config and config.hooks and hook_env:
         dataset_path = config.dataset_path
         case_source_dir = str(Path(dataset_path).resolve() / case_id) if dataset_path else ""
@@ -324,6 +333,23 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
             run_hooks(config.hooks.before_each, env=case_hook_env,
                       cwd=case_ws, log_dir=log_dir,
                       phase_name="before_each", case_id=case_id)
+
+        # Collect hook outputs and merge with global
+        case_outputs = collect_hook_outputs(case_ws)
+        global_env = (global_hook_outputs or {}).get("env", {})
+        case_env = case_outputs.get("env", {})
+        merged_env = {**global_env, **case_env}
+
+        if merged_env:
+            inject_hook_env(case_ws, merged_env)
+            # Re-check settings_path since we may have just created it
+            settings_path = case_settings if case_settings.exists() else settings_path
+            # Forward-propagate to after_each hooks
+            case_hook_env.update({k: str(v) for k, v in merged_env.items()})
+
+        global_data = (global_hook_outputs or {}).get("data", {})
+        case_data_out = case_outputs.get("data", {})
+        merged_hook_data = {**global_data, **case_data_out}
 
     result = runner.run_skill(
         skill_name=skill_name,
@@ -349,6 +375,9 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
         (case_output / "stdout.log").write_text(result.stdout)
     if result.stderr:
         (case_output / "stderr.log").write_text(result.stderr)
+
+    # Save hook output data for judges
+    save_hook_data(case_output, merged_hook_data)
 
     if input_path.exists() and not input_path.is_symlink():
         shutil.copy2(input_path, case_output / "input.yaml")
@@ -423,12 +452,14 @@ def _execute_per_case(args, config, runner, runner_cls,
     wall_clock_start = time.monotonic()
 
     try:
-        # Run before_all hooks (inside try so after_all runs on failure)
+        # Run before_all hooks and collect outputs
+        global_hook_outputs = {}
         if config.hooks.before_all:
             print("Running before_all hooks...", file=sys.stderr)
             run_hooks(config.hooks.before_all, env=hook_env,
                       cwd=Path.cwd(), log_dir=log_dir,
                       phase_name="before_all")
+            global_hook_outputs = collect_hook_outputs(workspace)
 
         if effective_parallelism > 1:
             from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -452,7 +483,8 @@ def _execute_per_case(args, config, runner, runner_cls,
                         mlflow_experiment, config.mlflow.tracking_uri,
                         system_prompt, max_budget, timeout_s,
                         len(case_order), i,
-                        config=config, hook_env=hook_env)
+                        config=config, hook_env=hook_env,
+                        global_hook_outputs=global_hook_outputs)
                     futures[fut] = case_id
 
                 for fut in as_completed(futures):
@@ -468,7 +500,8 @@ def _execute_per_case(args, config, runner, runner_cls,
                     skill_args_template, model, mlflow_experiment,
                     config.mlflow.tracking_uri, system_prompt,
                     max_budget, timeout_s, len(case_order), i,
-                    config=config, hook_env=hook_env)
+                    config=config, hook_env=hook_env,
+                    global_hook_outputs=global_hook_outputs)
                 if result is not None:
                     case_results[case_id] = result
     finally:

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -22,12 +22,16 @@ import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
 import argparse
 import json
+import os
 import shutil
 import sys
 import time
 from pathlib import Path
 
 from agent_eval.agent import RUNNERS
+from agent_eval.hooks import (
+    HookError, build_hook_env, run_hooks, run_hooks_safe,
+)
 
 _HARNESS_SYSTEM_PROMPT = (
     "You are running inside an evaluation harness. Tool interception hooks "
@@ -64,6 +68,8 @@ def main():
                         help="Claude Code reasoning effort (default: from eval.yaml runner.effort)")
     parser.add_argument("--parallelism", type=int, default=None,
                         help="Max parallel case executions (default: from eval.yaml or sequential)")
+    parser.add_argument("--run-id", default=None,
+                        help="Run identifier (for hook env vars and log paths)")
     args = parser.parse_args()
 
     from agent_eval.config import EvalConfig
@@ -157,34 +163,58 @@ def main():
     print(f"Agent: {runner.name} | Model: {model}", file=sys.stderr)
     print(f"Workspace: {args.workspace}", file=sys.stderr)
 
-    # Set MLflow environment in the workspace settings
-    if mlflow_experiment:
-        from agent_eval.mlflow.experiment import inject_tracing_env
-        inject_tracing_env(args.workspace, project_root=Path.cwd(),
-                           tracking_uri=config.mlflow.tracking_uri,
-                           experiment_name=mlflow_experiment)
-
-    workspace_settings = Path(args.workspace) / ".claude" / "settings.json"
-    settings_path = workspace_settings if workspace_settings.exists() else None
-
-
-    result = runner.run_skill(
-        skill_name=args.skill,
-        args=skill_args,
-        workspace=Path(args.workspace),
+    # Build hook environment for batch mode
+    run_id = args.run_id or ""
+    hook_env = build_hook_env(
+        workspace=args.workspace,
+        run_id=run_id,
+        config_path=str(Path(args.config).resolve()),
+        project_root=str(Path.cwd()),
         model=model,
-        settings_path=settings_path,
-        system_prompt=system_prompt,
-        max_budget_usd=max_budget,
-        timeout_s=timeout_s,
     )
+    log_dir = output_dir / "hooks"
 
-    _save_result(result, args, output_dir, runner, model, eval_params=eval_params)
+    # Run before_all hooks
+    if config.hooks.before_all:
+        print("Running before_all hooks...", file=sys.stderr)
+        run_hooks(config.hooks.before_all, env=hook_env,
+                  cwd=Path.cwd(), log_dir=log_dir,
+                  phase_name="before_all")
 
-    # Copy batch input files to output dir for MLflow artifact logging.
-    _copy_input_files_batch(Path(args.workspace), output_dir)
+    try:
+        # Set MLflow environment in the workspace settings
+        if mlflow_experiment:
+            from agent_eval.mlflow.experiment import inject_tracing_env
+            inject_tracing_env(args.workspace, project_root=Path.cwd(),
+                               tracking_uri=config.mlflow.tracking_uri,
+                               experiment_name=mlflow_experiment)
 
-    sys.exit(result.exit_code)
+        workspace_settings = Path(args.workspace) / ".claude" / "settings.json"
+        settings_path = workspace_settings if workspace_settings.exists() else None
+
+        result = runner.run_skill(
+            skill_name=args.skill,
+            args=skill_args,
+            workspace=Path(args.workspace),
+            model=model,
+            settings_path=settings_path,
+            system_prompt=system_prompt,
+            max_budget_usd=max_budget,
+            timeout_s=timeout_s,
+        )
+
+        _save_result(result, args, output_dir, runner, model, eval_params=eval_params)
+
+        # Copy batch input files to output dir for MLflow artifact logging.
+        _copy_input_files_batch(Path(args.workspace), output_dir)
+
+        sys.exit(result.exit_code)
+    finally:
+        if config.hooks.after_all:
+            print("Running after_all hooks...", file=sys.stderr)
+            run_hooks_safe(config.hooks.after_all, env=hook_env,
+                           cwd=Path.cwd(), log_dir=log_dir,
+                           phase_name="after_all")
 
 
 def _resolve_arguments(template, case_data):
@@ -245,7 +275,7 @@ def _build_eval_params(args, config, skill_args, max_budget, timeout_s, effort=N
 def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
                      skill_args_template, model, mlflow_experiment,
                      mlflow_tracking_uri, system_prompt, max_budget, timeout_s,
-                     total_cases, index):
+                     total_cases, index, config=None, hook_env=None):
     """Execute and collect results for a single test case.
 
     Thread-safe: all I/O is to case-specific directories.
@@ -277,6 +307,24 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
     print(f"  [{index}/{total_cases}] {case_id}: /{skill_name} {case_args}",
           file=sys.stderr)
 
+    # Per-case hooks: build case-specific env and run before_each
+    case_hook_env = None
+    if config and config.hooks and hook_env:
+        dataset_path = config.dataset_path
+        case_source_dir = str(Path(dataset_path).resolve() / case_id) if dataset_path else ""
+        case_hook_env = {
+            **hook_env,
+            "CASE_ID": case_id,
+            "CASE_WORKSPACE": str(case_ws.resolve()),
+            "CASE_SOURCE_DIR": case_source_dir,
+            "CASE_INPUT": str((case_ws / "input.yaml").resolve()),
+        }
+        log_dir = output_dir / "hooks"
+        if config.hooks.before_each:
+            run_hooks(config.hooks.before_each, env=case_hook_env,
+                      cwd=case_ws, log_dir=log_dir,
+                      phase_name="before_each", case_id=case_id)
+
     result = runner.run_skill(
         skill_name=skill_name,
         args=case_args,
@@ -287,6 +335,13 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
         max_budget_usd=max_budget,
         timeout_s=timeout_s,
     )
+
+    # Run after_each hooks
+    if config and config.hooks and config.hooks.after_each and case_hook_env:
+        log_dir = output_dir / "hooks"
+        run_hooks(config.hooks.after_each, env=case_hook_env,
+                  cwd=case_ws, log_dir=log_dir,
+                  phase_name="after_each", case_id=case_id)
 
     case_output = output_dir / "cases" / case_id
     case_output.mkdir(parents=True, exist_ok=True)
@@ -353,48 +408,75 @@ def _execute_per_case(args, config, runner, runner_cls,
           file=sys.stderr)
     print(f"Agent: {runner.name} | Model: {model}", file=sys.stderr)
 
+    # Build hook environment
+    run_id = args.run_id or ""
+    hook_env = build_hook_env(
+        workspace=str(workspace),
+        run_id=run_id,
+        config_path=str(Path(args.config).resolve()),
+        project_root=str(Path.cwd()),
+        model=model,
+    )
+    log_dir = output_dir / "hooks"
+
+    # Run before_all hooks
+    if config.hooks.before_all:
+        print("Running before_all hooks...", file=sys.stderr)
+        run_hooks(config.hooks.before_all, env=hook_env,
+                  cwd=Path.cwd(), log_dir=log_dir,
+                  phase_name="before_all")
+
     case_results = {}
     wall_clock_start = time.monotonic()
 
-    if effective_parallelism > 1:
-        from concurrent.futures import ThreadPoolExecutor, as_completed
+    try:
+        if effective_parallelism > 1:
+            from concurrent.futures import ThreadPoolExecutor, as_completed
 
-        futures = {}
-        with ThreadPoolExecutor(max_workers=effective_parallelism) as pool:
+            futures = {}
+            with ThreadPoolExecutor(max_workers=effective_parallelism) as pool:
+                for i, entry in enumerate(case_order, 1):
+                    case_id = entry["case_id"] if isinstance(entry, dict) else entry
+                    case_ws = workspace / "cases" / case_id
+                    case_runner = runner_cls.from_config(
+                        config,
+                        log_prefix=f"eval:{case_id}",
+                        subagent_model=subagent_model,
+                        mlflow_experiment=mlflow_experiment,
+                        mlflow_tracking_uri=config.mlflow.tracking_uri,
+                        effort=effort,
+                    )
+                    fut = pool.submit(
+                        _run_single_case, case_runner, args.skill, case_id,
+                        case_ws, output_dir, skill_args_template, model,
+                        mlflow_experiment, config.mlflow.tracking_uri,
+                        system_prompt, max_budget, timeout_s,
+                        len(case_order), i,
+                        config=config, hook_env=hook_env)
+                    futures[fut] = case_id
+
+                for fut in as_completed(futures):
+                    case_id, result = fut.result()
+                    if result is not None:
+                        case_results[case_id] = result
+        else:
             for i, entry in enumerate(case_order, 1):
                 case_id = entry["case_id"] if isinstance(entry, dict) else entry
                 case_ws = workspace / "cases" / case_id
-                case_runner = runner_cls.from_config(
-                    config,
-                    log_prefix=f"eval:{case_id}",
-                    subagent_model=subagent_model,
-                    mlflow_experiment=mlflow_experiment,
-                    mlflow_tracking_uri=config.mlflow.tracking_uri,
-                    effort=effort,
-                )
-                fut = pool.submit(
-                    _run_single_case, case_runner, args.skill, case_id,
-                    case_ws, output_dir, skill_args_template, model,
-                    mlflow_experiment, config.mlflow.tracking_uri,
-                    system_prompt, max_budget, timeout_s,
-                    len(case_order), i)
-                futures[fut] = case_id
-
-            for fut in as_completed(futures):
-                case_id, result = fut.result()
+                case_id, result = _run_single_case(
+                    runner, args.skill, case_id, case_ws, output_dir,
+                    skill_args_template, model, mlflow_experiment,
+                    config.mlflow.tracking_uri, system_prompt,
+                    max_budget, timeout_s, len(case_order), i,
+                    config=config, hook_env=hook_env)
                 if result is not None:
                     case_results[case_id] = result
-    else:
-        for i, entry in enumerate(case_order, 1):
-            case_id = entry["case_id"] if isinstance(entry, dict) else entry
-            case_ws = workspace / "cases" / case_id
-            case_id, result = _run_single_case(
-                runner, args.skill, case_id, case_ws, output_dir,
-                skill_args_template, model, mlflow_experiment,
-                config.mlflow.tracking_uri, system_prompt,
-                max_budget, timeout_s, len(case_order), i)
-            if result is not None:
-                case_results[case_id] = result
+    finally:
+        if config.hooks.after_all:
+            print("Running after_all hooks...", file=sys.stderr)
+            run_hooks_safe(config.hooks.after_all, env=hook_env,
+                           cwd=Path.cwd(), log_dir=log_dir,
+                           phase_name="after_all")
 
     wall_clock_s = round(time.monotonic() - wall_clock_start, 1)
 

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -245,6 +245,15 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
                 record["tool_calls"] = _extract_tool_calls(
                     stdout_text, tool_outputs)
 
+    # --- Hook outputs (from before_each hooks via .hook-outputs.yaml) ---
+    hook_outputs_path = case_dir / "hook_outputs.yaml"
+    if hook_outputs_path.exists():
+        try:
+            with open(hook_outputs_path) as f:
+                record["hook_outputs"] = yaml.safe_load(f) or {}
+        except (yaml.YAMLError, OSError):
+            record["hook_outputs"] = {}
+
     return record
 
 

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -1449,6 +1449,22 @@ def cmd_judges(args):
         samples_override = max(1, samples_override)
         if samples_override == 1:
             samples_override = None
+
+    # Run before_scoring hooks
+    if config.hooks.before_scoring:
+        from agent_eval.hooks import build_hook_env, run_hooks
+        hook_env = build_hook_env(
+            workspace=args.workspace or "",
+            run_id=args.run_id,
+            config_path=str(Path(args.config).resolve()),
+            project_root=str(project_root),
+            model=args.model or "",
+        )
+        log_dir = runs_dir / args.run_id / "hooks"
+        print("Running before_scoring hooks...", file=sys.stderr)
+        run_hooks(config.hooks.before_scoring, env=hook_env,
+                  cwd=project_root, log_dir=log_dir,
+                  phase_name="before_scoring")
     judges = load_judges(config, project_root)
     n_llm = sum(1 for _, _, _, jt, _ in judges if jt == "llm")
     sampled = [n for n, _, _, jt, s in judges
@@ -1639,6 +1655,10 @@ def main():
                             "judge N times per case; median (score) / majority "
                             "(bool) becomes the value, spread recorded for "
                             "stability reporting")
+    jdg_p.add_argument("--workspace", default=None,
+                       help="Workspace path (for before_scoring hook env vars)")
+    jdg_p.add_argument("--model", default=None,
+                       help="Skill model (for before_scoring hook env vars)")
 
     # pairwise
     pw_p = subparsers.add_parser("pairwise", help="Pairwise comparison")

--- a/specs/006-execution-hooks/spec.md
+++ b/specs/006-execution-hooks/spec.md
@@ -157,6 +157,13 @@ When `condition` is set, the harness runs `bash -c "<condition>"` first. If it e
 6. **No harness file mutation.** Hooks must not modify `.claude/settings.json`, `batch.yaml`, `case_order.yaml`, or other harness-managed files. They may freely create, extract, or modify other files in the workspace.
 7. **Timeout enforcement.** Hooks are killed (SIGTERM, then SIGKILL after 5s) if they exceed `timeout`. Timed-out hooks are treated as failures.
 
+### Security
+
+1. **Trust model.** Hooks in `eval.yaml` are trusted developer input — the same trust level as the `skill` field or judge definitions. The harness does not sandbox or restrict hook commands. Untrusted third parties should not be able to modify `eval.yaml` or dataset case directories.
+2. **Privilege level.** Hooks run with the full permissions of the harness process. There is no privilege separation between hooks and the rest of the pipeline.
+3. **Path validation.** Hook log filenames are sanitized to prevent path traversal (CWE-22). `case_id` values used in log paths are restricted to alphanumeric characters, dots, hyphens, and underscores.
+4. **Data flow risks.** Hooks that execute commands against external systems (databases, APIs) using dataset files (e.g., `psql < seed.sql`) assume those files are trusted. If datasets are sourced from untrusted origins, hook authors should validate inputs or use parameterized tooling rather than passing raw files to interpreters.
+
 ### Implementation
 
 Changes are localized to three files:
@@ -273,6 +280,8 @@ hooks:
       on_failure: continue
       description: "Tear down services"
 ```
+
+> **Note:** Database seeding from case files (`seed.sql`) assumes the dataset is trusted. If datasets are sourced externally, validate SQL files or use a parameterized seeding script rather than raw `psql`.
 
 ### Network Shims (PATH Manipulation)
 

--- a/specs/006-execution-hooks/spec.md
+++ b/specs/006-execution-hooks/spec.md
@@ -118,7 +118,12 @@ Hooks inherit the caller's full environment plus harness-injected variables:
 | `CASE_SOURCE_DIR` | per-case hooks | Absolute path to the original case directory in the dataset |
 | `CASE_INPUT` | per-case hooks | Absolute path to `input.yaml` in the case workspace |
 
-`CASE_SOURCE_DIR` is the key variable — it gives hooks access to files in the dataset case directory (like `snapshot.tar.gz`, `fixtures/`, test data) that workspace.py deliberately does not copy into the case workspace to avoid leaking annotations and gold standards to the skill.
+`CASE_SOURCE_DIR` is the key variable — it gives hooks access to files in the dataset case directory (like `snapshot.tar.gz`, `fixtures/`, test data). Static case files can also be copied declaratively via `dataset.workspace.files` (added in #70), which whitelists specific files for workspace provisioning. The two mechanisms are complementary:
+
+- **`dataset.workspace.files`** — declarative copy of static case files into the workspace during setup.
+- **`before_each` + `CASE_SOURCE_DIR`** — the imperative escape hatch for what a static copy can't do: extracting archives, seeding databases, pulling volumes, or any computed/dynamic provisioning.
+
+Per-case env vars (`CASE_ID`, `CASE_WORKSPACE`, `CASE_SOURCE_DIR`, `CASE_INPUT`) are only available in case/prompt execution modes. In batch mode, only `before_all`, `before_scoring`, and `after_all` hooks run; `before_each`/`after_each` are not executed.
 
 Variables from `execution.env` are also available, resolved the same way as during skill execution (`$VAR` references resolved from the caller's environment).
 

--- a/specs/006-execution-hooks/spec.md
+++ b/specs/006-execution-hooks/spec.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented
+Proposed
 
 ## Problem
 

--- a/specs/006-execution-hooks/spec.md
+++ b/specs/006-execution-hooks/spec.md
@@ -2,18 +2,18 @@
 
 ## Status
 
-Proposed
+Implemented
 
 ## Problem
 
-Eval cases often depend on resources that the harness doesn't manage today — compressed archives, running services, generated fixtures, OCI image volumes, seed data, network shims. Users work around this with manual scripts and env vars external to the harness:
+Eval cases often depend on resources that the harness doesn't manage today — running services, database seeding, generated fixtures, environment provisioning, or pre-/post-processing steps. Users work around this with manual scripts and env vars external to the harness:
 
 ```bash
 # Current workaround — external to the harness, fragile, not reproducible
-export EVAL_SNAPSHOT_DIR=$(./evals/scripts/extract-snapshots.sh 5.0.0-0.nightly-...)
-docker run -d --name eval-jira -p 8080:8080 quay.io/stbenjam/jira-emulator:latest
-/eval-run --config eval-payload-analysis.yaml --model sonnet
-docker rm -f eval-jira
+docker run -d --name eval-db -p 5432:5432 postgres:16
+psql -h localhost -U eval -f seed.sql eval_db
+/eval-run --config eval.yaml --model sonnet
+docker rm -f eval-db
 ```
 
 This has several problems:

--- a/specs/006-execution-hooks/spec.md
+++ b/specs/006-execution-hooks/spec.md
@@ -351,6 +351,10 @@ hooks:
 
 No breaking changes. `hooks:` is a new optional top-level key in eval.yaml. Existing configs without it behave identically. The eval-run skill instructions would add hook execution calls at each lifecycle point, and `preflight.py` would validate hook commands are syntactically valid.
 
+## Open Questions
+
+**Per-case hook overrides.** Should individual cases be able to define their own `before_each`/`after_each` hooks (e.g., via a `hooks.yaml` in the case directory)? Currently, per-case variation is handled by the `condition` field and `CASE_SOURCE_DIR` — hooks run or skip based on what files exist in the case directory. This covers the common pattern ("extract if snapshot exists", "seed if SQL present") but requires the eval author to anticipate all variations upfront in eval.yaml. Per-case hooks would let cases bring their own setup without touching the global config, at the cost of another file to discover/validate and harder reasoning about what runs for a given case. Deferred for now — revisit if the conditional approach proves insufficient.
+
 ## Future Extensions
 
 - **Hook outputs as judge inputs**: `before_scoring` hooks could write structured data that judges receive via a new `{{ hook_outputs }}` template variable.

--- a/specs/006-execution-hooks/spec.md
+++ b/specs/006-execution-hooks/spec.md
@@ -1,0 +1,359 @@
+# 0006: Execution Hooks
+
+## Status
+
+Proposed
+
+## Problem
+
+Eval cases often depend on resources that the harness doesn't manage today — compressed archives, running services, generated fixtures, OCI image volumes, seed data, network shims. Users work around this with manual scripts and env vars external to the harness:
+
+```bash
+# Current workaround — external to the harness, fragile, not reproducible
+export EVAL_SNAPSHOT_DIR=$(./evals/scripts/extract-snapshots.sh 5.0.0-0.nightly-...)
+docker run -d --name eval-jira -p 8080:8080 quay.io/stbenjam/jira-emulator:latest
+/eval-run --config eval-payload-analysis.yaml --model sonnet
+docker rm -f eval-jira
+```
+
+This has several problems:
+- **Not reproducible** — setup steps live in tribal knowledge or READMEs, not in the eval config
+- **Not validated** — the harness can't check that prerequisites are met before execution
+- **Not cleaned up** — leaked temp files and orphaned containers accumulate
+- **Not reported** — setup failures are invisible; the user sees a confusing skill failure instead
+
+## Scope
+
+Add **lifecycle hooks** to `eval.yaml` — user-defined shell commands that run at well-defined points in the eval pipeline. Does **not** change the runner contract, judge interface, or workspace layout.
+
+## Design
+
+### Hook Points
+
+Six hook points spanning the full eval lifecycle, using conventional test-framework naming:
+
+```
+before_all
+ ├─ before_each (case 1)
+ │   └─ [skill execution]
+ │   └─ after_each (case 1)
+ ├─ before_each (case 2)
+ │   └─ [skill execution]
+ │   └─ after_each (case 2)
+ ├─ [collection]
+ ├─ before_scoring
+ │   └─ [judge scoring]
+ └─ after_all
+```
+
+| Hook | Runs | CWD | When | Use Case |
+|------|------|-----|------|----------|
+| `before_all` | Once | Project root | After workspace creation, before any case executes | Start services, extract shared archives, populate shared caches, pull OCI volumes |
+| `before_each` | Per case | Case workspace | After case workspace setup, before skill execution | Extract per-case archives, seed case-specific state, configure case-specific services |
+| `after_each` | Per case | Case workspace | After skill execution, before collection | Normalize outputs, capture ephemeral state (container logs, DB snapshots), clean up temp files |
+| `before_scoring` | Once | Project root | After collection, before judge scoring | Aggregate cross-case data, start services needed by judges, prepare scoring context |
+| `after_all` | Once | Project root | After scoring completes (or on failure) | Stop services, clean temp dirs, upload results, send notifications |
+
+`after_all` is **guaranteed to run** even if earlier steps fail — it is a finally block for cleanup. All other hooks abort the run on failure (unless `on_failure: continue`).
+
+### eval.yaml Schema
+
+```yaml
+hooks:
+  before_all:
+    - command: "scripts/start-services.sh"
+      timeout: 120
+      description: "Start Jira emulator and seed database"
+    - command: "scripts/extract-shared-archives.sh $AGENT_EVAL_WORKSPACE"
+      timeout: 60
+
+  before_each:
+    - command: |
+        archive="$CASE_SOURCE_DIR/snapshot.tar.gz"
+        [ -f "$archive" ] && tar xzf "$archive" -C .
+      timeout: 60
+      description: "Extract case snapshot"
+
+  after_each:
+    - command: "docker logs eval-jira > jira-debug.log 2>&1 || true"
+      timeout: 15
+      on_failure: continue
+
+  before_scoring:
+    - command: "python3 scripts/aggregate-cross-case-data.py --workspace $AGENT_EVAL_WORKSPACE"
+      timeout: 30
+
+  after_all:
+    - command: "scripts/teardown-services.sh"
+      timeout: 30
+      on_failure: continue
+      description: "Stop services and clean up"
+```
+
+Each hook entry:
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `command` | string | yes | — | Shell command (`bash -c`). Multi-line supported. |
+| `timeout` | int | no | 120 | Max seconds before the hook is killed |
+| `description` | string | no | — | Human-readable label for progress output |
+| `on_failure` | enum | no | `fail` | `fail` aborts the run, `continue` logs a warning and proceeds |
+| `condition` | string | no | — | Shell expression; hook runs only if this exits 0 (see Conditional Hooks) |
+
+Hooks within a phase run sequentially in declaration order. A failing hook (with `on_failure: fail`) skips remaining hooks in that phase and aborts.
+
+### Environment Variables
+
+Hooks inherit the caller's full environment plus harness-injected variables:
+
+| Variable | Available In | Value |
+|----------|-------------|-------|
+| `AGENT_EVAL_WORKSPACE` | all | Root workspace path (`/tmp/agent-eval/{run-id}`) |
+| `AGENT_EVAL_RUN_ID` | all | Current run ID (e.g., `2026-05-31-sonnet`) |
+| `AGENT_EVAL_CONFIG` | all | Absolute path to eval.yaml |
+| `AGENT_EVAL_PROJECT_ROOT` | all | Project root directory |
+| `AGENT_EVAL_MODEL` | all | Skill model being tested (e.g., `sonnet`) |
+| `CASE_ID` | per-case hooks | Case ID (e.g., `case-001-name`) |
+| `CASE_WORKSPACE` | per-case hooks | Absolute path to case workspace directory |
+| `CASE_SOURCE_DIR` | per-case hooks | Absolute path to the original case directory in the dataset |
+| `CASE_INPUT` | per-case hooks | Absolute path to `input.yaml` in the case workspace |
+
+`CASE_SOURCE_DIR` is the key variable — it gives hooks access to files in the dataset case directory (like `snapshot.tar.gz`, `fixtures/`, test data) that workspace.py deliberately does not copy into the case workspace to avoid leaking annotations and gold standards to the skill.
+
+Variables from `execution.env` are also available, resolved the same way as during skill execution (`$VAR` references resolved from the caller's environment).
+
+### Conditional Hooks
+
+The `condition` field enables hooks that only run when relevant:
+
+```yaml
+hooks:
+  before_each:
+    # Only extract if the case has a snapshot archive
+    - command: "tar xzf $CASE_SOURCE_DIR/snapshot.tar.gz -C ."
+      condition: "test -f $CASE_SOURCE_DIR/snapshot.tar.gz"
+      description: "Extract snapshot (if present)"
+
+    # Only seed the database if the case has seed data
+    - command: "psql < $CASE_SOURCE_DIR/seed.sql"
+      condition: "test -f $CASE_SOURCE_DIR/seed.sql"
+
+  before_all:
+    # Only start Docker services if Docker is available
+    - command: "docker compose -f eval-services.yaml up -d"
+      condition: "command -v docker"
+      description: "Start eval services"
+```
+
+When `condition` is set, the harness runs `bash -c "<condition>"` first. If it exits non-zero, the hook is silently skipped (not treated as a failure). This avoids needing `[ -f ... ] && ...` guards inside every command.
+
+### Execution Contract
+
+1. **Hooks run in the harness process**, not inside Claude Code. They are ordinary shell commands with no access to the skill's Claude session.
+2. **Hooks are blocking.** The pipeline waits for each hook to finish before proceeding to the next step.
+3. **Stdout/stderr are captured** to `{run_dir}/hooks/{hook_name}[.{case_id}].log`. Hooks should not assume an interactive terminal.
+4. **`on_failure: fail`** (default) aborts the run. `on_failure: continue` logs a warning and proceeds. `after_all` always uses `continue` semantics internally (guaranteed cleanup).
+5. **Parallelism**: When `execution.parallelism > 1`, `before_each` and `after_each` hooks run in the case's thread — concurrent with other cases' hooks. Hooks must be safe for concurrent execution. Shared resources (ports, containers, databases) should be managed in `before_all`/`after_all` (which are single-threaded), not in per-case hooks.
+6. **No harness file mutation.** Hooks must not modify `.claude/settings.json`, `batch.yaml`, `case_order.yaml`, or other harness-managed files. They may freely create, extract, or modify other files in the workspace.
+7. **Timeout enforcement.** Hooks are killed (SIGTERM, then SIGKILL after 5s) if they exceed `timeout`. Timed-out hooks are treated as failures.
+
+### Implementation
+
+Changes are localized to three files:
+
+**`agent_eval/config.py`** — Add hook dataclasses to the config schema:
+
+```python
+@dataclass
+class HookEntry:
+    command: str
+    timeout: int = 120
+    description: str = ""
+    on_failure: str = "fail"  # "fail" | "continue"
+    condition: str = ""
+
+@dataclass
+class HooksConfig:
+    before_all: list[HookEntry] = field(default_factory=list)
+    before_each: list[HookEntry] = field(default_factory=list)
+    after_each: list[HookEntry] = field(default_factory=list)
+    before_scoring: list[HookEntry] = field(default_factory=list)
+    after_all: list[HookEntry] = field(default_factory=list)
+```
+
+**`agent_eval/hooks.py`** (new) — Hook executor:
+
+```python
+def run_hooks(
+    entries: list[HookEntry],
+    env: dict[str, str],
+    cwd: Path,
+    log_dir: Path,
+    phase_name: str,
+    case_id: str | None = None,
+) -> list[HookResult]:
+    """Run hooks sequentially. Returns results. Raises on failure if on_failure=fail."""
+```
+
+**`skills/eval-run/scripts/execute.py`** — Import `run_hooks` and call at each lifecycle point. Wire `after_all` into a `try/finally` around the main execution loop.
+
+### Interaction with Existing Features
+
+**Tool interception (`inputs.tools`)**: Hooks and tool interception are orthogonal. Hooks prepare the environment; tool interception controls what the skill can do during execution. A common pattern is `before_all` starts a service, `inputs.tools` intercepts the skill's HTTP calls to that service.
+
+**`execution.env`**: Hook-injected env vars are available to hooks via the standard environment. Hooks cannot inject new env vars into the skill's session (that would require modifying `.claude/settings.json`, which is prohibited). Use `execution.env` for skill-visible variables.
+
+**Workspace symlinks**: Hooks run after workspace setup, so project symlinks are already in place. Hooks can rely on symlinked resources (e.g., `scripts/` symlink) being available.
+
+## Examples
+
+### Compressed Artifacts (Motivating Case)
+
+A payload analysis eval stores snapshot data as tar.gz to keep git lean:
+
+```yaml
+hooks:
+  before_each:
+    - command: |
+        mkdir -p snapshot
+        tar xzf "$CASE_SOURCE_DIR/snapshot.tar.gz" -C snapshot
+      condition: "test -f $CASE_SOURCE_DIR/snapshot.tar.gz"
+      timeout: 60
+      description: "Extract payload snapshot"
+
+execution:
+  arguments: "{payload_tag} --snapshot-dir snapshot"
+```
+
+### OCI Image Volumes
+
+Eval data stored as OCI images on a registry:
+
+```yaml
+hooks:
+  before_all:
+    - command: |
+        mkdir -p "$AGENT_EVAL_WORKSPACE/archives"
+        skopeo copy docker://quay.io/org/eval-data:latest \
+          dir:"$AGENT_EVAL_WORKSPACE/archives"
+      timeout: 300
+      description: "Pull eval data from registry"
+
+execution:
+  env:
+    EVAL_ARCHIVES_DIR: $AGENT_EVAL_WORKSPACE/archives
+```
+
+### Service Lifecycle (Database + Emulator)
+
+```yaml
+hooks:
+  before_all:
+    - command: |
+        docker compose -f evals/services.yaml up -d
+        timeout 30 bash -c 'until curl -sf localhost:8080/health; do sleep 1; done'
+      timeout: 60
+      description: "Start Jira emulator and Postgres"
+
+  before_each:
+    - command: "psql -h localhost -U eval -f $CASE_SOURCE_DIR/seed.sql eval_db"
+      condition: "test -f $CASE_SOURCE_DIR/seed.sql"
+      timeout: 15
+      description: "Seed database for case"
+
+  after_each:
+    - command: "psql -h localhost -U eval -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;' eval_db"
+      timeout: 10
+      on_failure: continue
+      description: "Reset database between cases"
+
+  after_all:
+    - command: "docker compose -f evals/services.yaml down -v"
+      timeout: 30
+      on_failure: continue
+      description: "Tear down services"
+```
+
+### Network Shims (PATH Manipulation)
+
+Replace real CLI tools with shims that serve from local archives:
+
+```yaml
+hooks:
+  before_each:
+    - command: |
+        mkdir -p .shims
+        cp "$AGENT_EVAL_PROJECT_ROOT/evals/shims/"* .shims/
+        chmod +x .shims/*
+        # Prepend shims to PATH in the skill's env
+        echo "PATH=.shims:$PATH" >> .env.local
+      timeout: 10
+      description: "Install CLI shims for hermetic execution"
+```
+
+### Generated Fixtures
+
+Derive test inputs from a template + case-specific parameters:
+
+```yaml
+hooks:
+  before_each:
+    - command: |
+        python3 "$AGENT_EVAL_PROJECT_ROOT/evals/scripts/render-fixture.py" \
+          --template "$AGENT_EVAL_PROJECT_ROOT/evals/templates/cluster.yaml.j2" \
+          --params input.yaml \
+          --output cluster-state.yaml
+      timeout: 30
+      description: "Generate cluster fixture from template"
+```
+
+### Cross-Case Aggregation Before Scoring
+
+Compute derived data that judges need but that spans multiple cases:
+
+```yaml
+hooks:
+  before_scoring:
+    - command: |
+        python3 scripts/compute-cross-case-baselines.py \
+          --workspace "$AGENT_EVAL_WORKSPACE" \
+          --output "$AGENT_EVAL_WORKSPACE/cross-case-stats.json"
+      timeout: 30
+      description: "Compute cross-case statistics for judges"
+```
+
+### Notification on Completion
+
+```yaml
+hooks:
+  after_all:
+    - command: |
+        python3 scripts/notify-slack.py \
+          --channel "#eval-results" \
+          --run-id "$AGENT_EVAL_RUN_ID" \
+          --model "$AGENT_EVAL_MODEL"
+      timeout: 15
+      on_failure: continue
+      description: "Post results to Slack"
+```
+
+## Alternatives Considered
+
+**Wrapper scripts around `/eval-run`.** Works today but the harness can't validate, reproduce, report on, or clean up after external setup steps. Hooks inside eval.yaml are declarative, version-controlled, and visible in the run report.
+
+**Extending workspace.py to copy all case files.** Rejected — the workspace deliberately excludes annotations and gold standards to prevent leaking expected outcomes to the skill. A blanket copy would require an exclusion mechanism. Hooks let the case author choose exactly what to extract, with `CASE_SOURCE_DIR` providing controlled access.
+
+**`inputs.files` schema field.** A static list of extra files to copy from the case directory. Handles the simple case but can't extract archives, start services, generate fixtures, or run arbitrary setup. Hooks are strictly more capable with minimal additional complexity.
+
+**Makefile / CI-level setup.** Moves setup out of the eval config into CI pipeline definitions. Fragments the eval specification across multiple files and systems. Hooks keep everything in eval.yaml.
+
+## Migration
+
+No breaking changes. `hooks:` is a new optional top-level key in eval.yaml. Existing configs without it behave identically. The eval-run skill instructions would add hook execution calls at each lifecycle point, and `preflight.py` would validate hook commands are syntactically valid.
+
+## Future Extensions
+
+- **Hook outputs as judge inputs**: `before_scoring` hooks could write structured data that judges receive via a new `{{ hook_outputs }}` template variable.
+- **Built-in hook library**: Common patterns (archive extraction, Docker lifecycle, DB reset) could become named builtins: `- builtin: extract-archives` instead of inline shell.
+- **Dry-run mode**: `--dry-run` flag that prints hook commands without executing, for debugging eval configs.
+- **Hook metrics**: Capture duration and exit code per hook, surface in the HTML report alongside judge results.

--- a/specs/006-execution-hooks/spec.md
+++ b/specs/006-execution-hooks/spec.md
@@ -30,19 +30,19 @@ Add **lifecycle hooks** to `eval.yaml` — user-defined shell commands that run 
 
 ### Hook Points
 
-Six hook points spanning the full eval lifecycle, using conventional test-framework naming:
+Five hook points spanning the full eval lifecycle, using conventional test-framework naming:
 
 ```
-before_all
- ├─ before_each (case 1)
- │   └─ [skill execution]
+before_all ──→ collect .hook-outputs.yaml (global env/data)
+ ├─ before_each (case 1) ──→ collect .hook-outputs.yaml (case env/data)
+ │   └─ [skill execution]  ← merged env injected here
  │   └─ after_each (case 1)
- ├─ before_each (case 2)
- │   └─ [skill execution]
+ ├─ before_each (case 2) ──→ collect .hook-outputs.yaml (case env/data)
+ │   └─ [skill execution]  ← merged env injected here
  │   └─ after_each (case 2)
  ├─ [collection]
- ├─ before_scoring
- │   └─ [judge scoring]
+ ├─ before_scoring ──→ collect .hook-outputs.yaml (scoring data)
+ │   └─ [judge scoring]  ← hook_outputs in record dict
  └─ after_all
 ```
 
@@ -147,6 +147,111 @@ hooks:
 
 When `condition` is set, the harness runs `bash -c "<condition>"` first. If it exits non-zero, the hook is silently skipped (not treated as a failure). This avoids needing `[ -f ... ] && ...` guards inside every command.
 
+### Hook Outputs
+
+Hooks are fire-and-forget by default — they modify the filesystem but can't feed state back into the pipeline. This is insufficient when setup hooks provision dynamic resources (ephemeral repos, service URLs, temporary API keys) that the skill needs at execution time.
+
+#### The problem
+
+Consider a functional test that creates ephemeral GitHub fixtures before each case:
+
+```bash
+# before_each hook creates a repo and issue, but the skill needs the URL
+gh repo create org/eval-repo-abc123 --private
+gh issue create --repo org/eval-repo-abc123 --title "Test issue"
+# How does GITHUB_ISSUE_URL=https://github.com/org/eval-repo-abc123/issues/1
+# reach the skill's environment?
+```
+
+Today there is no channel for this. The hook runs, the skill runs, but dynamic state can't flow between them.
+
+#### Solution: `.hook-outputs.yaml`
+
+After each hook phase completes, the harness checks for a `.hook-outputs.yaml` file in the hook's working directory:
+
+- **Per-case hooks** (`before_each`, `after_each`): `$CASE_WORKSPACE/.hook-outputs.yaml`
+- **Global hooks** (`before_all`, `before_scoring`): `$AGENT_EVAL_WORKSPACE/.hook-outputs.yaml`
+
+If present, the harness parses it as YAML and processes two well-known top-level keys:
+
+| Key | Type | Effect |
+|-----|------|--------|
+| `env` | `dict[str, str]` | Merged into the skill runner's environment before execution. For Claude Code, injected into `.claude/settings.json` env block. For CLI runners, merged into the subprocess env dict. |
+| `data` | `dict[str, any]` | Carried as `outputs["hook_outputs"]` in the record dict passed to judges. Supports arbitrary structured data. |
+
+All other top-level keys are ignored (reserved for future use).
+
+#### File format
+
+```yaml
+# $CASE_WORKSPACE/.hook-outputs.yaml
+env:
+  GITHUB_ISSUE_URL: https://github.com/org/eval-repo-abc123/issues/1
+  EPHEMERAL_REPO: org/eval-repo-abc123
+data:
+  fixture_created_at: "2026-06-01T12:00:00Z"
+  issue_number: 1
+```
+
+#### Merge semantics
+
+- **`env` merging**: Hook-output env vars are merged *after* `execution.env` resolution but *before* skill execution. Hook outputs take precedence over `execution.env` for the same key — this is intentional, since hooks run later and may override static config with dynamic values.
+- **`before_all` + `before_each`**: Both can write `.hook-outputs.yaml`. Per-case outputs are merged on top of global outputs, so a case-level var overrides a global one with the same name.
+- **`data` merging**: Same precedence — per-case `data` merges on top of global `data`. Judges receive the merged dict as `outputs["hook_outputs"]`.
+- **Forward propagation**: Hook-output env vars are available to subsequent hooks in the same case. After `before_each` outputs are collected, the merged env is used for both the skill execution *and* the `after_each` hooks. This lets teardown hooks reference dynamic values set during setup (e.g., `$EPHEMERAL_REPO`).
+- **File lifecycle**: The harness reads and deletes `.hook-outputs.yaml` after processing to prevent stale outputs from leaking across cases. Hooks must write the file fresh each time.
+
+#### Writing from bash
+
+For simple env-only cases, a one-liner suffices:
+
+```bash
+printf 'env:\n  GITHUB_ISSUE_URL: %s\n' "$url" > "$CASE_WORKSPACE/.hook-outputs.yaml"
+```
+
+For hooks written in Python or other languages, write YAML or JSON (the harness accepts both `.hook-outputs.yaml` and `.hook-outputs.json`):
+
+```python
+import json
+from pathlib import Path
+
+outputs = {
+    "env": {"SERVICE_URL": f"http://localhost:{port}"},
+    "data": {"port": port, "container_id": container_id},
+}
+Path(".hook-outputs.yaml").write_text(json.dumps(outputs))
+```
+
+#### Implementation
+
+After `run_hooks()` returns, the harness calls a new `collect_hook_outputs(cwd)` function:
+
+```python
+def collect_hook_outputs(cwd: Path) -> dict:
+    """Read and remove .hook-outputs.yaml from cwd. Returns parsed dict or {}."""
+    for name in (".hook-outputs.yaml", ".hook-outputs.json"):
+        path = cwd / name
+        if path.exists():
+            content = yaml.safe_load(path.read_text()) or {}
+            path.unlink()
+            return content
+    return {}
+```
+
+In `execute.py`, the flow becomes:
+
+1. Run `before_all` hooks → `collect_hook_outputs($AGENT_EVAL_WORKSPACE)` → store global outputs
+2. For each case:
+   a. Run `before_each` hooks → `collect_hook_outputs($CASE_WORKSPACE)` → merge with global outputs
+   b. Inject merged `env` into runner environment
+   c. Execute skill
+   d. Run `after_each` hooks
+3. During scoring, pass merged `data` as `outputs["hook_outputs"]` to judges
+
+#### Security considerations
+
+Hook outputs are trusted at the same level as hooks themselves (see Security section). The harness does not validate or sanitize values in `.hook-outputs.yaml` — they flow directly into the runner environment and judge inputs. This is consistent with the trust model: if you can write eval.yaml hooks, you can already execute arbitrary commands.
+
 ### Execution Contract
 
 1. **Hooks run in the harness process**, not inside Claude Code. They are ordinary shell commands with no access to the skill's Claude session.
@@ -154,7 +259,7 @@ When `condition` is set, the harness runs `bash -c "<condition>"` first. If it e
 3. **Stdout/stderr are captured** to `{run_dir}/hooks/{hook_name}[.{case_id}].log`. Hooks should not assume an interactive terminal.
 4. **`on_failure: fail`** (default) aborts the run. `on_failure: continue` logs a warning and proceeds. `after_all` always uses `continue` semantics internally (guaranteed cleanup).
 5. **Parallelism**: When `execution.parallelism > 1`, `before_each` and `after_each` hooks run in the case's thread — concurrent with other cases' hooks. Hooks must be safe for concurrent execution. Shared resources (ports, containers, databases) should be managed in `before_all`/`after_all` (which are single-threaded), not in per-case hooks.
-6. **No harness file mutation.** Hooks must not modify `.claude/settings.json`, `batch.yaml`, `case_order.yaml`, or other harness-managed files. They may freely create, extract, or modify other files in the workspace.
+6. **No harness file mutation.** Hooks must not modify `.claude/settings.json`, `batch.yaml`, `case_order.yaml`, or other harness-managed files. They may freely create, extract, or modify other files in the workspace. The one exception is `.hook-outputs.yaml` — hooks write this file to pass state forward, and the harness reads and deletes it after each phase (see Hook Outputs).
 7. **Timeout enforcement.** Hooks are killed (SIGTERM, then SIGKILL after 5s) if they exceed `timeout`. Timed-out hooks are treated as failures.
 
 ### Security
@@ -208,7 +313,7 @@ def run_hooks(
 
 **Tool interception (`inputs.tools`)**: Hooks and tool interception are orthogonal. Hooks prepare the environment; tool interception controls what the skill can do during execution. A common pattern is `before_all` starts a service, `inputs.tools` intercepts the skill's HTTP calls to that service.
 
-**`execution.env`**: Hook-injected env vars are available to hooks via the standard environment. Hooks cannot inject new env vars into the skill's session (that would require modifying `.claude/settings.json`, which is prohibited). Use `execution.env` for skill-visible variables.
+**`execution.env`**: Hook-injected env vars are available to hooks via the standard environment. Hooks can also inject *new* env vars into the skill's session by writing `.hook-outputs.yaml` with an `env:` block (see Hook Outputs). This is the intended mechanism for dynamic values that aren't known at eval.yaml authoring time. Use `execution.env` for static values and hook outputs for dynamic ones — hook outputs take precedence when both define the same key.
 
 **Workspace symlinks**: Hooks run after workspace setup, so project symlinks are already in place. Hooks can rely on symlinked resources (e.g., `scripts/` symlink) being available.
 
@@ -283,6 +388,44 @@ hooks:
 
 > **Note:** Database seeding from case files (`seed.sql`) assumes the dataset is trusted. If datasets are sourced externally, validate SQL files or use a parameterized seeding script rather than raw `psql`.
 
+### Ephemeral Fixtures with Dynamic State
+
+Functional tests that create disposable external resources (repos, issues, API keys) and feed the resulting identifiers into the skill:
+
+```yaml
+hooks:
+  before_each:
+    - command: |
+        # Create ephemeral GitHub fixtures for this case
+        repo=$(scripts/create-ephemeral-repo.sh "$CASE_ID")
+        issue_url=$(gh issue create --repo "$repo" \
+          --title "$(yq '.title' input.yaml)" --body "$(yq '.body' input.yaml)" \
+          | tail -1)
+
+        # Pass dynamic state forward to the skill via hook outputs
+        printf 'env:\n  GITHUB_ISSUE_URL: %s\n  EPHEMERAL_REPO: %s\n' \
+          "$issue_url" "$repo" > "$CASE_WORKSPACE/.hook-outputs.yaml"
+      timeout: 60
+      description: "Create ephemeral repo and fixtures"
+
+  after_each:
+    - command: "scripts/capture-fixture-state.sh $CASE_WORKSPACE"
+      timeout: 15
+      description: "Capture fixture state for judges"
+    - command: |
+        # EPHEMERAL_REPO is available because the harness injected it
+        # from .hook-outputs.yaml into the environment
+        [ -n "$EPHEMERAL_REPO" ] && gh repo delete "$EPHEMERAL_REPO" --yes
+      timeout: 30
+      on_failure: continue
+      description: "Delete ephemeral repo"
+
+execution:
+  arguments: "--issue-url $GITHUB_ISSUE_URL"
+```
+
+The `before_each` hook creates the fixture and writes `.hook-outputs.yaml`. The harness reads the `env:` block and injects `GITHUB_ISSUE_URL` into the skill's environment before execution. The `after_each` hook tears down the fixture. No custom runner script needed.
+
 ### Network Shims (PATH Manipulation)
 
 Replace real CLI tools with shims that serve from local archives:
@@ -294,8 +437,9 @@ hooks:
         mkdir -p .shims
         cp "$AGENT_EVAL_PROJECT_ROOT/evals/shims/"* .shims/
         chmod +x .shims/*
-        # Prepend shims to PATH in the skill's env
-        echo "PATH=.shims:$PATH" >> .env.local
+        # Prepend shims to PATH via hook outputs
+        printf 'env:\n  PATH: .shims:%s\n' "$PATH" \
+          > "$CASE_WORKSPACE/.hook-outputs.yaml"
       timeout: 10
       description: "Install CLI shims for hermetic execution"
 ```
@@ -356,6 +500,8 @@ hooks:
 
 **Makefile / CI-level setup.** Moves setup out of the eval config into CI pipeline definitions. Fragments the eval specification across multiple files and systems. Hooks keep everything in eval.yaml.
 
+**`.hook-env` dotenv file for hook outputs.** Hooks write `KEY=VALUE` lines to a `.hook-env` file that the harness parses and injects into the runner environment. Simpler for trivial cases (`echo "URL=..." >> .hook-env`) but fragile for real-world use — quoting, multiline values, comments, and escaping all become parsing hazards. The YAML approach (`.hook-outputs.yaml`) handles these naturally, supports structured `data` for judges alongside `env` for the runner, and is consistent with the project's existing use of YAML everywhere.
+
 ## Migration
 
 No breaking changes. `hooks:` is a new optional top-level key in eval.yaml. Existing configs without it behave identically. The eval-run skill instructions would add hook execution calls at each lifecycle point, and `preflight.py` would validate hook commands are syntactically valid.
@@ -366,7 +512,7 @@ No breaking changes. `hooks:` is a new optional top-level key in eval.yaml. Exis
 
 ## Future Extensions
 
-- **Hook outputs as judge inputs**: `before_scoring` hooks could write structured data that judges receive via a new `{{ hook_outputs }}` template variable.
+- **`{{ hook_outputs }}` template variable in judge prompts**: Hook outputs are available as `outputs["hook_outputs"]` in the record dict. A future enhancement could expose them directly in Jinja2 judge prompts via `{{ hook_outputs }}` for more ergonomic access.
 - **Built-in hook library**: Common patterns (archive extraction, Docker lifecycle, DB reset) could become named builtins: `- builtin: extract-archives` instead of inline shell.
 - **Dry-run mode**: `--dry-run` flag that prints hook commands without executing, for debugging eval configs.
 - **Hook metrics**: Capture duration and exit code per hook, surface in the HTML report alongside judge results.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -239,3 +239,41 @@ dataset:
 """, name="eval/my-eval/eval.yaml"))
     resolved = cfg.resolve_path(cfg.dataset.path)
     assert resolved == abs_path
+
+
+def test_batch_mode_warns_on_per_case_hooks(tmp_path):
+    """Per-case hooks in batch mode emit a warning at config load time."""
+    import warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+skill: s
+execution:
+  mode: batch
+hooks:
+  before_each:
+    - command: "echo setup"
+  after_each:
+    - command: "echo cleanup"
+"""))
+    assert len(w) == 1
+    assert "before_each, after_each" in str(w[0].message)
+    assert "batch mode" in str(w[0].message)
+
+
+def test_case_mode_no_warning_on_per_case_hooks(tmp_path):
+    """Per-case hooks in case mode do not emit a warning."""
+    import warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+skill: s
+execution:
+  mode: case
+hooks:
+  before_each:
+    - command: "echo setup"
+"""))
+    assert len(w) == 0

--- a/tests/test_hook_outputs.py
+++ b/tests/test_hook_outputs.py
@@ -18,9 +18,9 @@ _real_execv = os.execv
 os.execv = lambda *a, **kw: None  # no-op during import
 
 from agent_eval.agent.base import RunResult
-from agent_eval.config import EvalConfig, HookEntry, HooksConfig
+from agent_eval.config import DatasetConfig, EvalConfig, HookEntry, HooksConfig
 from agent_eval.hooks import (
-    build_hook_env, collect_hook_outputs, inject_hook_env, run_hooks,
+    build_hook_env, collect_hook_outputs, run_hooks,
     save_hook_data,
 )
 from execute import _run_single_case
@@ -71,49 +71,6 @@ def test_hook_writes_outputs_json(tmp_path):
 
     outputs = collect_hook_outputs(case_ws)
     assert outputs["env"]["API_KEY"] == "test-key-123"
-
-
-# ---------------------------------------------------------------------------
-# inject_hook_env patches settings.json
-# ---------------------------------------------------------------------------
-
-def test_inject_hook_env_creates_settings(tmp_path):
-    """Hook env vars are written into .claude/settings.json."""
-    workspace = tmp_path / "workspace"
-    workspace.mkdir()
-
-    inject_hook_env(workspace, {"FIXTURE_URL": "https://example.com/1"})
-
-    settings_path = workspace / ".claude" / "settings.json"
-    assert settings_path.exists()
-    settings = json.loads(settings_path.read_text())
-    assert settings["env"]["FIXTURE_URL"] == "https://example.com/1"
-
-
-def test_inject_hook_env_merges_with_existing(tmp_path):
-    """Hook env vars merge into existing settings.json env block."""
-    workspace = tmp_path / "workspace"
-    settings_dir = workspace / ".claude"
-    settings_dir.mkdir(parents=True)
-    (settings_dir / "settings.json").write_text(
-        json.dumps({"env": {"EXISTING": "keep"}, "permissions": {"allow": []}}))
-
-    inject_hook_env(workspace, {"NEW_VAR": "added"})
-
-    settings = json.loads((settings_dir / "settings.json").read_text())
-    assert settings["env"]["EXISTING"] == "keep"
-    assert settings["env"]["NEW_VAR"] == "added"
-    assert settings["permissions"] == {"allow": []}
-
-
-def test_inject_hook_env_noop_when_empty(tmp_path):
-    """No settings.json created when env dict is empty."""
-    workspace = tmp_path / "workspace"
-    workspace.mkdir()
-
-    inject_hook_env(workspace, {})
-
-    assert not (workspace / ".claude" / "settings.json").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -170,11 +127,8 @@ def test_full_hook_outputs_flow(tmp_path):
     assert outputs["env"]["SERVICE_URL"] == "http://localhost:8080"
     assert outputs["data"]["container_id"] == "abc123"
 
-    # 3. Harness injects env into settings.json
-    inject_hook_env(case_ws, outputs.get("env"))
-    settings = json.loads(
-        (case_ws / ".claude" / "settings.json").read_text())
-    assert settings["env"]["SERVICE_URL"] == "http://localhost:8080"
+    # 3. Hook env is available for passing to runner via extra_env
+    assert outputs["env"]["SERVICE_URL"] == "http://localhost:8080"
 
     # 4. Harness saves data for judges
     save_hook_data(case_output, outputs.get("data"))
@@ -254,13 +208,14 @@ def _make_config(before_each=None, after_each=None, dataset_path=None):
         after_each=after_each or [],
     )
     if dataset_path:
-        config.dataset_path = str(dataset_path)
+        config.dataset = DatasetConfig(path=str(dataset_path))
+        config.config_dir = Path(dataset_path).parent
     return config
 
 
 def test_run_single_case_injects_hook_env(tmp_path):
-    """before_each hook writes .hook-outputs.yaml → env injected into
-    settings.json before runner.run_skill is called."""
+    """before_each hook writes .hook-outputs.yaml → env passed to runner
+    via extra_env parameter."""
     case_ws = tmp_path / "workspace" / "cases" / "case-001"
     case_ws.mkdir(parents=True)
     output_dir = tmp_path / "output"
@@ -298,16 +253,12 @@ def test_run_single_case_injects_hook_env(tmp_path):
     assert result is not None
     assert result["exit_code"] == 0
 
-    # Verify env was injected into settings.json
-    settings_path = case_ws / ".claude" / "settings.json"
-    assert settings_path.exists()
-    settings = json.loads(settings_path.read_text())
-    assert settings["env"]["ISSUE_URL"] == "https://github.com/org/repo/issues/1"
-
-    # Verify settings_path was passed to runner
+    # Verify extra_env was passed to runner.run_skill
     call_kwargs = runner.run_skill.call_args
-    assert call_kwargs.kwargs.get("settings_path") == settings_path or \
-        call_kwargs[1].get("settings_path") == settings_path
+    extra_env = call_kwargs.kwargs.get("extra_env") or (
+        call_kwargs[1].get("extra_env") if len(call_kwargs) > 1 else None)
+    assert extra_env is not None, "extra_env should be passed to run_skill"
+    assert extra_env.get("ISSUE_URL") == "https://github.com/org/repo/issues/1"
 
 
 def test_run_single_case_saves_hook_data(tmp_path):
@@ -426,19 +377,21 @@ def test_run_single_case_merges_global_and_case_outputs(tmp_path):
         "data": {"global_key": "global_val", "shared_key": "from_global"},
     }
 
+    runner = _make_mock_runner()
     _run_single_case(
-        _make_mock_runner(), "test-skill", "case-001", case_ws, output_dir,
+        runner, "test-skill", "case-001", case_ws, output_dir,
         "", "sonnet", None, None, None, 5.0, 600,
         1, 1, config=config, hook_env=hook_env,
         global_hook_outputs=global_hook_outputs,
     )
 
     # Check env: case overrides global for SHARED, both GLOBAL_VAR and CASE_VAR present
-    settings = json.loads(
-        (case_ws / ".claude" / "settings.json").read_text())
-    assert settings["env"]["GLOBAL_VAR"] == "from_global"
-    assert settings["env"]["CASE_VAR"] == "from_case"
-    assert settings["env"]["SHARED"] == "from_case"
+    call_kwargs = runner.run_skill.call_args
+    extra_env = call_kwargs.kwargs.get("extra_env") or (
+        call_kwargs[1].get("extra_env") if len(call_kwargs) > 1 else None)
+    assert extra_env["GLOBAL_VAR"] == "from_global"
+    assert extra_env["CASE_VAR"] == "from_case"
+    assert extra_env["SHARED"] == "from_case"
 
     # Check data: merged and available to judges
     case_output = output_dir / "cases" / "case-001"
@@ -536,28 +489,14 @@ def test_run_single_case_after_each_runs_on_before_each_failure(tmp_path):
 
 
 def test_cli_runner_receives_hook_output_env_vars(tmp_path):
-    """Hook output env vars injected via inject_hook_env flow into the CLI
-    runner's subprocess environment, not just settings.json."""
+    """Hook output env vars flow into the CLI runner via extra_env."""
     from agent_eval.agent.cli_runner import CliRunner
 
-    case_ws = tmp_path / "workspace" / "cases" / "case-001"
-    case_ws.mkdir(parents=True)
-
-    # Inject hook env vars (simulating what the harness does after before_each)
-    inject_hook_env(case_ws, {"FIXTURE_URL": "https://example.com/42"})
-
-    # Verify settings.json was written
-    settings_path = case_ws / ".claude" / "settings.json"
-    assert settings_path.exists()
-
-    # Create a CLI runner and run a command that echoes the env var
     runner = CliRunner(command="echo {agent}")
 
-    # The runner should pick up FIXTURE_URL from settings.json
-    # and pass it through to the subprocess environment
-    env = runner._build_env(settings_path=settings_path)
+    env = runner._build_env(extra_env={"FIXTURE_URL": "https://example.com/42"})
     assert env.get("FIXTURE_URL") == "https://example.com/42", \
-        "CLI runner _build_env() should read hook env vars from settings.json"
+        "CLI runner _build_env() should merge extra_env into subprocess env"
 
 
 def test_run_single_case_no_hooks_no_side_effects(tmp_path):

--- a/tests/test_hook_outputs.py
+++ b/tests/test_hook_outputs.py
@@ -448,6 +448,74 @@ def test_run_single_case_merges_global_and_case_outputs(tmp_path):
     assert record["hook_outputs"]["shared_key"] == "from_case"
 
 
+def test_run_single_case_after_each_runs_on_runner_exception(tmp_path):
+    """after_each hooks run even when runner.run_skill() raises an exception,
+    so cleanup hooks (e.g. deleting ephemeral repos) are guaranteed to fire."""
+    case_ws = tmp_path / "workspace" / "cases" / "case-001"
+    case_ws.mkdir(parents=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    dataset = tmp_path / "dataset"
+    (dataset / "case-001").mkdir(parents=True)
+
+    marker = tmp_path / "after_each_ran.txt"
+
+    config = _make_config(
+        after_each=[HookEntry(
+            command=f'echo cleanup > {marker}',
+        )],
+        dataset_path=dataset,
+    )
+    hook_env = build_hook_env(
+        workspace=str(tmp_path / "workspace"),
+        run_id="test-run",
+        config_path="eval.yaml",
+        project_root=str(Path.cwd()),
+        model="sonnet",
+    )
+
+    runner = _make_mock_runner()
+    runner.run_skill.side_effect = RuntimeError("unexpected crash")
+
+    case_id, result = _run_single_case(
+        runner, "test-skill", "case-001", case_ws, output_dir,
+        "", "sonnet", None, None, None, 5.0, 600,
+        1, 1, config=config, hook_env=hook_env,
+    )
+
+    # after_each must have run despite the exception
+    assert marker.exists(), "after_each hook did not run after runner exception"
+    assert marker.read_text().strip() == "cleanup"
+    # The case should report as failed
+    assert result is None or result["exit_code"] != 0
+
+
+def test_cli_runner_receives_hook_output_env_vars(tmp_path):
+    """Hook output env vars injected via inject_hook_env flow into the CLI
+    runner's subprocess environment, not just settings.json."""
+    from agent_eval.agent.cli_runner import CliRunner
+
+    case_ws = tmp_path / "workspace" / "cases" / "case-001"
+    case_ws.mkdir(parents=True)
+
+    # Inject hook env vars (simulating what the harness does after before_each)
+    inject_hook_env(case_ws, {"FIXTURE_URL": "https://example.com/42"})
+
+    # Verify settings.json was written
+    settings_path = case_ws / ".claude" / "settings.json"
+    assert settings_path.exists()
+
+    # Create a CLI runner and run a command that echoes the env var
+    runner = CliRunner(command="echo {agent}")
+
+    # The runner should pick up FIXTURE_URL from settings.json
+    # and pass it through to the subprocess environment
+    env = runner._build_env(settings_path=settings_path)
+    assert env.get("FIXTURE_URL") == "https://example.com/42", \
+        "CLI runner _build_env() should read hook env vars from settings.json"
+
+
 def test_run_single_case_no_hooks_no_side_effects(tmp_path):
     """Without hooks configured, no settings.json or hook_outputs.yaml created."""
     case_ws = tmp_path / "workspace" / "cases" / "case-001"

--- a/tests/test_hook_outputs.py
+++ b/tests/test_hook_outputs.py
@@ -491,6 +491,49 @@ def test_run_single_case_after_each_runs_on_runner_exception(tmp_path):
     assert result is None or result["exit_code"] != 0
 
 
+def test_run_single_case_after_each_runs_on_before_each_failure(tmp_path):
+    """after_each hooks run even when a before_each hook fails with
+    on_failure: fail, so resources created by earlier hooks get cleaned up."""
+    case_ws = tmp_path / "workspace" / "cases" / "case-001"
+    case_ws.mkdir(parents=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    dataset = tmp_path / "dataset"
+    (dataset / "case-001").mkdir(parents=True)
+
+    marker = tmp_path / "after_each_ran.txt"
+
+    config = _make_config(
+        before_each=[
+            HookEntry(command="echo setup-resource"),
+            HookEntry(command="exit 1", on_failure="fail"),
+        ],
+        after_each=[HookEntry(
+            command=f'echo cleanup > {marker}',
+        )],
+        dataset_path=dataset,
+    )
+    hook_env = build_hook_env(
+        workspace=str(tmp_path / "workspace"),
+        run_id="test-run",
+        config_path="eval.yaml",
+        project_root=str(Path.cwd()),
+        model="sonnet",
+    )
+
+    case_id, result = _run_single_case(
+        _make_mock_runner(), "test-skill", "case-001", case_ws, output_dir,
+        "", "sonnet", None, None, None, 5.0, 600,
+        1, 1, config=config, hook_env=hook_env,
+    )
+
+    # after_each must have run despite before_each failure
+    assert marker.exists(), "after_each hook did not run after before_each failure"
+    assert marker.read_text().strip() == "cleanup"
+    assert result is None
+
+
 def test_cli_runner_receives_hook_output_env_vars(tmp_path):
     """Hook output env vars injected via inject_hook_env flow into the CLI
     runner's subprocess environment, not just settings.json."""

--- a/tests/test_hook_outputs.py
+++ b/tests/test_hook_outputs.py
@@ -1,0 +1,469 @@
+"""Integration tests for hook outputs (.hook-outputs.yaml) flow."""
+
+import json
+import os
+import sys
+import textwrap
+import unittest.mock
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Neutralize _bootstrap before importing execute.py/score.py — prevents
+# os.execv from replacing the pytest process when running under system python.
+_real_execv = os.execv
+os.execv = lambda *a, **kw: None  # no-op during import
+
+from agent_eval.agent.base import RunResult
+from agent_eval.config import EvalConfig, HookEntry, HooksConfig
+from agent_eval.hooks import (
+    build_hook_env, collect_hook_outputs, inject_hook_env, run_hooks,
+    save_hook_data,
+)
+from execute import _run_single_case
+from score import load_case_record
+
+os.execv = _real_execv  # restore
+
+
+# ---------------------------------------------------------------------------
+# Hook writes .hook-outputs.yaml → harness collects it
+# ---------------------------------------------------------------------------
+
+def test_hook_writes_outputs_yaml(tmp_path):
+    """A before_each hook writes .hook-outputs.yaml; harness collects it."""
+    log_dir = tmp_path / "hooks"
+    case_ws = tmp_path / "case-ws"
+    case_ws.mkdir()
+
+    entries = [HookEntry(
+        command=(
+            'printf "env:\\n  FIXTURE_URL: https://example.com/123\\n'
+            'data:\\n  issue_id: 42\\n" > .hook-outputs.yaml'
+        ),
+    )]
+    run_hooks(entries, dict(os.environ), case_ws, log_dir, "before_each",
+              case_id="case-001")
+
+    assert (case_ws / ".hook-outputs.yaml").exists()
+    outputs = collect_hook_outputs(case_ws)
+
+    assert outputs["env"]["FIXTURE_URL"] == "https://example.com/123"
+    assert outputs["data"]["issue_id"] == 42
+    assert not (case_ws / ".hook-outputs.yaml").exists()
+
+
+def test_hook_writes_outputs_json(tmp_path):
+    """Hook writes .hook-outputs.json instead of YAML."""
+    log_dir = tmp_path / "hooks"
+    case_ws = tmp_path / "case-ws"
+    case_ws.mkdir()
+
+    payload = json.dumps({"env": {"API_KEY": "test-key-123"}})
+    entries = [HookEntry(
+        command=f"echo '{payload}' > .hook-outputs.json",
+    )]
+    run_hooks(entries, dict(os.environ), case_ws, log_dir, "before_each",
+              case_id="case-001")
+
+    outputs = collect_hook_outputs(case_ws)
+    assert outputs["env"]["API_KEY"] == "test-key-123"
+
+
+# ---------------------------------------------------------------------------
+# inject_hook_env patches settings.json
+# ---------------------------------------------------------------------------
+
+def test_inject_hook_env_creates_settings(tmp_path):
+    """Hook env vars are written into .claude/settings.json."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    inject_hook_env(workspace, {"FIXTURE_URL": "https://example.com/1"})
+
+    settings_path = workspace / ".claude" / "settings.json"
+    assert settings_path.exists()
+    settings = json.loads(settings_path.read_text())
+    assert settings["env"]["FIXTURE_URL"] == "https://example.com/1"
+
+
+def test_inject_hook_env_merges_with_existing(tmp_path):
+    """Hook env vars merge into existing settings.json env block."""
+    workspace = tmp_path / "workspace"
+    settings_dir = workspace / ".claude"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "settings.json").write_text(
+        json.dumps({"env": {"EXISTING": "keep"}, "permissions": {"allow": []}}))
+
+    inject_hook_env(workspace, {"NEW_VAR": "added"})
+
+    settings = json.loads((settings_dir / "settings.json").read_text())
+    assert settings["env"]["EXISTING"] == "keep"
+    assert settings["env"]["NEW_VAR"] == "added"
+    assert settings["permissions"] == {"allow": []}
+
+
+def test_inject_hook_env_noop_when_empty(tmp_path):
+    """No settings.json created when env dict is empty."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    inject_hook_env(workspace, {})
+
+    assert not (workspace / ".claude" / "settings.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# save_hook_data round-trip (write + read back as YAML)
+# ---------------------------------------------------------------------------
+
+def test_save_hook_data_creates_file(tmp_path):
+    """save_hook_data writes hook_outputs.yaml."""
+    case_dir = tmp_path / "cases" / "test-case"
+
+    save_hook_data(case_dir, {"issue_id": 42, "repo": "org/test"})
+
+    path = case_dir / "hook_outputs.yaml"
+    assert path.exists()
+    loaded = yaml.safe_load(path.read_text())
+    assert loaded == {"issue_id": 42, "repo": "org/test"}
+
+
+def test_save_hook_data_noop_when_empty(tmp_path):
+    """No file created when data is empty or None."""
+    case_dir = tmp_path / "cases" / "test-case"
+    case_dir.mkdir(parents=True)
+
+    save_hook_data(case_dir, {})
+    save_hook_data(case_dir, None)
+
+    assert not (case_dir / "hook_outputs.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: hook → collect → inject → save
+# ---------------------------------------------------------------------------
+
+def test_full_hook_outputs_flow(tmp_path):
+    """Full flow: hook writes outputs → harness collects, injects env,
+    saves data."""
+    case_ws = tmp_path / "workspace" / "cases" / "case-001"
+    case_ws.mkdir(parents=True)
+    log_dir = tmp_path / "hooks"
+    case_output = tmp_path / "output" / "cases" / "case-001"
+
+    # 1. Hook writes .hook-outputs.yaml
+    entries = [HookEntry(
+        command=(
+            'printf "env:\\n  SERVICE_URL: http://localhost:8080\\n'
+            'data:\\n  container_id: abc123\\n" > .hook-outputs.yaml'
+        ),
+    )]
+    run_hooks(entries, dict(os.environ), case_ws, log_dir, "before_each",
+              case_id="case-001")
+
+    # 2. Harness collects outputs
+    outputs = collect_hook_outputs(case_ws)
+    assert outputs["env"]["SERVICE_URL"] == "http://localhost:8080"
+    assert outputs["data"]["container_id"] == "abc123"
+
+    # 3. Harness injects env into settings.json
+    inject_hook_env(case_ws, outputs.get("env"))
+    settings = json.loads(
+        (case_ws / ".claude" / "settings.json").read_text())
+    assert settings["env"]["SERVICE_URL"] == "http://localhost:8080"
+
+    # 4. Harness saves data for judges
+    save_hook_data(case_output, outputs.get("data"))
+    assert (case_output / "hook_outputs.yaml").exists()
+    loaded = yaml.safe_load(
+        (case_output / "hook_outputs.yaml").read_text())
+    assert loaded["container_id"] == "abc123"
+
+
+def test_global_and_case_outputs_merge(tmp_path):
+    """Global (before_all) and per-case (before_each) outputs merge correctly."""
+    global_ws = tmp_path / "workspace"
+    global_ws.mkdir()
+    case_ws = tmp_path / "workspace" / "cases" / "case-001"
+    case_ws.mkdir(parents=True)
+    log_dir = tmp_path / "hooks"
+
+    # before_all hook writes global outputs
+    entries_all = [HookEntry(
+        command=(
+            'printf "env:\\n  SHARED_URL: http://shared\\n'
+            'data:\\n  shared_key: global_val\\n" '
+            '> "$AGENT_EVAL_WORKSPACE/.hook-outputs.yaml"'
+        ),
+    )]
+    env = {**os.environ, "AGENT_EVAL_WORKSPACE": str(global_ws)}
+    run_hooks(entries_all, env, Path.cwd(), log_dir, "before_all")
+    global_outputs = collect_hook_outputs(global_ws)
+
+    # before_each hook writes case-specific outputs
+    entries_each = [HookEntry(
+        command=(
+            'printf "env:\\n  CASE_URL: http://case1\\n  SHARED_URL: http://override\\n'
+            'data:\\n  case_key: case_val\\n" > .hook-outputs.yaml'
+        ),
+    )]
+    run_hooks(entries_each, env, case_ws, log_dir, "before_each",
+              case_id="case-001")
+    case_outputs = collect_hook_outputs(case_ws)
+
+    # Merge: case overrides global
+    merged_env = {
+        **global_outputs.get("env", {}),
+        **case_outputs.get("env", {}),
+    }
+    merged_data = {
+        **global_outputs.get("data", {}),
+        **case_outputs.get("data", {}),
+    }
+
+    assert merged_env["SHARED_URL"] == "http://override"
+    assert merged_env["CASE_URL"] == "http://case1"
+    assert merged_data["shared_key"] == "global_val"
+    assert merged_data["case_key"] == "case_val"
+
+
+# ---------------------------------------------------------------------------
+# _run_single_case integration tests (mock runner, real hooks)
+# ---------------------------------------------------------------------------
+
+def _make_mock_runner():
+    """Create a mock runner that records call args and returns a RunResult."""
+    runner = unittest.mock.MagicMock()
+    runner.run_skill.return_value = RunResult(
+        exit_code=0, stdout="ok", stderr="", duration_s=1.0,
+        cost_usd=0.01, num_turns=1,
+    )
+    return runner
+
+
+def _make_config(before_each=None, after_each=None, dataset_path=None):
+    """Build an EvalConfig with hooks configured."""
+    config = EvalConfig()
+    config.skill = "test-skill"
+    config.hooks = HooksConfig(
+        before_each=before_each or [],
+        after_each=after_each or [],
+    )
+    if dataset_path:
+        config.dataset_path = str(dataset_path)
+    return config
+
+
+def test_run_single_case_injects_hook_env(tmp_path):
+    """before_each hook writes .hook-outputs.yaml → env injected into
+    settings.json before runner.run_skill is called."""
+    case_ws = tmp_path / "workspace" / "cases" / "case-001"
+    case_ws.mkdir(parents=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    dataset = tmp_path / "dataset"
+    (dataset / "case-001").mkdir(parents=True)
+
+    config = _make_config(
+        before_each=[HookEntry(
+            command=(
+                'printf "env:\\n  ISSUE_URL: https://github.com/org/repo/issues/1\\n'
+                'data:\\n  repo: org/repo\\n" > .hook-outputs.yaml'
+            ),
+        )],
+        dataset_path=dataset,
+    )
+    hook_env = build_hook_env(
+        workspace=str(tmp_path / "workspace"),
+        run_id="test-run",
+        config_path="eval.yaml",
+        project_root=str(Path.cwd()),
+        model="sonnet",
+    )
+
+    runner = _make_mock_runner()
+
+    case_id, result = _run_single_case(
+        runner, "test-skill", "case-001", case_ws, output_dir,
+        "--arg1 val1", "sonnet", None, None, None, 5.0, 600,
+        1, 1, config=config, hook_env=hook_env,
+    )
+
+    assert case_id == "case-001"
+    assert result is not None
+    assert result["exit_code"] == 0
+
+    # Verify env was injected into settings.json
+    settings_path = case_ws / ".claude" / "settings.json"
+    assert settings_path.exists()
+    settings = json.loads(settings_path.read_text())
+    assert settings["env"]["ISSUE_URL"] == "https://github.com/org/repo/issues/1"
+
+    # Verify settings_path was passed to runner
+    call_kwargs = runner.run_skill.call_args
+    assert call_kwargs.kwargs.get("settings_path") == settings_path or \
+        call_kwargs[1].get("settings_path") == settings_path
+
+
+def test_run_single_case_saves_hook_data(tmp_path):
+    """Hook data is saved to case output dir as hook_outputs.yaml."""
+    case_ws = tmp_path / "workspace" / "cases" / "case-001"
+    case_ws.mkdir(parents=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    dataset = tmp_path / "dataset"
+    (dataset / "case-001").mkdir(parents=True)
+
+    config = _make_config(
+        before_each=[HookEntry(
+            command=(
+                'printf "data:\\n  container_id: abc123\\n  port: 5432\\n"'
+                ' > .hook-outputs.yaml'
+            ),
+        )],
+        dataset_path=dataset,
+    )
+    hook_env = build_hook_env(
+        workspace=str(tmp_path / "workspace"),
+        run_id="test-run",
+        config_path="eval.yaml",
+        project_root=str(Path.cwd()),
+        model="sonnet",
+    )
+
+    _run_single_case(
+        _make_mock_runner(), "test-skill", "case-001", case_ws, output_dir,
+        "", "sonnet", None, None, None, 5.0, 600,
+        1, 1, config=config, hook_env=hook_env,
+    )
+
+    # Verify hook data was saved and is loadable by score.py
+    case_output = output_dir / "cases" / "case-001"
+    record = load_case_record(case_output, EvalConfig())
+    assert record["hook_outputs"]["container_id"] == "abc123"
+    assert record["hook_outputs"]["port"] == 5432
+
+
+def test_run_single_case_forward_propagates_env_to_after_each(tmp_path):
+    """Env vars from before_each .hook-outputs.yaml are available as
+    environment variables in after_each hooks."""
+    case_ws = tmp_path / "workspace" / "cases" / "case-001"
+    case_ws.mkdir(parents=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    dataset = tmp_path / "dataset"
+    (dataset / "case-001").mkdir(parents=True)
+
+    marker = tmp_path / "after_each_saw_env.txt"
+
+    config = _make_config(
+        before_each=[HookEntry(
+            command=(
+                'printf "env:\\n  DYNAMIC_VAR: injected_value\\n"'
+                ' > .hook-outputs.yaml'
+            ),
+        )],
+        after_each=[HookEntry(
+            command=f'echo "$DYNAMIC_VAR" > {marker}',
+        )],
+        dataset_path=dataset,
+    )
+    hook_env = build_hook_env(
+        workspace=str(tmp_path / "workspace"),
+        run_id="test-run",
+        config_path="eval.yaml",
+        project_root=str(Path.cwd()),
+        model="sonnet",
+    )
+
+    _run_single_case(
+        _make_mock_runner(), "test-skill", "case-001", case_ws, output_dir,
+        "", "sonnet", None, None, None, 5.0, 600,
+        1, 1, config=config, hook_env=hook_env,
+    )
+
+    assert marker.exists()
+    assert marker.read_text().strip() == "injected_value"
+
+
+def test_run_single_case_merges_global_and_case_outputs(tmp_path):
+    """Global hook outputs merge with per-case outputs, case wins on conflict."""
+    case_ws = tmp_path / "workspace" / "cases" / "case-001"
+    case_ws.mkdir(parents=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    dataset = tmp_path / "dataset"
+    (dataset / "case-001").mkdir(parents=True)
+
+    config = _make_config(
+        before_each=[HookEntry(
+            command=(
+                'printf "env:\\n  CASE_VAR: from_case\\n  SHARED: from_case\\n'
+                'data:\\n  case_key: case_val\\n  shared_key: from_case\\n"'
+                ' > .hook-outputs.yaml'
+            ),
+        )],
+        dataset_path=dataset,
+    )
+    hook_env = build_hook_env(
+        workspace=str(tmp_path / "workspace"),
+        run_id="test-run",
+        config_path="eval.yaml",
+        project_root=str(Path.cwd()),
+        model="sonnet",
+    )
+
+    global_hook_outputs = {
+        "env": {"GLOBAL_VAR": "from_global", "SHARED": "from_global"},
+        "data": {"global_key": "global_val", "shared_key": "from_global"},
+    }
+
+    _run_single_case(
+        _make_mock_runner(), "test-skill", "case-001", case_ws, output_dir,
+        "", "sonnet", None, None, None, 5.0, 600,
+        1, 1, config=config, hook_env=hook_env,
+        global_hook_outputs=global_hook_outputs,
+    )
+
+    # Check env: case overrides global for SHARED, both GLOBAL_VAR and CASE_VAR present
+    settings = json.loads(
+        (case_ws / ".claude" / "settings.json").read_text())
+    assert settings["env"]["GLOBAL_VAR"] == "from_global"
+    assert settings["env"]["CASE_VAR"] == "from_case"
+    assert settings["env"]["SHARED"] == "from_case"
+
+    # Check data: merged and available to judges
+    case_output = output_dir / "cases" / "case-001"
+    record = load_case_record(case_output, EvalConfig())
+    assert record["hook_outputs"]["global_key"] == "global_val"
+    assert record["hook_outputs"]["case_key"] == "case_val"
+    assert record["hook_outputs"]["shared_key"] == "from_case"
+
+
+def test_run_single_case_no_hooks_no_side_effects(tmp_path):
+    """Without hooks configured, no settings.json or hook_outputs.yaml created."""
+    case_ws = tmp_path / "workspace" / "cases" / "case-001"
+    case_ws.mkdir(parents=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    config = EvalConfig()
+    config.skill = "test-skill"
+
+    _run_single_case(
+        _make_mock_runner(), "test-skill", "case-001", case_ws, output_dir,
+        "", "sonnet", None, None, None, 5.0, 600,
+        1, 1, config=config,
+    )
+
+    case_output = output_dir / "cases" / "case-001"
+    assert not (case_ws / ".claude" / "settings.json").exists()
+    assert not (case_output / "hook_outputs.yaml").exists()

--- a/tests/test_hook_outputs.py
+++ b/tests/test_hook_outputs.py
@@ -531,7 +531,8 @@ def test_run_single_case_after_each_runs_on_before_each_failure(tmp_path):
     # after_each must have run despite before_each failure
     assert marker.exists(), "after_each hook did not run after before_each failure"
     assert marker.read_text().strip() == "cleanup"
-    assert result is None
+    assert result is not None
+    assert result["exit_code"] != 0
 
 
 def test_cli_runner_receives_hook_output_env_vars(tmp_path):

--- a/tests/test_hook_pipeline.py
+++ b/tests/test_hook_pipeline.py
@@ -1,0 +1,204 @@
+"""Integration test for the full hooks lifecycle pipeline.
+
+Exercises the real harness scripts end-to-end via subprocess:
+workspace.py → execute.py (with hooks + CLI runner) → score.py
+
+Uses runner.type=cli so no API keys are needed.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPTS = Path(__file__).parent.parent / "skills" / "eval-run" / "scripts"
+
+
+def _run_script(script_name, args, cwd, env=None):
+    """Run a harness script and return the completed process."""
+    cmd = [sys.executable, str(SCRIPTS / script_name)] + args
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=str(cwd), env=env)
+
+
+@pytest.fixture
+def hook_eval_project(tmp_path):
+    """Set up a minimal eval project with hooks at every lifecycle phase."""
+    project = tmp_path / "project"
+    project.mkdir()
+
+    cases_dir = project / "cases"
+    for case_id in ("case-001", "case-002"):
+        case = cases_dir / case_id
+        case.mkdir(parents=True)
+        (case / "input.yaml").write_text(
+            yaml.dump({"prompt": f"hello from {case_id}"}))
+
+    eval_config = {
+        "name": "hooks-pipeline-test",
+        "skill": "test-echo",
+        "execution": {
+            "mode": "case",
+            "arguments": "{prompt}",
+        },
+        "runner": {
+            "type": "cli",
+            "command": [
+                "bash", "-c",
+                "echo PROMPT={args} TEST_VAR=$TEST_VAR",
+            ],
+        },
+        "models": {"skill": "test-model"},
+        "dataset": {
+            "path": "cases",
+            "schema": "Each case has a prompt field",
+        },
+        "outputs": [
+            {"path": "output", "schema": "Text file with echo output"},
+        ],
+        "hooks": {
+            "before_all": [{
+                "command": "touch $AGENT_EVAL_WORKSPACE/before_all.marker",
+                "description": "Global setup marker",
+            }],
+            "before_each": [{
+                "command": (
+                    "touch $CASE_WORKSPACE/before_each.marker\n"
+                    "cat > .hook-outputs.yaml <<'HOOKEOF'\n"
+                    "env:\n"
+                    "  TEST_VAR: hook_injected_value\n"
+                    "data:\n"
+                    "  setup_ts: '12345'\n"
+                    "HOOKEOF\n"
+                ),
+                "description": "Per-case setup with outputs",
+            }],
+            "after_each": [{
+                "command": "touch $CASE_WORKSPACE/after_each.marker",
+                "description": "Per-case cleanup",
+                "on_failure": "continue",
+            }],
+            "before_scoring": [{
+                "command": "touch $AGENT_EVAL_WORKSPACE/before_scoring.marker",
+                "description": "Pre-scoring hook",
+            }],
+            "after_all": [{
+                "command": "touch $AGENT_EVAL_WORKSPACE/after_all.marker",
+                "description": "Final teardown",
+                "on_failure": "continue",
+            }],
+        },
+        "judges": [{
+            "name": "hook_data_check",
+            "description": "Verify hook outputs reached judges",
+            "check": (
+                'hook_data = outputs.get("hook_outputs", {})\n'
+                'if hook_data.get("setup_ts") == "12345":\n'
+                '    return True, "Hook data present"\n'
+                'return False, f"Missing hook data: {hook_data}"'
+            ),
+        }],
+    }
+    (project / "eval.yaml").write_text(
+        yaml.dump(eval_config, default_flow_style=False))
+
+    return project
+
+
+def test_hooks_lifecycle_pipeline(hook_eval_project, tmp_path):
+    """Full pipeline: workspace → execute (with hooks) → score → verify."""
+    project = hook_eval_project
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    run_id = "test-run-001"
+
+    env = {**os.environ, "AGENT_EVAL_RUNS_DIR": str(runs_dir)}
+
+    # Step 1: Create workspace
+    ws_result = _run_script("workspace.py", [
+        "--config", "eval.yaml",
+        "--run-id", run_id,
+    ], cwd=project, env=env)
+    assert ws_result.returncode == 0, f"workspace.py failed:\n{ws_result.stderr}"
+
+    workspace = None
+    for line in ws_result.stdout.splitlines():
+        if line.startswith("WORKSPACE:"):
+            workspace = Path(line.split(":", 1)[1].strip())
+            break
+    assert workspace and workspace.exists(), \
+        f"No workspace found. stdout:\n{ws_result.stdout}"
+
+    # Step 2: Execute with hooks + CLI runner
+    # score.py uses _get_runs_dir(config.skill) = AGENT_EVAL_RUNS_DIR/test-echo
+    output_dir = runs_dir / "test-echo" / run_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    exec_result = _run_script("execute.py", [
+        "--workspace", str(workspace),
+        "--skill", "test-echo",
+        "--model", "test-model",
+        "--output", str(output_dir),
+        "--config", str(project / "eval.yaml"),
+        "--agent", "cli",
+        "--run-id", run_id,
+    ], cwd=project, env=env)
+    assert exec_result.returncode == 0, \
+        f"execute.py failed:\n{exec_result.stderr}"
+
+    # -- Verify all hook phases ran --
+
+    assert (workspace / "before_all.marker").exists(), \
+        "before_all hook did not run"
+    assert (workspace / "after_all.marker").exists(), \
+        "after_all hook did not run"
+
+    for case_id in ("case-001", "case-002"):
+        case_ws = workspace / "cases" / case_id
+        assert (case_ws / "before_each.marker").exists(), \
+            f"before_each did not run for {case_id}"
+        assert (case_ws / "after_each.marker").exists(), \
+            f"after_each did not run for {case_id}"
+
+    # -- Verify hook env vars were injected into the CLI runner --
+    # The CLI runner writes result.txt to the workspace's output/ dir,
+    # and execute.py captures stdout. Check stdout.log for the env var.
+    for case_id in ("case-001", "case-002"):
+        stdout_file = output_dir / "cases" / case_id / "stdout.log"
+        assert stdout_file.exists(), f"stdout.log missing for {case_id}"
+        content = stdout_file.read_text()
+        assert "hook_injected_value" in content, \
+            f"Hook env not injected for {case_id}. Got: {content}"
+
+    # -- Verify hook data saved for judges --
+    for case_id in ("case-001", "case-002"):
+        ho_path = output_dir / "cases" / case_id / "hook_outputs.yaml"
+        assert ho_path.exists(), f"hook_outputs.yaml missing for {case_id}"
+        ho = yaml.safe_load(ho_path.read_text())
+        assert ho.get("setup_ts") == "12345", \
+            f"Wrong hook data for {case_id}: {ho}"
+
+    # Step 3: Score (runs before_scoring hooks + judges)
+    score_result = _run_script("score.py", [
+        "judges",
+        "--run-id", run_id,
+        "--config", str(project / "eval.yaml"),
+        "--workspace", str(workspace),
+        "--model", "test-model",
+    ], cwd=project, env=env)
+    assert score_result.returncode == 0, \
+        f"score.py failed:\n{score_result.stderr}"
+
+    assert (workspace / "before_scoring.marker").exists(), \
+        "before_scoring hook did not run"
+
+    # -- Verify judge passed (hook data was accessible) --
+    summary_path = output_dir / "summary.yaml"
+    assert summary_path.exists(), f"No summary.yaml at {summary_path}"
+    summary = yaml.safe_load(summary_path.read_text())
+    judges = summary.get("judges", {})
+    assert "hook_data_check" in judges, f"Judge missing from summary: {summary}"
+    assert judges["hook_data_check"]["pass_rate"] == 1.0, \
+        f"Judge failed: {judges['hook_data_check']}"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -243,6 +243,52 @@ def test_empty_entries_returns_empty(tmp_path):
 # run_hooks_safe
 # ---------------------------------------------------------------------------
 
+def test_invalid_on_failure_rejected(tmp_path):
+    with pytest.raises(ValueError, match="on_failure must be"):
+        EvalConfig.from_yaml(_write(tmp_path, textwrap.dedent("""\
+            name: t
+            skill: s
+            hooks:
+              before_all:
+                - command: "echo x"
+                  on_failure: fial
+        """)))
+
+
+def test_negative_timeout_rejected(tmp_path):
+    with pytest.raises(ValueError, match="timeout must be a positive"):
+        EvalConfig.from_yaml(_write(tmp_path, textwrap.dedent("""\
+            name: t
+            skill: s
+            hooks:
+              before_all:
+                - command: "echo x"
+                  timeout: -1
+        """)))
+
+
+def test_zero_timeout_rejected(tmp_path):
+    with pytest.raises(ValueError, match="timeout must be a positive"):
+        EvalConfig.from_yaml(_write(tmp_path, textwrap.dedent("""\
+            name: t
+            skill: s
+            hooks:
+              before_all:
+                - command: "echo x"
+                  timeout: 0
+        """)))
+
+
+def test_case_id_sanitized_in_log_filename(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="echo safe")]
+    results = run_hooks(entries, dict(os.environ), tmp_path, log_dir,
+                        "before_each", case_id="../../etc/passwd")
+    # Log file must stay inside log_dir regardless of malicious case_id
+    assert results[0].log_file.resolve().parent == log_dir.resolve()
+    assert "/" not in results[0].log_file.name
+
+
 def test_run_hooks_safe_never_raises(tmp_path):
     log_dir = tmp_path / "hooks"
     entries = [

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -10,7 +10,9 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from agent_eval.config import EvalConfig, HookEntry, HooksConfig
-from agent_eval.hooks import HookError, HookResult, run_hooks, run_hooks_safe
+from agent_eval.hooks import (
+    HookError, HookResult, collect_hook_outputs, run_hooks, run_hooks_safe,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -299,3 +301,53 @@ def test_run_hooks_safe_never_raises(tmp_path):
     assert len(results) == 2
     assert results[0].exit_code == 1
     assert results[1].exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# collect_hook_outputs
+# ---------------------------------------------------------------------------
+
+def test_collect_hook_outputs_yaml(tmp_path):
+    (tmp_path / ".hook-outputs.yaml").write_text(
+        "env:\n  FOO: bar\ndata:\n  count: 42\n")
+    result = collect_hook_outputs(tmp_path)
+    assert result == {"env": {"FOO": "bar"}, "data": {"count": 42}}
+    assert not (tmp_path / ".hook-outputs.yaml").exists()
+
+
+def test_collect_hook_outputs_json(tmp_path):
+    import json
+    (tmp_path / ".hook-outputs.json").write_text(
+        json.dumps({"env": {"KEY": "val"}}))
+    result = collect_hook_outputs(tmp_path)
+    assert result == {"env": {"KEY": "val"}}
+    assert not (tmp_path / ".hook-outputs.json").exists()
+
+
+def test_collect_hook_outputs_yaml_takes_precedence(tmp_path):
+    (tmp_path / ".hook-outputs.yaml").write_text("env:\n  FROM: yaml\n")
+    (tmp_path / ".hook-outputs.json").write_text('{"env": {"FROM": "json"}}')
+    result = collect_hook_outputs(tmp_path)
+    assert result["env"]["FROM"] == "yaml"
+    assert not (tmp_path / ".hook-outputs.yaml").exists()
+    # JSON file should still exist — only the first match is consumed
+    assert (tmp_path / ".hook-outputs.json").exists()
+
+
+def test_collect_hook_outputs_no_file(tmp_path):
+    result = collect_hook_outputs(tmp_path)
+    assert result == {}
+
+
+def test_collect_hook_outputs_malformed_yaml(tmp_path):
+    (tmp_path / ".hook-outputs.yaml").write_text(": : : not valid yaml [")
+    result = collect_hook_outputs(tmp_path)
+    assert result == {}
+    assert not (tmp_path / ".hook-outputs.yaml").exists()
+
+
+def test_collect_hook_outputs_empty_file(tmp_path):
+    (tmp_path / ".hook-outputs.yaml").write_text("")
+    result = collect_hook_outputs(tmp_path)
+    assert result == {}
+    assert not (tmp_path / ".hook-outputs.yaml").exists()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,255 @@
+"""Tests for lifecycle hook execution."""
+
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.config import EvalConfig, HookEntry, HooksConfig
+from agent_eval.hooks import HookError, HookResult, run_hooks, run_hooks_safe
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+
+def _write(tmp_path, body):
+    p = tmp_path / "eval.yaml"
+    p.write_text(body)
+    return p
+
+
+def test_hooks_config_parses_all_phases(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, textwrap.dedent("""\
+        name: t
+        skill: s
+        hooks:
+          before_all:
+            - command: "echo setup"
+              timeout: 60
+              description: "Start services"
+            - command: "echo ready"
+          before_each:
+            - command: "echo case-setup"
+              condition: "test -f snapshot.tar.gz"
+          after_each:
+            - command: "echo case-teardown"
+              on_failure: continue
+          before_scoring:
+            - command: "python3 aggregate.py"
+              timeout: 30
+          after_all:
+            - command: "echo cleanup"
+              on_failure: continue
+              description: "Tear down services"
+    """)))
+    assert len(cfg.hooks.before_all) == 2
+    assert cfg.hooks.before_all[0].command == "echo setup"
+    assert cfg.hooks.before_all[0].timeout == 60
+    assert cfg.hooks.before_all[0].description == "Start services"
+    assert cfg.hooks.before_all[1].command == "echo ready"
+    assert cfg.hooks.before_all[1].timeout == 120  # default
+
+    assert len(cfg.hooks.before_each) == 1
+    assert cfg.hooks.before_each[0].condition == "test -f snapshot.tar.gz"
+
+    assert len(cfg.hooks.after_each) == 1
+    assert cfg.hooks.after_each[0].on_failure == "continue"
+
+    assert len(cfg.hooks.before_scoring) == 1
+    assert cfg.hooks.before_scoring[0].timeout == 30
+
+    assert len(cfg.hooks.after_all) == 1
+    assert cfg.hooks.after_all[0].description == "Tear down services"
+
+
+def test_hooks_config_defaults_to_empty(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, "name: t\nskill: s\n"))
+    assert cfg.hooks.before_all == []
+    assert cfg.hooks.before_each == []
+    assert cfg.hooks.after_each == []
+    assert cfg.hooks.before_scoring == []
+    assert cfg.hooks.after_all == []
+
+
+def test_hooks_config_empty_block(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, textwrap.dedent("""\
+        name: t
+        skill: s
+        hooks:
+    """)))
+    assert cfg.hooks.before_all == []
+
+
+# ---------------------------------------------------------------------------
+# Hook execution
+# ---------------------------------------------------------------------------
+
+def test_successful_hook(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="echo hello")]
+    env = dict(os.environ)
+    results = run_hooks(entries, env, tmp_path, log_dir, "before_all")
+    assert len(results) == 1
+    assert results[0].exit_code == 0
+    assert not results[0].skipped
+    assert not results[0].timed_out
+    assert results[0].log_file.exists()
+    assert "hello" in results[0].log_file.read_text()
+
+
+def test_failing_hook_raises(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="exit 1", on_failure="fail")]
+    with pytest.raises(HookError) as exc_info:
+        run_hooks(entries, dict(os.environ), tmp_path, log_dir, "before_all")
+    assert exc_info.value.exit_code == 1
+    assert exc_info.value.phase == "before_all"
+
+
+def test_failing_hook_continue(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [
+        HookEntry(command="exit 1", on_failure="continue"),
+        HookEntry(command="echo second"),
+    ]
+    results = run_hooks(entries, dict(os.environ), tmp_path, log_dir, "after_each")
+    assert len(results) == 2
+    assert results[0].exit_code == 1
+    assert results[1].exit_code == 0
+
+
+def test_failing_hook_fail_stops_remaining(tmp_path):
+    log_dir = tmp_path / "hooks"
+    marker = tmp_path / "should_not_exist"
+    entries = [
+        HookEntry(command="exit 1", on_failure="fail"),
+        HookEntry(command=f"touch {marker}"),
+    ]
+    with pytest.raises(HookError):
+        run_hooks(entries, dict(os.environ), tmp_path, log_dir, "before_all")
+    assert not marker.exists()
+
+
+def test_condition_pass(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="echo ran", condition="true")]
+    results = run_hooks(entries, dict(os.environ), tmp_path, log_dir, "before_each")
+    assert len(results) == 1
+    assert not results[0].skipped
+    assert results[0].exit_code == 0
+
+
+def test_condition_fail_skips(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="echo should-not-run", condition="false")]
+    results = run_hooks(entries, dict(os.environ), tmp_path, log_dir, "before_each")
+    assert len(results) == 1
+    assert results[0].skipped
+    assert results[0].log_file is None
+
+
+def test_condition_checks_file_existence(tmp_path):
+    log_dir = tmp_path / "hooks"
+    target = tmp_path / "marker.txt"
+    entries = [HookEntry(
+        command="echo found",
+        condition=f"test -f {target}",
+    )]
+
+    # Without the file: skipped
+    results = run_hooks(entries, dict(os.environ), tmp_path, log_dir, "before_each")
+    assert results[0].skipped
+
+    # With the file: runs
+    target.write_text("x")
+    results = run_hooks(entries, dict(os.environ), tmp_path, log_dir, "before_each")
+    assert not results[0].skipped
+    assert results[0].exit_code == 0
+
+
+def test_timeout_kills_hook(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="sleep 60", timeout=1, on_failure="continue")]
+    results = run_hooks(entries, dict(os.environ), tmp_path, log_dir, "before_all")
+    assert len(results) == 1
+    assert results[0].timed_out
+    assert results[0].duration_s < 10  # Should be ~1s, not 60s
+
+
+def test_timeout_raises_when_fail(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="sleep 60", timeout=1, on_failure="fail")]
+    with pytest.raises(HookError) as exc_info:
+        run_hooks(entries, dict(os.environ), tmp_path, log_dir, "before_all")
+    assert exc_info.value.timed_out
+
+
+def test_env_vars_available(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="echo $MY_TEST_VAR")]
+    env = {**os.environ, "MY_TEST_VAR": "hook_value_42"}
+    results = run_hooks(entries, env, tmp_path, log_dir, "before_all")
+    assert results[0].exit_code == 0
+    assert "hook_value_42" in results[0].log_file.read_text()
+
+
+def test_cwd_is_respected(tmp_path):
+    log_dir = tmp_path / "hooks"
+    work_dir = tmp_path / "workdir"
+    work_dir.mkdir()
+    entries = [HookEntry(command="pwd")]
+    results = run_hooks(entries, dict(os.environ), work_dir, log_dir, "before_each")
+    assert results[0].exit_code == 0
+    assert str(work_dir) in results[0].log_file.read_text()
+
+
+def test_case_id_in_log_filename(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="echo case")]
+    results = run_hooks(entries, dict(os.environ), tmp_path, log_dir,
+                        "before_each", case_id="case-001")
+    assert results[0].log_file.name == "before_each.case-001.0.log"
+
+
+def test_log_filename_without_case_id(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="echo global")]
+    results = run_hooks(entries, dict(os.environ), tmp_path, log_dir, "before_all")
+    assert results[0].log_file.name == "before_all.0.log"
+
+
+def test_multiline_command(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [HookEntry(command="echo line1\necho line2")]
+    results = run_hooks(entries, dict(os.environ), tmp_path, log_dir, "before_all")
+    assert results[0].exit_code == 0
+    content = results[0].log_file.read_text()
+    assert "line1" in content
+    assert "line2" in content
+
+
+def test_empty_entries_returns_empty(tmp_path):
+    log_dir = tmp_path / "hooks"
+    results = run_hooks([], dict(os.environ), tmp_path, log_dir, "before_all")
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# run_hooks_safe
+# ---------------------------------------------------------------------------
+
+def test_run_hooks_safe_never_raises(tmp_path):
+    log_dir = tmp_path / "hooks"
+    entries = [
+        HookEntry(command="exit 1", on_failure="fail"),
+        HookEntry(command="echo second"),
+    ]
+    results = run_hooks_safe(entries, dict(os.environ), tmp_path, log_dir, "after_all")
+    assert len(results) == 2
+    assert results[0].exit_code == 1
+    assert results[1].exit_code == 0


### PR DESCRIPTION
## Summary

Please see `specs/006-execution-hooks/spec.md` for details.  An implementation is included but happy to iterate on the spec to make sure we get the right abstraction here.

Eval cases can depend on external resources (services, databases, fixtures) that today must be managed with ad-hoc scripts outside the harness. This adds lifecycle hooks to `eval.yaml` — user-defined shell commands that run at well-defined points in the eval pipeline, making setup and teardown declarative, version-controlled, and managed by the harness.

Five hook points spanning the full eval lifecycle:

```
  before_all          → start services, extract shared archives
   ├─ before_each     → seed per-case state, extract case-specific data
   │   └─ [skill execution]
   │   └─ after_each  → capture ephemeral state, normalize outputs
   ├─ [collection]
   ├─ before_scoring  → aggregate cross-case data for judges
   └─ after_all       → stop services, clean up (guaranteed, even on failure)
```

  Each hook supports `timeout`, `condition` (skip if shell expression fails), `on_failure` (`fail` or `continue`), and `description` for progress
  output. Hook stdout/stderr is captured to `{run_dir}/hooks/`.

  ## Changes

  - **`agent_eval/config.py`** — `HookEntry` and `HooksConfig` dataclasses, parsed from `hooks:` block in eval.yaml
  - **`agent_eval/hooks.py`** *(new)* — Hook executor (`run_hooks`, `run_hooks_safe`) with timeout enforcement, condition checks, and a standalone CLI
  entry point
  - **`skills/eval-run/scripts/execute.py`** — Calls `before_all`/`after_all` around execution (with `try/finally` for guaranteed cleanup),
  `before_each`/`after_each` around each case
  - **`skills/eval-run/scripts/score.py`** — Calls `before_scoring` hooks at the start of judge scoring
  - **`skills/eval-run/SKILL.md`** — Documents hook behavior, adds `--run-id` to execute.py and `--workspace`/`--model` to score.py invocations
  - **`specs/006-execution-hooks/spec.md`** — Full design spec
  - **`tests/test_hooks.py`** *(new)* — 19 tests covering config parsing, execution, conditions, timeouts, failure modes, env vars, and log capture

  ## Example

  ```yaml
  hooks:
    before_all:
      - command: "docker compose -f evals/services.yaml up -d"
        timeout: 60
        description: "Start eval services"
    before_each:
      - command: "psql -h localhost -U eval -f $CASE_SOURCE_DIR/seed.sql eval_db"
        condition: "test -f $CASE_SOURCE_DIR/seed.sql"
        description: "Seed database for case"
    after_all:
      - command: "docker compose -f evals/services.yaml down -v"
        on_failure: continue
        description: "Tear down services"
```

  Test plan

- [x] All 19 new hook tests pass
- [x] Full test suite (262 tests) passes with no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution lifecycle hooks added (before_all, before_each, after_each, before_scoring, after_all) with conditional execution, per-hook timeouts, fail/continue semantics, log capture, and hook-provided env/data merged and injected into runs and judges.

* **CLI / UX**
  * Added run-id support; score CLI accepts workspace and model context; batch mode warns and ignores per-case hooks; after_all hooks run reliably and hook logs are written per run/case.

* **Documentation**
  * Specs and skill docs updated with hook semantics, env injection, outputs, and file lifecycle.

* **Tests**
  * Extensive unit and integration tests covering parsing, execution, timeouts, outputs, merging, and safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->