### PR TITLE
feat: OTel trace capture and OpenCode runner

### DIFF
--- a/agent_eval/agent/__init__.py
+++ b/agent_eval/agent/__init__.py
@@ -3,16 +3,18 @@
 from .base import EvalRunner, RunResult
 from .claude_code import ClaudeCodeRunner
 from .cli_runner import CliRunner
+from .opencode import OpenCodeRunner
 from .responses_api import ResponsesAPIRunner
 
 RUNNERS = {
     "claude-code": ClaudeCodeRunner,
     "cli": CliRunner,
+    "opencode": OpenCodeRunner,
     "responses-api": ResponsesAPIRunner,
 }
 
 __all__ = [
     "EvalRunner", "RunResult",
-    "ClaudeCodeRunner", "CliRunner", "ResponsesAPIRunner",
+    "ClaudeCodeRunner", "CliRunner", "OpenCodeRunner", "ResponsesAPIRunner",
     "RUNNERS",
 ]

--- a/agent_eval/agent/base.py
+++ b/agent_eval/agent/base.py
@@ -51,6 +51,26 @@ class EvalRunner(ABC):
     def name(self) -> str:
         """Short identifier for this runner (e.g. 'claude-code', 'agent-sdk')."""
 
+    def setup_workspace(
+        self,
+        workspace: Path,
+        config,
+        *,
+        project_root: Optional[Path] = None,
+        interceptor_src: Optional[Path] = None,
+    ) -> None:
+        """Configure workspace with runner-specific settings.
+
+        Called after generic workspace setup (dirs, symlinks, inputs).
+        Each runner writes its own config files, hooks, and permissions.
+
+        Args:
+            workspace: Root workspace (batch) or case workspace (case mode).
+            config: EvalConfig instance.
+            project_root: Project root directory (where eval.yaml lives).
+            interceptor_src: Path to tool interceptor script (tools.py).
+        """
+
     @abstractmethod
     def run_skill(
         self,
@@ -63,6 +83,7 @@ class EvalRunner(ABC):
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
         extra_env: Optional[dict] = None,
+        output_dir: Optional[Path] = None,
     ) -> RunResult:
         """Invoke a skill in an isolated workspace.
 
@@ -79,6 +100,8 @@ class EvalRunner(ABC):
             timeout_s: Timeout in seconds.
             extra_env: Additional env vars to inject (e.g. from hook outputs).
                 Merged after execution.env, so hook env overrides static config.
+            output_dir: Where to write trace artifacts (e.g. otel_spans.json).
+                Defaults to workspace if not provided.
 
         Returns:
             RunResult with exit code, output, timing, and optional usage stats.

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -2,12 +2,15 @@
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import threading
 import time
 from pathlib import Path
 from typing import Optional
+
+import yaml
 
 from .base import EvalRunner, RunResult
 from .stream_capture import (
@@ -52,6 +55,7 @@ class ClaudeCodeRunner(EvalRunner):
             mlflow_tracking_uri=overrides.get("mlflow_tracking_uri"),
             effort=overrides.get("effort", config.runner.effort),
             log_prefix=log_prefix,
+            otel_config=config.runner.otel,
         )
 
     def __init__(
@@ -65,6 +69,7 @@ class ClaudeCodeRunner(EvalRunner):
         mlflow_tracking_uri: Optional[str] = None,
         log_prefix: Optional[str] = None,
         effort: Optional[str] = None,
+        otel_config=None,
     ):
         self._permissions = permissions or {}
         self._subagent_model = subagent_model
@@ -79,6 +84,7 @@ class ClaudeCodeRunner(EvalRunner):
                 f"Invalid effort '{effort}'. "
                 f"Must be one of: {sorted(self._VALID_EFFORTS)}")
         self._effort = effort
+        self._otel_config = otel_config
 
     @property
     def name(self) -> str:
@@ -95,6 +101,40 @@ class ClaudeCodeRunner(EvalRunner):
             return ""
 
     def run_skill(
+        self,
+        skill_name: str,
+        args: str,
+        workspace: Path,
+        model: str,
+        settings_path: Optional[Path] = None,
+        system_prompt: Optional[str] = None,
+        max_budget_usd: float = 5.0,
+        timeout_s: int = 600,
+        extra_env: Optional[dict] = None,
+        output_dir: Optional[Path] = None,
+    ) -> RunResult:
+        receiver = None
+        if self._otel_config and self._otel_config.enabled:
+            from agent_eval.otel.receiver import OTLPReceiver
+            otel_output = output_dir or workspace
+            receiver = OTLPReceiver(output_dir=otel_output)
+            self._otel_port = receiver.start()
+        else:
+            self._otel_port = None
+
+        try:
+            return self._run_skill_inner(
+                skill_name, args, workspace, model,
+                settings_path, system_prompt,
+                max_budget_usd, timeout_s,
+                extra_env=extra_env,
+            )
+        finally:
+            if receiver:
+                receiver.stop(flush_timeout_s=5)
+                self._otel_port = None
+
+    def _run_skill_inner(
         self,
         skill_name: str,
         args: str,
@@ -329,7 +369,6 @@ class ClaudeCodeRunner(EvalRunner):
         if session_dir.exists() and session_dir.is_dir():
             shutil.rmtree(session_dir, ignore_errors=True)
 
-    # Environment keys safe to forward to evaluated skills
     _SAFE_ENV_KEYS = {
         "PATH", "HOME", "USER", "SHELL", "LANG", "LC_ALL", "TERM",
         "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN",
@@ -342,6 +381,14 @@ class ClaudeCodeRunner(EvalRunner):
         "CLOUDSDK_CONFIG", "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
         "MLFLOW_TRACKING_URI", "MLFLOW_EXPERIMENT_NAME",
         "AGENT_EVAL_RUNS_DIR",
+        # OTel
+        "OTEL_TRACES_EXPORTER", "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_PROTOCOL", "OTEL_EXPORTER_OTLP_HEADERS",
+        "OTEL_RESOURCE_ATTRIBUTES", "OTEL_SERVICE_NAME",
+        "OTEL_LOG_TOOL_CONTENT", "OTEL_LOG_USER_PROMPTS",
+        "OTEL_LOG_TOOL_DETAILS", "OTEL_LOG_RAW_API_BODIES",
+        "CLAUDE_CODE_ENABLE_TELEMETRY",
+        "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA",
     }
 
     def _build_env(self, extra_env=None):
@@ -365,7 +412,233 @@ class ClaudeCodeRunner(EvalRunner):
             env["MLFLOW_EXPERIMENT_NAME"] = self._mlflow_experiment
         if self._mlflow_tracking_uri:
             env["MLFLOW_TRACKING_URI"] = self._mlflow_tracking_uri
+        if self._otel_port:
+            self._inject_otel_env(env)
         return env
+
+    def _inject_otel_env(self, env: dict) -> None:
+        """Set OTel env vars for the agent subprocess."""
+        cfg = self._otel_config
+        env["OTEL_TRACES_EXPORTER"] = "otlp"
+        env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{self._otel_port}"
+        env["OTEL_EXPORTER_OTLP_PROTOCOL"] = cfg.protocol
+        env["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+        env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
+        env["OTEL_LOG_USER_PROMPTS"] = "1"
+        env["OTEL_LOG_TOOL_DETAILS"] = "1"
+        if cfg.content:
+            env["OTEL_LOG_TOOL_CONTENT"] = "1"
+        if cfg.resource_attributes:
+            attrs = ",".join(f"{k}={v}" for k, v in cfg.resource_attributes.items())
+            env["OTEL_RESOURCE_ATTRIBUTES"] = attrs
+
+    # ── Workspace setup ─────────────────────────────────────────
+
+    def setup_workspace(self, workspace, config, *, project_root=None,
+                        interceptor_src=None):
+        if config.inputs.tools:
+            self._ws_setup_tool_hooks(workspace, config, project_root,
+                                      interceptor_src)
+        else:
+            self._ws_setup_subagent_only(workspace, config, project_root)
+
+    def _ws_setup_subagent_only(self, workspace, config, project_root):
+        """Minimal .claude/settings.json with SubagentStop hook."""
+        settings_dir = workspace / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+
+        settings = {}
+        self._ws_carry_over_permissions(settings, project_root)
+        self._ws_merge_harness_permissions(settings, config)
+
+        if project_root:
+            settings.setdefault("permissions", {}).setdefault(
+                "additionalDirectories", []).append(
+                    str(project_root.resolve()))
+
+        from agent_eval.agent.stream_capture import setup_subagent_hook
+        subagent_dir = str((workspace / "subagents").resolve())
+        setup_subagent_hook(settings, subagent_dir)
+
+        self._ws_inject_env(settings, config)
+        self._ws_apply_runner_settings(settings, config)
+
+        with open(settings_dir / "settings.json", "w") as f:
+            json.dump(settings, f, indent=2)
+
+        print("HOOKS: SubagentStop configured (subagent capture)")
+
+    def _ws_setup_tool_hooks(self, workspace, config, project_root,
+                              interceptor_src):
+        """Generate settings.json with PreToolUse hooks + tool_handlers.yaml."""
+        handlers = []
+        hook_matchers = set()
+        for tool_cfg in config.inputs.tools:
+            handler = {"match": tool_cfg.match}
+            patterns = self._ws_extract_tool_patterns(tool_cfg.match)
+            handler["patterns"] = patterns
+            if tool_cfg.prompt:
+                handler["prompt"] = tool_cfg.prompt
+            if tool_cfg.prompt_file:
+                handler["prompt_file"] = tool_cfg.prompt_file
+            handlers.append(handler)
+            hook_matchers.update(patterns)
+
+        handler_data = {"handlers": handlers}
+        if config.models.hook:
+            handler_data["hook_model"] = config.models.hook
+        with open(workspace / "tool_handlers.yaml", "w") as f:
+            yaml.dump(handler_data, f, default_flow_style=False)
+
+        hooks_dir = workspace / "hooks"
+        hooks_dir.mkdir(exist_ok=True)
+        if interceptor_src and interceptor_src.exists():
+            shutil.copy2(interceptor_src, hooks_dir / "tools.py")
+
+        settings_dir = workspace / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+
+        settings = {"hooks": {"PreToolUse": []}}
+        for matcher in sorted(hook_matchers):
+            settings["hooks"]["PreToolUse"].append({
+                "matcher": matcher,
+                "hooks": [{
+                    "type": "command",
+                    "command": f"python3 {workspace}/hooks/tools.py",
+                }],
+            })
+
+        self._ws_carry_over_permissions(settings, project_root)
+        self._ws_merge_harness_permissions(settings, config)
+
+        if project_root:
+            settings.setdefault("permissions", {}).setdefault(
+                "additionalDirectories", []).append(
+                    str(project_root.resolve()))
+
+        from agent_eval.agent.stream_capture import setup_subagent_hook
+        subagent_dir = str((workspace / "subagents").resolve())
+        setup_subagent_hook(settings, subagent_dir)
+
+        self._ws_inject_env(settings, config)
+        self._ws_apply_runner_settings(settings, config)
+
+        with open(settings_dir / "settings.json", "w") as f:
+            json.dump(settings, f, indent=2)
+
+        print(f"HOOKS: {len(hook_matchers)} tool interceptors configured")
+
+    @staticmethod
+    def _ws_carry_over_permissions(settings, project_root):
+        """Copy project .claude/settings.json permissions into workspace settings."""
+        if not project_root:
+            return
+        project_settings = project_root / ".claude" / "settings.json"
+        if not project_settings.exists():
+            return
+        try:
+            with open(project_settings) as f:
+                proj = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return
+
+        proj_perms = proj.get("permissions", {})
+        if proj_perms.get("allow"):
+            allow_list = _expand_symlink_permissions(list(proj_perms["allow"]))
+            settings.setdefault("permissions", {})["allow"] = allow_list
+        if proj_perms.get("deny"):
+            settings.setdefault("permissions", {})["deny"] = list(
+                proj_perms["deny"])
+        if proj_perms.get("additionalDirectories"):
+            dirs = list(proj_perms["additionalDirectories"])
+            for d in list(dirs):
+                resolved = str(Path(d).resolve())
+                if resolved != d and resolved not in dirs:
+                    dirs.append(resolved)
+            settings.setdefault("permissions", {}).setdefault(
+                "additionalDirectories", []).extend(dirs)
+
+    @staticmethod
+    def _ws_merge_harness_permissions(settings, config):
+        """Merge eval.yaml permissions.allow into settings."""
+        allow = (config.permissions or {}).get("allow") if hasattr(
+            config, "permissions") else None
+        if not allow:
+            return
+        harness_allow = _expand_symlink_permissions(list(allow))
+        existing = settings.setdefault("permissions", {}).setdefault(
+            "allow", [])
+        for pattern in harness_allow:
+            if pattern not in existing:
+                existing.append(pattern)
+
+    @staticmethod
+    def _ws_inject_env(settings, config):
+        """Inject execution.env into settings.json env block."""
+        if not config.execution.env:
+            return
+        env_block = settings.setdefault("env", {})
+        for key, value in config.execution.env.items():
+            if isinstance(value, str) and value.startswith("$"):
+                resolved = os.environ.get(value[1:])
+                if resolved is not None:
+                    env_block[key] = resolved
+            else:
+                env_block[key] = str(value)
+
+    @staticmethod
+    def _ws_apply_runner_settings(settings, config):
+        """Merge eval.yaml runner.settings into workspace settings."""
+        user_settings = getattr(config.runner, "settings", None) or {}
+        if user_settings:
+            _deep_merge(settings, user_settings)
+
+    @staticmethod
+    def _ws_extract_tool_patterns(match_text):
+        """Extract tool name patterns from a natural language match description."""
+        patterns = []
+        known_tools = ["AskUserQuestion", "Bash", "Read", "Write", "Edit",
+                       "Glob", "Grep", "Agent", "Skill"]
+        for tool in known_tools:
+            if tool.lower() in match_text.lower():
+                patterns.append(tool)
+        for m in re.finditer(r'(mcp__\w+(?:__\w+)*(?:\*)?)', match_text):
+            patterns.append(m.group(1))
+        if not patterns and ("script" in match_text.lower()
+                             or "api" in match_text.lower()):
+            patterns.append("Bash")
+        return patterns or ["*"]
+
+
+def _expand_symlink_permissions(allow_list):
+    """Add resolved-path variants for permission patterns with symlinked dirs."""
+    extras = []
+    for pattern in allow_list:
+        m = re.match(r'(Write|Edit|Bash)\((.+)\)', pattern)
+        if not m:
+            continue
+        tool, glob_path = m.groups()
+        prefix = re.split(r'[*?]', glob_path, maxsplit=1)[0].rstrip('/')
+        if not prefix or not prefix.startswith('/'):
+            continue
+        resolved = str(Path(prefix).resolve())
+        if resolved != prefix:
+            resolved_pattern = f"{tool}({glob_path.replace(prefix, resolved)})"
+            if resolved_pattern not in allow_list:
+                extras.append(resolved_pattern)
+    return allow_list + extras
+
+
+def _deep_merge(dst, src):
+    """Recursively merge src into dst. Lists are extended, dicts merged."""
+    for k, v in src.items():
+        if isinstance(v, dict) and isinstance(dst.get(k), dict):
+            _deep_merge(dst[k], v)
+        elif isinstance(v, list) and isinstance(dst.get(k), list):
+            dst[k].extend(v)
+        else:
+            dst[k] = v
+    return dst
 
 
 def _extract_denial_list(result_obj, streaming_count):

--- a/agent_eval/agent/cli_runner.py
+++ b/agent_eval/agent/cli_runner.py
@@ -88,6 +88,7 @@ class CliRunner(EvalRunner):
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
         extra_env: Optional[dict] = None,
+        output_dir: Optional[Path] = None,
     ) -> RunResult:
         workspace = workspace.resolve()
         output_dir = workspace / "output"

--- a/agent_eval/agent/opencode.py
+++ b/agent_eval/agent/opencode.py
@@ -83,6 +83,7 @@ class OpenCodeRunner(EvalRunner):
         system_prompt: Optional[str] = None,
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
+        output_dir: Optional[Path] = None,
     ) -> RunResult:
         receiver = None
         otel_port = None

--- a/agent_eval/agent/opencode.py
+++ b/agent_eval/agent/opencode.py
@@ -83,13 +83,14 @@ class OpenCodeRunner(EvalRunner):
         system_prompt: Optional[str] = None,
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
+        extra_env: Optional[dict] = None,
         output_dir: Optional[Path] = None,
     ) -> RunResult:
         receiver = None
         otel_port = None
         if self._otel_config and self._otel_config.enabled:
             from agent_eval.otel.receiver import OTLPReceiver
-            otel_output = workspace
+            otel_output = output_dir or workspace
             receiver = OTLPReceiver(output_dir=otel_output)
             otel_port = receiver.start()
 

--- a/agent_eval/agent/opencode.py
+++ b/agent_eval/agent/opencode.py
@@ -1,0 +1,305 @@
+"""OpenCode CLI runner implementation.
+
+Runs skills using the OpenCode CLI (anomalyco/opencode) in non-interactive
+mode via `opencode run --format json`.
+
+OTel trace capture is supported but requires an upstream fix in OpenCode
+(process.exit() kills spans before flush). Until then, usage and events
+are extracted from OpenCode's JSON stdout events.
+"""
+
+import json
+import os
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from .base import EvalRunner, RunResult
+
+_print_lock = threading.Lock()
+
+
+class OpenCodeRunner(EvalRunner):
+    """Runs skills using the OpenCode CLI in non-interactive mode."""
+
+    @classmethod
+    def from_config(cls, config, *, log_prefix=None, **overrides):
+        return cls(
+            permissions=config.permissions,
+            env=config.runner.env,
+            system_prompt=config.runner.system_prompt,
+            otel_config=config.runner.otel,
+            log_prefix=log_prefix,
+            effort=overrides.get("effort", config.runner.effort),
+        )
+
+    def __init__(
+        self,
+        permissions: Optional[dict] = None,
+        env: Optional[dict] = None,
+        system_prompt: Optional[str] = None,
+        otel_config=None,
+        log_prefix: Optional[str] = None,
+        effort: Optional[str] = None,
+    ):
+        self._permissions = permissions or {}
+        self._env = env or {}
+        self._system_prompt = system_prompt
+        self._otel_config = otel_config
+        self._log_prefix = log_prefix
+        self._effort = effort
+
+    @property
+    def name(self) -> str:
+        return "opencode"
+
+    def setup_workspace(self, workspace, config, *, project_root=None,
+                        interceptor_src=None):
+        """Write opencode.json with permissions and optional OTel config."""
+        config_data = {"$schema": "https://opencode.ai/config.json"}
+
+        config_data["permission"] = {"task": "deny"}
+
+        deny = self._permissions.get("deny", [])
+        for pattern in deny:
+            config_data["permission"][pattern.lower()] = "deny"
+
+        if self._otel_config and self._otel_config.enabled:
+            config_data.setdefault("experimental", {})
+            config_data["experimental"]["openTelemetry"] = True
+
+        (workspace / "opencode.json").write_text(
+            json.dumps(config_data, indent=2))
+
+    def run_skill(
+        self,
+        skill_name: str,
+        args: str,
+        workspace: Path,
+        model: str,
+        settings_path: Optional[Path] = None,
+        system_prompt: Optional[str] = None,
+        max_budget_usd: float = 5.0,
+        timeout_s: int = 600,
+    ) -> RunResult:
+        receiver = None
+        otel_port = None
+        if self._otel_config and self._otel_config.enabled:
+            from agent_eval.otel.receiver import OTLPReceiver
+            otel_output = workspace
+            receiver = OTLPReceiver(output_dir=otel_output)
+            otel_port = receiver.start()
+
+        try:
+            return self._run_inner(
+                skill_name, args, workspace, model,
+                system_prompt, max_budget_usd, timeout_s,
+                otel_port,
+            )
+        finally:
+            if receiver:
+                receiver.stop(flush_timeout_s=5)
+
+    def _run_inner(
+        self,
+        skill_name: str,
+        args: str,
+        workspace: Path,
+        model: str,
+        system_prompt: Optional[str],
+        max_budget_usd: float,
+        timeout_s: int,
+        otel_port: Optional[int],
+    ) -> RunResult:
+        if skill_name:
+            prompt = f"Use the {skill_name} skill"
+            if args:
+                prompt += f" with arguments: {args}"
+        else:
+            prompt = args or ""
+
+        # --dangerously-skip-permissions: auto-approve tool calls that
+        # aren't explicitly denied in opencode.json. Workaround for
+        # OpenCode's ruleset ordering bug (#13851) where "allow" rules
+        # in config get overridden by session presets for external paths.
+        cmd = ["opencode", "run", "--format", "json",
+               "--dangerously-skip-permissions"]
+
+        if model:
+            cmd.extend(["--model", model])
+
+        if self._effort:
+            cmd.extend(["--variant", self._effort])
+
+        cmd.extend(["--dir", str(workspace)])
+        cmd.append(prompt)
+
+        env = self._build_env(otel_port, workspace)
+        start = time.monotonic()
+        deadline = start + timeout_s
+        timed_out = False
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=str(workspace),
+                text=True,
+                env=env,
+            )
+
+            def _watchdog():
+                nonlocal timed_out
+                remaining = max(0, deadline - time.monotonic())
+                try:
+                    proc.wait(timeout=remaining if remaining > 0 else 0.1)
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+                    proc.kill()
+
+            watchdog = threading.Thread(target=_watchdog, daemon=True)
+            watchdog.start()
+
+            stdout_lines = []
+            for line in proc.stdout:
+                line = line.rstrip("\n")
+                stdout_lines.append(line)
+                if self._log_prefix:
+                    msg = self._extract_progress(line)
+                    if msg:
+                        with _print_lock:
+                            print(f"  {self._log_prefix} | {msg}", flush=True)
+
+            stderr = proc.stderr.read()
+            proc.wait(timeout=5)
+            if timed_out:
+                raise subprocess.TimeoutExpired(cmd, timeout_s)
+
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+            duration = time.monotonic() - start
+            return RunResult(
+                exit_code=-1,
+                stdout="\n".join(stdout_lines),
+                stderr=f"Timed out after {timeout_s}s",
+                duration_s=duration,
+            )
+        except Exception as e:
+            duration = time.monotonic() - start
+            return RunResult(
+                exit_code=-1, stdout="", stderr=str(e), duration_s=duration,
+            )
+
+        duration = time.monotonic() - start
+        usage = _extract_usage_from_events(stdout_lines)
+
+        return RunResult(
+            exit_code=proc.returncode,
+            stdout="\n".join(stdout_lines),
+            stderr=stderr or "",
+            duration_s=duration,
+            token_usage=usage.get("token_usage"),
+            cost_usd=usage.get("cost_usd"),
+            num_turns=usage.get("num_turns"),
+            resolved_model=usage.get("resolved_model"),
+            models_used=usage.get("models_used"),
+        )
+
+    def _build_env(self, otel_port: Optional[int], workspace: Path) -> dict:
+        """Build subprocess environment: inherit env, apply runner.env, add OTel."""
+        env = os.environ.copy()
+        for k, v in self._env.items():
+            if isinstance(v, str) and v.startswith("$"):
+                resolved = os.environ.get(v[1:])
+                if resolved is not None:
+                    env[k] = resolved
+            else:
+                env[k] = str(v)
+
+        if otel_port and self._otel_config:
+            cfg = self._otel_config
+            env["OTEL_EXPORTER_OTLP_ENDPOINT"] = f"http://127.0.0.1:{otel_port}"
+            env["OTEL_EXPORTER_OTLP_PROTOCOL"] = cfg.protocol
+            env["OTEL_BSP_SCHEDULE_DELAY"] = "0"
+            if cfg.resource_attributes:
+                attrs = ",".join(f"{k}={v}" for k, v in cfg.resource_attributes.items())
+                env["OTEL_RESOURCE_ATTRIBUTES"] = attrs
+
+        return env
+
+    @staticmethod
+    def _extract_progress(line: str) -> str:
+        """Extract progress message from OpenCode JSON output."""
+        try:
+            obj = json.loads(line)
+            event_type = obj.get("type", "")
+            if event_type == "text":
+                text = obj.get("part", {}).get("text", "").strip()
+                if text and len(text) < 100:
+                    return text
+            elif event_type == "tool_call":
+                name = obj.get("name", "")
+                return f"Tool: {name}" if name else ""
+            elif event_type == "step_finish":
+                part = obj.get("part", {})
+                cost = part.get("cost") or 0
+                return f"Step done (${cost:.4f})"
+        except (json.JSONDecodeError, ValueError):
+            pass
+        return ""
+
+
+def _extract_usage_from_events(stdout_lines: list) -> dict:
+    """Extract token usage and cost from OpenCode JSON stdout events.
+
+    OpenCode emits step_finish events with cost and token breakdowns::
+
+        {"type": "step_finish", "part": {
+            "cost": 0.0054,
+            "tokens": {"total": 14227, "input": 2, "output": 5,
+                       "reasoning": 0, "cache": {"read": 13896, "write": 324}}
+        }}
+    """
+    total_cost = 0.0
+    total_input = 0
+    total_output = 0
+    total_cache_read = 0
+    total_cache_write = 0
+    num_turns = 0
+
+    for line in stdout_lines:
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        if obj.get("type") == "step_finish":
+            part = obj.get("part", {})
+            cost = part.get("cost") or 0
+            if cost:
+                total_cost += cost
+
+            tokens = part.get("tokens") or {}
+            total_input += tokens.get("input") or 0
+            total_output += tokens.get("output") or 0
+            cache = tokens.get("cache") or {}
+            total_cache_read += cache.get("read") or 0
+            total_cache_write += cache.get("write") or 0
+            num_turns += 1
+
+    return {
+        "token_usage": {
+            "input": total_input,
+            "output": total_output,
+            "cache_read": total_cache_read,
+            "cache_create": total_cache_write,
+        } if num_turns else None,
+        "cost_usd": total_cost or None,
+        "num_turns": num_turns or None,
+        "resolved_model": None,
+        "models_used": None,
+    }

--- a/agent_eval/agent/responses_api.py
+++ b/agent_eval/agent/responses_api.py
@@ -264,6 +264,7 @@ class ResponsesAPIRunner(EvalRunner):
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
         extra_env: Optional[dict] = None,
+        output_dir: Optional[Path] = None,
     ) -> RunResult:
         client = None
         effective_model = model or self._default_model

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -178,6 +178,29 @@ class ExecutionConfig:
 
 
 @dataclass
+class OTelConfig:
+    """OpenTelemetry trace capture configuration.
+
+    When enabled, the harness starts a local OTLP receiver per case,
+    configures the agent subprocess to export spans to it, and uses
+    the collected spans (via a per-runtime SpanMapper) to generate
+    events.json for judges.
+
+    enabled: start the local OTLP receiver and inject OTel env vars.
+    content: log full tool input/output content in spans.
+    api_bodies: log raw API request/response bodies to files
+        (required for Claude Code to capture assistant text).
+    resource_attributes: extra key=value pairs for OTEL_RESOURCE_ATTRIBUTES.
+    protocol: OTLP wire protocol (http/json or http/protobuf).
+    """
+    enabled: bool = False
+    content: bool = True
+    api_bodies: bool = True
+    resource_attributes: dict = field(default_factory=dict)
+    protocol: str = "http/json"
+
+
+@dataclass
 class RunnerConfig:
     """Which agent harness runs the skill, and runner-specific knobs.
 
@@ -198,6 +221,7 @@ class RunnerConfig:
     env: dict = field(default_factory=dict)
     system_prompt: Optional[str] = None
     effort: Optional[str] = None  # Claude Code: low | medium | high | xhigh | max
+    otel: OTelConfig = field(default_factory=OTelConfig)
 
 
 @dataclass
@@ -376,6 +400,14 @@ class EvalConfig:
             )
             if not (isinstance(command, str) or valid_list):
                 raise ValueError("runner.command must be a string or list of strings")
+        otel_raw = runner_raw.get("otel") or {}
+        otel = OTelConfig(
+            enabled=otel_raw.get("enabled", False),
+            content=otel_raw.get("content", True),
+            api_bodies=otel_raw.get("api_bodies", True),
+            resource_attributes=otel_raw.get("resource_attributes") or {},
+            protocol=otel_raw.get("protocol", "http/json"),
+        )
         runner = RunnerConfig(
             type=runner_raw.get("type", "claude-code"),
             command=command,
@@ -384,6 +416,7 @@ class EvalConfig:
             env=runner_raw.get("env", {}) or {},
             system_prompt=runner_raw.get("system_prompt"),
             effort=runner_raw.get("effort"),
+            otel=otel,
         )
 
         # Models block

--- a/agent_eval/otel/__init__.py
+++ b/agent_eval/otel/__init__.py
@@ -1,0 +1,1 @@
+"""OpenTelemetry trace capture for agent evaluation."""

--- a/agent_eval/otel/receiver.py
+++ b/agent_eval/otel/receiver.py
@@ -1,0 +1,134 @@
+"""Lightweight in-process OTLP/HTTP receiver for eval trace capture.
+
+Starts an HTTP server on a random port, accepts OTLP/HTTP JSON trace
+exports at POST /v1/traces, accumulates ResourceSpans payloads, and
+writes them to otel_spans.json on shutdown.
+
+No external dependencies — stdlib only.
+"""
+
+import json
+import logging
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_OUTPUT_FILENAME = "otel_spans.json"
+
+
+class _OTLPHandler(BaseHTTPRequestHandler):
+    """Handles OTLP/HTTP JSON trace export requests."""
+
+    def do_POST(self):
+        if self.path != "/v1/traces":
+            self.send_error(404)
+            return
+
+        content_type = self.headers.get("Content-Type", "")
+        if "application/json" not in content_type:
+            self.send_error(
+                415, f"Unsupported content type: {content_type}. "
+                     f"Only application/json is supported.")
+            return
+
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        try:
+            payload = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            self.send_error(400, "Invalid JSON")
+            return
+
+        resource_spans = payload.get("resourceSpans", [])
+        if resource_spans:
+            with self.server.lock:
+                self.server.resource_spans.extend(resource_spans)
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{}')
+
+    def log_message(self, format, *args):
+        pass
+
+
+class OTLPReceiver:
+    """In-process OTLP/HTTP JSON receiver for eval trace capture.
+
+    Usage::
+
+        receiver = OTLPReceiver(output_dir=Path("case-01/"))
+        port = receiver.start()
+        # ... run agent with OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:{port}
+        path = receiver.stop()
+        # path == case-01/otel_spans.json
+    """
+
+    def __init__(self, output_dir: Path):
+        self._output_dir = Path(output_dir)
+        self._server = None
+        self._thread = None
+
+    def start(self) -> int:
+        """Start the receiver server. Returns the assigned port."""
+        self._server = HTTPServer(("127.0.0.1", 0), _OTLPHandler)
+        self._server.lock = threading.Lock()
+        self._server.resource_spans = []
+
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            daemon=True,
+        )
+        self._thread.start()
+
+        port = self._server.server_address[1]
+        log.debug("OTLP receiver started on port %d", port)
+        return port
+
+    @property
+    def endpoint(self) -> str:
+        """OTLP endpoint URL for agent env vars."""
+        if not self._server:
+            raise RuntimeError("Receiver not started")
+        port = self._server.server_address[1]
+        return f"http://127.0.0.1:{port}"
+
+    @property
+    def span_count(self) -> int:
+        """Number of ResourceSpans received so far."""
+        if not self._server:
+            return 0
+        with self._server.lock:
+            return len(self._server.resource_spans)
+
+    def stop(self, flush_timeout_s: float = 5.0) -> Path:
+        """Shutdown server, write collected spans, return output path.
+
+        Blocks up to *flush_timeout_s* for the server thread to finish.
+        """
+        if not self._server:
+            raise RuntimeError("Receiver not started")
+
+        self._server.shutdown()
+        self._thread.join(timeout=flush_timeout_s)
+        self._server.server_close()
+
+        with self._server.lock:
+            resource_spans = list(self._server.resource_spans)
+
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = self._output_dir / _OUTPUT_FILENAME
+        output_path.write_text(json.dumps(
+            {"resourceSpans": resource_spans},
+            indent=2,
+        ))
+
+        log.debug("OTLP receiver stopped: %d ResourceSpans written to %s",
+                   len(resource_spans), output_path)
+
+        self._server = None
+        self._thread = None
+        return output_path

--- a/agent_eval/otel/span_mapper.py
+++ b/agent_eval/otel/span_mapper.py
@@ -1,0 +1,577 @@
+"""Convert OTel spans to canonical event format for judges.
+
+Each agent runtime emits different OTel span schemas. SpanMapper
+implementations translate runtime-specific spans into the flat event
+dicts that parse_stream_events() produces, so judges never change.
+"""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+
+def _nano_to_iso(nano) -> str:
+    """Convert nanosecond Unix timestamp to ISO 8601."""
+    try:
+        ts = int(nano) / 1e9
+        return (datetime.fromtimestamp(ts, tz=timezone.utc)
+                .strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z")
+    except (TypeError, ValueError, OSError):
+        return ""
+
+
+def _get_attr(attributes: list, key: str, default=None):
+    """Extract a value from an OTLP attributes list by key."""
+    for attr in (attributes or []):
+        if attr.get("key") == key:
+            val = attr.get("value", {})
+            for vtype in ("stringValue", "intValue", "doubleValue", "boolValue"):
+                if vtype in val:
+                    return val[vtype]
+            return default
+    return default
+
+
+def _flatten_spans(resource_spans: list[dict]) -> list[dict]:
+    """Extract all spans from an OTLP ResourceSpans list, sorted by start time."""
+    spans = []
+    for rs in resource_spans:
+        resource_attrs = (rs.get("resource") or {}).get("attributes", [])
+        for ss in rs.get("scopeSpans", []):
+            for span in ss.get("spans", []):
+                span["_resource_attrs"] = resource_attrs
+                spans.append(span)
+    spans.sort(key=lambda s: int(s.get("startTimeUnixNano", 0)))
+    return spans
+
+
+class SpanMapper(ABC):
+    """Convert OTLP JSON spans to canonical event dicts."""
+
+    @abstractmethod
+    def map_spans(self, resource_spans: list[dict],
+                  api_bodies_dir: Optional[Path] = None) -> list[dict]:
+        """OTLP JSON ResourceSpans list -> canonical event dicts.
+
+        Output format matches events.py::parse_stream_events():
+        - {"type": "system", "subtype": "init", "model": ..., "timestamp": ...}
+        - {"type": "assistant", "text": ..., "tools": [...], "timestamp": ...}
+        - {"type": "tool_result", "tool_use_id": ..., "tool_name": ..., ...}
+        - {"type": "result", "cost_usd": ..., "num_turns": ..., "timestamp": ...}
+        """
+
+    @abstractmethod
+    def extract_usage(self, resource_spans: list[dict]) -> dict:
+        """Extract execution metrics from spans.
+
+        Returns dict with keys:
+        - token_usage: {"input": N, "output": N, "cache_read": N, "cache_create": N}
+        - cost_usd: float
+        - num_turns: int
+        - per_model_usage: {model: {input, output, ...}}
+        - per_model_turns: {model: int}
+        - models_used: [str]
+        - resolved_model: str (first model seen)
+        """
+
+
+class ClaudeCodeSpanMapper(SpanMapper):
+    """Maps claude_code.* OTel spans to canonical event dicts.
+
+    Claude Code span hierarchy::
+
+        claude_code.interaction (root)
+          claude_code.llm_request (API call: tokens, cost, model)
+          claude_code.tool (tool invocation: name, input, output)
+          claude_code.hook (hook execution)
+    """
+
+    def map_spans(self, resource_spans, api_bodies_dir=None):
+        spans = _flatten_spans(resource_spans)
+        if not spans:
+            return []
+
+        api_bodies = {}
+        if api_bodies_dir and api_bodies_dir.is_dir():
+            api_bodies = self._load_api_bodies(api_bodies_dir)
+
+        events = []
+        span_by_id = {s.get("spanId"): s for s in spans}
+        tool_names = {}  # tool_use_id -> tool_name
+
+        # Emit system/init from first interaction span
+        for span in spans:
+            if span.get("name") == "claude_code.interaction":
+                first_model = None
+                for s in spans:
+                    if s.get("name") == "claude_code.llm_request":
+                        first_model = _get_attr(s.get("attributes", []), "model")
+                        if first_model:
+                            break
+                events.append({
+                    "type": "system",
+                    "subtype": "init",
+                    "model": first_model or "",
+                    "timestamp": _nano_to_iso(span.get("startTimeUnixNano")),
+                })
+                break
+
+        for span in spans:
+            name = span.get("name", "")
+            attrs = span.get("attributes", [])
+            ts = _nano_to_iso(span.get("startTimeUnixNano"))
+            parent_id = span.get("parentSpanId")
+            agent_id = _get_attr(attrs, "agent_id")
+            parent_agent_id = _get_attr(attrs, "parent_agent_id")
+
+            if name == "claude_code.llm_request":
+                # Extract assistant text from API body logs if available
+                request_id = _get_attr(attrs, "request_id") or ""
+                text = api_bodies.get(request_id, "")
+                has_tool_call = _get_attr(attrs, "response.has_tool_call")
+
+                if text or not has_tool_call:
+                    event = {
+                        "type": "assistant",
+                        "text": text,
+                        "tools": [],
+                        "timestamp": ts,
+                        "_msg_id": _get_attr(attrs, "gen_ai.response.id") or span.get("spanId"),
+                    }
+                    if agent_id and parent_agent_id:
+                        event["agent_id"] = agent_id
+                        parent_span = span_by_id.get(parent_id)
+                        if parent_span:
+                            event["parent_tool_use_id"] = parent_span.get("spanId")
+                    events.append(event)
+
+            elif name == "claude_code.tool":
+                tool_name = _get_attr(attrs, "tool_name") or ""
+                span_id = span.get("spanId", "")
+                tool_names[span_id] = tool_name
+
+                tool_input = self._extract_tool_content(span, "input")
+                tool_output = self._extract_tool_content(span, "output")
+
+                # Assistant event with tool_use
+                tool_event = {
+                    "type": "assistant",
+                    "text": "",
+                    "tools": [{
+                        "name": tool_name,
+                        "id": span_id,
+                        "input": tool_input if isinstance(tool_input, dict) else {"content": tool_input},
+                    }],
+                    "timestamp": ts,
+                    "_msg_id": f"tool-{span_id}",
+                }
+                if agent_id and parent_agent_id:
+                    tool_event["agent_id"] = agent_id
+                    parent_span = span_by_id.get(parent_id)
+                    if parent_span:
+                        tool_event["parent_tool_use_id"] = parent_span.get("spanId")
+                events.append(tool_event)
+
+                # Tool result event
+                exec_span = self._find_child_span(spans, span_id, "claude_code.tool.execution")
+                is_error = False
+                if exec_span:
+                    success = _get_attr(exec_span.get("attributes", []), "success")
+                    is_error = success is False or str(success).lower() == "false"
+
+                result_content = tool_output if isinstance(tool_output, str) else json.dumps(tool_output) if tool_output else ""
+                result_ts = _nano_to_iso(span.get("endTimeUnixNano"))
+
+                result_event = {
+                    "type": "tool_result",
+                    "tool_use_id": span_id,
+                    "tool_name": tool_name,
+                    "content": result_content,
+                    "is_error": is_error,
+                    "timestamp": result_ts,
+                }
+                if agent_id and parent_agent_id:
+                    result_event["agent_id"] = agent_id
+                    result_event["parent_tool_use_id"] = tool_event.get("parent_tool_use_id")
+                events.append(result_event)
+
+        # Synthesize result event from aggregated usage
+        usage = self.extract_usage(resource_spans)
+        events.append({
+            "type": "result",
+            "cost_usd": usage.get("cost_usd"),
+            "num_turns": usage.get("num_turns"),
+            "timestamp": None,
+        })
+
+        return events
+
+    def extract_usage(self, resource_spans):
+        spans = _flatten_spans(resource_spans)
+        total_input = 0
+        total_output = 0
+        total_cache_read = 0
+        total_cache_create = 0
+        per_model = {}
+        turn_ids = set()
+        models_seen = set()
+        first_model = None
+
+        for span in spans:
+            if span.get("name") != "claude_code.llm_request":
+                continue
+            attrs = span.get("attributes", [])
+            model = _get_attr(attrs, "model") or ""
+            if model:
+                models_seen.add(model)
+                if not first_model:
+                    first_model = model
+
+            inp = int(_get_attr(attrs, "input_tokens") or 0)
+            out = int(_get_attr(attrs, "output_tokens") or 0)
+            cache_r = int(_get_attr(attrs, "cache_read_tokens") or 0)
+            cache_c = int(_get_attr(attrs, "cache_creation_tokens") or 0)
+
+            total_input += inp
+            total_output += out
+            total_cache_read += cache_r
+            total_cache_create += cache_c
+
+            if model:
+                if model not in per_model:
+                    per_model[model] = {
+                        "input": 0, "output": 0,
+                        "cache_read": 0, "cache_create": 0,
+                        "turns": set(),
+                    }
+                per_model[model]["input"] += inp
+                per_model[model]["output"] += out
+                per_model[model]["cache_read"] += cache_r
+                per_model[model]["cache_create"] += cache_c
+
+            msg_id = _get_attr(attrs, "gen_ai.response.id") or span.get("spanId")
+            # Only count as turn if this is a response with output
+            if out > 0 and msg_id:
+                turn_ids.add(msg_id)
+                if model and model in per_model:
+                    per_model[model]["turns"].add(msg_id)
+
+        per_model_usage = {}
+        per_model_turns = {}
+        for m, data in per_model.items():
+            per_model_usage[m] = {
+                "input": data["input"],
+                "output": data["output"],
+                "cache_read": data["cache_read"],
+                "cache_create": data["cache_create"],
+            }
+            per_model_turns[m] = len(data["turns"])
+
+        return {
+            "token_usage": {
+                "input": total_input,
+                "output": total_output,
+                "cache_read": total_cache_read,
+                "cache_create": total_cache_create,
+            },
+            "cost_usd": None,  # OTel spans don't carry cost directly
+            "num_turns": len(turn_ids),
+            "per_model_usage": per_model_usage or None,
+            "per_model_turns": per_model_turns or None,
+            "models_used": sorted(models_seen) if models_seen else None,
+            "resolved_model": first_model,
+        }
+
+    @staticmethod
+    def _extract_tool_content(span, kind):
+        """Extract tool input or output from span events.
+
+        With OTEL_LOG_TOOL_CONTENT=1, Claude Code emits a 'tool.output'
+        span event with attributes containing tool I/O.
+        """
+        for event in span.get("events", []):
+            if event.get("name") == "tool.output":
+                event_attrs = event.get("attributes", [])
+                content = _get_attr(event_attrs, f"tool.{kind}")
+                if content:
+                    try:
+                        return json.loads(content)
+                    except (json.JSONDecodeError, TypeError):
+                        return content
+        # Fallback: check span attributes for OTEL_LOG_TOOL_DETAILS
+        attrs = span.get("attributes", [])
+        if kind == "input":
+            for key in ("full_command", "file_path", "skill_name"):
+                val = _get_attr(attrs, key)
+                if val:
+                    return val
+        return None
+
+    @staticmethod
+    def _find_child_span(spans, parent_id, name):
+        """Find a child span by name under the given parent."""
+        for s in spans:
+            if s.get("parentSpanId") == parent_id and s.get("name") == name:
+                return s
+        return None
+
+    @staticmethod
+    def _load_api_bodies(bodies_dir: Path) -> dict:
+        """Load API response bodies from OTEL_LOG_RAW_API_BODIES=file:<dir>.
+
+        Returns {request_id: assistant_text} for responses that contain text.
+        """
+        bodies = {}
+        for f in sorted(bodies_dir.glob("*response*.json")):
+            try:
+                data = json.loads(f.read_text())
+                req_id = data.get("id", "")
+                content = data.get("content", [])
+                text_parts = []
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text_parts.append(block.get("text", ""))
+                if text_parts:
+                    bodies[req_id] = "\n".join(text_parts)
+            except (json.JSONDecodeError, OSError):
+                continue
+        return bodies
+
+
+class OpenCodeSpanMapper(SpanMapper):
+    """Maps OpenCode (anomalyco/opencode) AI SDK OTel spans to canonical events.
+
+    OpenCode uses two OTel layers:
+    - Infrastructure: opencode.run.* spans (session, turn, lifecycle)
+    - AI SDK: ai.streamText, ai.generateText, ai.toolCall spans
+    """
+
+    def map_spans(self, resource_spans, api_bodies_dir=None):
+        spans = _flatten_spans(resource_spans)
+        if not spans:
+            return []
+
+        events = []
+
+        # Find first model from AI SDK spans
+        first_model = None
+        for span in spans:
+            if span.get("name", "").startswith("ai."):
+                first_model = _get_attr(span.get("attributes", []), "gen_ai.request.model")
+                if first_model:
+                    break
+
+        if first_model:
+            events.append({
+                "type": "system",
+                "subtype": "init",
+                "model": first_model,
+                "timestamp": _nano_to_iso(spans[0].get("startTimeUnixNano")),
+            })
+
+        for span in spans:
+            name = span.get("name", "")
+            attrs = span.get("attributes", [])
+            ts = _nano_to_iso(span.get("startTimeUnixNano"))
+
+            if name in ("ai.streamText", "ai.generateText", "ai.generateObject"):
+                text = _get_attr(attrs, "gen_ai.completion") or ""
+                event = {
+                    "type": "assistant",
+                    "text": text,
+                    "tools": [],
+                    "timestamp": ts,
+                    "_msg_id": span.get("spanId"),
+                }
+                events.append(event)
+
+            elif name == "ai.toolCall":
+                tool_name = _get_attr(attrs, "ai.toolCall.name") or _get_attr(attrs, "gen_ai.tool.name") or ""
+                tool_id = _get_attr(attrs, "ai.toolCall.id") or span.get("spanId")
+                tool_input_raw = _get_attr(attrs, "ai.toolCall.args") or _get_attr(attrs, "gen_ai.tool.args") or "{}"
+
+                try:
+                    tool_input = json.loads(tool_input_raw)
+                except (json.JSONDecodeError, TypeError):
+                    tool_input = {"content": tool_input_raw}
+
+                events.append({
+                    "type": "assistant",
+                    "text": "",
+                    "tools": [{"name": tool_name, "id": tool_id, "input": tool_input}],
+                    "timestamp": ts,
+                    "_msg_id": f"tool-{tool_id}",
+                })
+
+                tool_result = _get_attr(attrs, "ai.toolCall.result") or _get_attr(attrs, "gen_ai.tool.result") or ""
+                status = span.get("status", {})
+                is_error = status.get("code") == 2  # STATUS_CODE_ERROR
+
+                events.append({
+                    "type": "tool_result",
+                    "tool_use_id": tool_id,
+                    "tool_name": tool_name,
+                    "content": tool_result if isinstance(tool_result, str) else json.dumps(tool_result),
+                    "is_error": is_error,
+                    "timestamp": _nano_to_iso(span.get("endTimeUnixNano")),
+                })
+
+        usage = self.extract_usage(resource_spans)
+        events.append({
+            "type": "result",
+            "cost_usd": usage.get("cost_usd"),
+            "num_turns": usage.get("num_turns"),
+            "timestamp": None,
+        })
+
+        return events
+
+    def extract_usage(self, resource_spans):
+        spans = _flatten_spans(resource_spans)
+        total_input = 0
+        total_output = 0
+        per_model = {}
+        turn_ids = set()
+        models_seen = set()
+        first_model = None
+
+        for span in spans:
+            name = span.get("name", "")
+            if not name.startswith("ai."):
+                continue
+            attrs = span.get("attributes", [])
+
+            model = _get_attr(attrs, "gen_ai.request.model") or ""
+            if model:
+                models_seen.add(model)
+                if not first_model:
+                    first_model = model
+
+            inp = int(_get_attr(attrs, "gen_ai.usage.input_tokens") or
+                      _get_attr(attrs, "gen_ai.usage.prompt_tokens") or 0)
+            out = int(_get_attr(attrs, "gen_ai.usage.output_tokens") or
+                      _get_attr(attrs, "gen_ai.usage.completion_tokens") or 0)
+
+            total_input += inp
+            total_output += out
+
+            if model:
+                if model not in per_model:
+                    per_model[model] = {"input": 0, "output": 0, "turns": set()}
+                per_model[model]["input"] += inp
+                per_model[model]["output"] += out
+
+            if out > 0 and name in ("ai.streamText", "ai.generateText", "ai.generateObject"):
+                turn_ids.add(span.get("spanId"))
+                if model and model in per_model:
+                    per_model[model]["turns"].add(span.get("spanId"))
+
+        per_model_usage = {}
+        per_model_turns = {}
+        for m, data in per_model.items():
+            per_model_usage[m] = {"input": data["input"], "output": data["output"]}
+            per_model_turns[m] = len(data["turns"])
+
+        return {
+            "token_usage": {"input": total_input, "output": total_output},
+            "cost_usd": None,
+            "num_turns": len(turn_ids),
+            "per_model_usage": per_model_usage or None,
+            "per_model_turns": per_model_turns or None,
+            "models_used": sorted(models_seen) if models_seen else None,
+            "resolved_model": first_model,
+        }
+
+
+def parse_opencode_events(stdout_text: str) -> list[dict]:
+    """Parse OpenCode JSON stdout into canonical event dicts.
+
+    Fallback when OTel spans aren't available (OpenCode has an upstream bug
+    where process.exit() kills spans before the BatchSpanProcessor flushes).
+
+    OpenCode --format json emits: step_start, text, tool_call, tool_result,
+    step_finish events.
+    """
+    events = []
+    for line in stdout_text.splitlines():
+        try:
+            obj = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        etype = obj.get("type", "")
+        part = obj.get("part", {})
+        ts_ms = obj.get("timestamp")
+        ts = ""
+        if ts_ms:
+            try:
+                from datetime import datetime, timezone
+                ts = (datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+                      .strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z")
+            except (TypeError, ValueError, OSError):
+                pass
+
+        if etype == "text":
+            events.append({
+                "type": "assistant",
+                "text": part.get("text", ""),
+                "tools": [],
+                "timestamp": ts,
+                "_msg_id": part.get("id", ""),
+            })
+
+        elif etype == "tool_call":
+            tool_name = part.get("tool", "") if isinstance(part, dict) else ""
+            tool_id = part.get("id", "")
+            tool_input = part.get("input", {})
+            if isinstance(tool_input, str):
+                try:
+                    tool_input = json.loads(tool_input)
+                except (json.JSONDecodeError, TypeError):
+                    tool_input = {"content": tool_input}
+            events.append({
+                "type": "assistant",
+                "text": "",
+                "tools": [{"name": tool_name, "id": tool_id, "input": tool_input}],
+                "timestamp": ts,
+                "_msg_id": f"tool-{tool_id}",
+            })
+
+        elif etype == "tool_result":
+            events.append({
+                "type": "tool_result",
+                "tool_use_id": part.get("toolCallID", part.get("id", "")),
+                "tool_name": part.get("tool", ""),
+                "content": part.get("output", part.get("text", "")),
+                "is_error": part.get("state") == "error",
+                "timestamp": ts,
+            })
+
+        elif etype == "step_finish":
+            cost = part.get("cost", 0)
+            tokens = part.get("tokens", {})
+            events.append({
+                "type": "result",
+                "cost_usd": cost or None,
+                "num_turns": 1,
+                "timestamp": ts,
+            })
+
+    return events
+
+
+SPAN_MAPPERS = {
+    "claude-code": ClaudeCodeSpanMapper,
+    "opencode": OpenCodeSpanMapper,
+}
+
+
+def get_span_mapper(runner_type: str) -> SpanMapper:
+    """Return the SpanMapper for a given runner type."""
+    cls = SPAN_MAPPERS.get(runner_type, ClaudeCodeSpanMapper)
+    return cls()

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -226,26 +226,42 @@ def _collect_per_case(workspace, output_dir, config):
 
 
 def _generate_events_json(case_dir, output_case_dir, config):
-    """Parse stdout.log into events.json using atomic write."""
-    # In case mode, execute.py writes stdout.log to the output directory,
-    # not the workspace. Check there first, fall back to workspace.
+    """Parse OTel spans or stdout.log into events.json using atomic write.
+
+    Prefers OTel spans (otel_spans.json) when available, falling back to
+    stream-json stdout parsing for backward compatibility.
+    """
+    # Priority 1: OTel spans (when available and non-empty)
+    otel_path = _find_otel_spans(output_case_dir, case_dir)
+    if otel_path:
+        events = _events_from_otel(otel_path, case_dir, config)
+        if events:
+            _write_events_json(output_case_dir, events)
+            return
+
+    # Priority 2: stdout-based parsing
     stdout_path = output_case_dir / "stdout.log"
     if not stdout_path.exists():
         stdout_path = case_dir / "stdout.log"
     if not stdout_path.exists():
-        output_case_dir.mkdir(parents=True, exist_ok=True)
-        dest = output_case_dir / "events.json"
-        fd, tmp_path = tempfile.mkstemp(dir=str(output_case_dir), suffix=".tmp")
-        with os.fdopen(fd, "w") as f:
-            json.dump([], f)
-        os.rename(tmp_path, str(dest))
+        _write_events_json(output_case_dir, [])
         return
 
     try:
         stdout_text = stdout_path.read_text()
     except OSError:
+        _write_events_json(output_case_dir, [])
         return
 
+    # OpenCode JSON events (--format json)
+    runner_type = config.runner.type if hasattr(config, "runner") else ""
+    if runner_type == "opencode":
+        from agent_eval.otel.span_mapper import parse_opencode_events
+        events = parse_opencode_events(stdout_text)
+        _write_events_json(output_case_dir, events)
+        return
+
+    # Claude Code stream-json
     events = parse_stream_events(stdout_text)
 
     subagent_dir = case_dir / "subagents"
@@ -253,6 +269,38 @@ def _generate_events_json(case_dir, output_case_dir, config):
         events = merge_subagent_transcripts(events, str(subagent_dir),
                                             result_cap=DEFAULT_RESULT_CAP)
 
+    _write_events_json(output_case_dir, events)
+
+
+def _find_otel_spans(output_case_dir, case_dir):
+    """Find otel_spans.json in output or workspace directories."""
+    for d in (output_case_dir, case_dir):
+        p = d / "otel_spans.json"
+        if p.exists():
+            return p
+    return None
+
+
+def _events_from_otel(otel_path, case_dir, config):
+    """Convert OTel spans to canonical event dicts."""
+    from agent_eval.otel.span_mapper import get_span_mapper
+    try:
+        data = json.loads(otel_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    resource_spans = data.get("resourceSpans", [])
+    if not resource_spans:
+        return None
+    mapper = get_span_mapper(config.runner.type)
+    api_bodies_dir = case_dir / ".work" / "otel-api-bodies"
+    return mapper.map_spans(
+        resource_spans,
+        api_bodies_dir=api_bodies_dir if api_bodies_dir.is_dir() else None,
+    )
+
+
+def _write_events_json(output_case_dir, events):
+    """Atomic write of events.json."""
     output_case_dir.mkdir(parents=True, exist_ok=True)
     dest = output_case_dir / "events.json"
     fd, tmp_path = tempfile.mkstemp(dir=str(output_case_dir), suffix=".tmp")

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -172,6 +172,7 @@ def main():
         config_path=str(Path(args.config).resolve()),
         project_root=str(Path.cwd()),
         model=model,
+        output_dir=output_dir,
     )
     log_dir = output_dir / "hooks"
 
@@ -352,6 +353,9 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
             case_data_out = case_outputs.get("data", {})
             merged_hook_data = {**global_data, **case_data_out}
 
+        case_output = output_dir / "cases" / case_id
+        case_output.mkdir(parents=True, exist_ok=True)
+
         result = runner.run_skill(
             skill_name=skill_name,
             args=case_args,
@@ -362,13 +366,13 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
             max_budget_usd=max_budget,
             timeout_s=timeout_s,
             extra_env=merged_env or None,
+            output_dir=case_output,
         )
     except Exception as exc:
         print(f"    → {case_id}: ERROR ({exc})", file=sys.stderr)
         result = None
         error_msg = str(exc)
     finally:
-        # Run after_each hooks (guaranteed, like after_all)
         if config and config.hooks and config.hooks.after_each and case_hook_env:
             log_dir = output_dir / "hooks"
             run_hooks_safe(config.hooks.after_each, env=case_hook_env,
@@ -393,8 +397,6 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
             f.write("\n")
         return case_id, failed_result
 
-    case_output = output_dir / "cases" / case_id
-    case_output.mkdir(parents=True, exist_ok=True)
     if result.stdout:
         (case_output / "stdout.log").write_text(result.stdout)
     if result.stderr:
@@ -402,6 +404,12 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
 
     # Save hook output data for judges
     save_hook_data(case_output, merged_hook_data)
+
+    # Copy OTel spans from workspace if the receiver wrote there
+    ws_otel = case_ws / "otel_spans.json"
+    if (ws_otel.exists() and not ws_otel.is_symlink()
+            and not (case_output / "otel_spans.json").exists()):
+        shutil.copy2(ws_otel, case_output / "otel_spans.json")
 
     if input_path.exists() and not input_path.is_symlink():
         shutil.copy2(input_path, case_output / "input.yaml")

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -175,13 +175,8 @@ def main():
                         link.parent.mkdir(parents=True, exist_ok=True)
                         link.symlink_to(sub.resolve())
 
-    # Generate tool interception hooks if inputs.tools configured
-    if config.inputs.tools:
-        _setup_tool_hooks(workspace, config)
-    else:
-        # Even without tool interception, set up SubagentStop hook
-        # to capture background agent transcripts for tracing.
-        _setup_subagent_only_hook(workspace, config)
+    # Runner-specific workspace configuration (hooks, permissions, config files)
+    _runner_setup(workspace, config)
 
     print(f"WORKSPACE: {workspace}")
     print(f"CASES: {len(case_dirs)}")
@@ -288,11 +283,8 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
                         link.parent.mkdir(parents=True, exist_ok=True)
                         link.symlink_to(sub.resolve())
 
-        # Set up hooks (tool interception + SubagentStop)
-        if config.inputs.tools:
-            _setup_tool_hooks(case_ws, config)
-        else:
-            _setup_subagent_only_hook(case_ws, config)
+        # Runner-specific workspace configuration
+        _runner_setup(case_ws, config)
 
         case_order.append({"case_id": case_id})
 
@@ -366,285 +358,23 @@ def _parse_file(path):
     return None
 
 
-def _expand_symlink_permissions(allow_list):
-    """Add resolved-path variants for permission patterns with symlinked dirs.
+def _runner_setup(workspace, config):
+    """Delegate workspace configuration to the runner implementation.
 
-    On macOS, /tmp is a symlink to /private/tmp.  Claude Code resolves file
-    paths to their canonical form before matching permission patterns, so
-    ``Write(/tmp/rfe-assess/**)`` won't match a write to the real path
-    ``/private/tmp/rfe-assess/...``.  This function detects such cases and
-    adds the resolved variant alongside the original.
+    Each runner writes its own config files, hooks, and permissions.
     """
-    extras = []
-    for pattern in allow_list:
-        m = re.match(r"(Write|Edit|Bash)\((.+)\)", pattern)
-        if not m:
-            continue
-        tool, glob_path = m.groups()
-        # Extract the directory prefix (everything before the first glob char)
-        prefix = re.split(r"[*?]", glob_path, maxsplit=1)[0].rstrip("/")
-        if not prefix or not prefix.startswith("/"):
-            continue
-        resolved = str(Path(prefix).resolve())
-        if resolved != prefix:
-            resolved_pattern = f"{tool}({glob_path.replace(prefix, resolved)})"
-            if resolved_pattern not in allow_list:
-                extras.append(resolved_pattern)
-    return allow_list + extras
-
-
-def _inject_env(settings, config):
-    """Inject execution.env into settings.json env block.
-
-    Values starting with ``$`` are resolved from ``os.environ``.
-    Missing env vars are silently omitted.  Literal values pass through.
-    """
-    if not config.execution.env:
+    from agent_eval.agent import RUNNERS
+    runner_cls = RUNNERS.get(config.runner.type)
+    if not runner_cls:
+        print(f"WARNING: unknown runner '{config.runner.type}', "
+              f"skipping workspace setup", file=sys.stderr)
         return
-    env_block = settings.setdefault("env", {})
-    for key, value in config.execution.env.items():
-        if isinstance(value, str) and value.startswith("$"):
-            resolved = os.environ.get(value[1:])
-            if resolved is not None:
-                env_block[key] = resolved
-        else:
-            env_block[key] = str(value)
-
-
-def _carry_over_permissions(settings):
-    """Copy project permissions (allow, deny, additionalDirectories) into settings."""
-    import json as _json
-
-    project_settings = Path.cwd() / ".claude" / "settings.json"
-    if not project_settings.exists():
-        return
-    try:
-        with open(project_settings) as f:
-            proj = _json.load(f)
-    except (_json.JSONDecodeError, OSError):
-        return
-
-    proj_perms = proj.get("permissions", {})
-    if proj_perms.get("allow"):
-        allow_list = _expand_symlink_permissions(list(proj_perms["allow"]))
-        settings.setdefault("permissions", {})["allow"] = allow_list
-    if proj_perms.get("deny"):
-        settings.setdefault("permissions", {})["deny"] = list(proj_perms["deny"])
-    if proj_perms.get("additionalDirectories"):
-        dirs = list(proj_perms["additionalDirectories"])
-        for d in list(dirs):
-            resolved = str(Path(d).resolve())
-            if resolved != d and resolved not in dirs:
-                dirs.append(resolved)
-        settings.setdefault("permissions", {}).setdefault(
-            "additionalDirectories", []
-        ).extend(dirs)
-
-
-def _merge_harness_permissions(settings, config):
-    """Merge eval.yaml permissions.allow into settings so named subagents
-    (which may not inherit --allowed-tools) receive the harness patterns."""
-    allow = (
-        (config.permissions or {}).get("allow")
-        if hasattr(config, "permissions")
-        else None
+    runner = runner_cls.from_config(config)
+    runner.setup_workspace(
+        workspace, config,
+        project_root=Path.cwd(),
+        interceptor_src=Path(__file__).parent / "tools.py",
     )
-    if not allow:
-        return
-    harness_allow = _expand_symlink_permissions(list(allow))
-    existing = settings.setdefault("permissions", {}).setdefault("allow", [])
-    for pattern in harness_allow:
-        if pattern not in existing:
-            existing.append(pattern)
-
-
-def _deep_merge(dst, src):
-    """Recursively merge src into dst. Lists are extended, dicts merged."""
-    for k, v in src.items():
-        if isinstance(v, dict) and isinstance(dst.get(k), dict):
-            _deep_merge(dst[k], v)
-        elif isinstance(v, list) and isinstance(dst.get(k), list):
-            dst[k].extend(v)
-        else:
-            dst[k] = v
-    return dst
-
-
-def _apply_runner_settings(settings, config):
-    """Merge eval.yaml `runner.settings` into the workspace settings dict.
-
-    Lets users add Claude Code settings (model defaults, env, MCP servers,
-    etc.) to a runner without forking the harness. Merged after harness
-    defaults so user overrides win for scalar keys; lists are extended.
-    """
-    user_settings = getattr(config.runner, "settings", None) or {}
-    if user_settings:
-        _deep_merge(settings, user_settings)
-
-
-def _setup_subagent_only_hook(workspace, config):
-    """Set up SubagentStop hook without tool interception.
-
-    When there are no inputs.tools, we still need the SubagentStop hook
-    to capture background agent transcripts for tracing. This creates
-    a minimal .claude/settings.json with just the hook and project
-    permissions.
-    """
-    import json as _json
-
-    settings_dir = workspace / ".claude"
-    settings_dir.mkdir(parents=True, exist_ok=True)
-
-    settings = {}
-
-    # Carry over project permissions (allow, deny, additionalDirectories)
-    _carry_over_permissions(settings)
-    _merge_harness_permissions(settings, config)
-
-    # Grant project root access
-    project_root = str(Path.cwd().resolve())
-    settings.setdefault("permissions", {}).setdefault(
-        "additionalDirectories", []
-    ).append(project_root)
-
-    # Add SubagentStop hook
-    from agent_eval.agent.stream_capture import setup_subagent_hook
-
-    subagent_dir = str((workspace / "subagents").resolve())
-    setup_subagent_hook(settings, subagent_dir)
-
-    # Inject execution.env into settings
-    _inject_env(settings, config)
-
-    # Apply user-provided runner.settings last so they can override defaults
-    _apply_runner_settings(settings, config)
-
-    with open(settings_dir / "settings.json", "w") as f:
-        _json.dump(settings, f, indent=2)
-
-    print("HOOKS: SubagentStop configured (subagent capture)")
-
-
-def _extract_tool_patterns(match_text):
-    """Extract tool name patterns from a natural language match description.
-
-    Looks for known tool names and patterns like mcp__*. This is a
-    heuristic — eval-run's agent can refine these to concrete patterns
-    at runtime by reading eval.md.
-    """
-    import re
-
-    patterns = []
-    # Known tool names
-    known_tools = [
-        "AskUserQuestion",
-        "Bash",
-        "Read",
-        "Write",
-        "Edit",
-        "Glob",
-        "Grep",
-        "Agent",
-        "Skill",
-    ]
-    for tool in known_tools:
-        if tool.lower() in match_text.lower():
-            patterns.append(tool)
-    # MCP tool patterns (mcp__something__*)
-    for m in re.finditer(r"(mcp__\w+(?:__\w+)*(?:\*)?)", match_text):
-        patterns.append(m.group(1))
-    # If nothing found, add "Bash" as fallback for script-based interception
-    if not patterns and ("script" in match_text.lower() or "api" in match_text.lower()):
-        patterns.append("Bash")
-    return patterns or ["*"]
-
-
-def _setup_tool_hooks(workspace, config):
-    """Generate settings.json and tool_handlers.yaml for tool interception."""
-    import json as _json
-
-    # Build handler config with resolved patterns
-    # The `match` field is natural language — for now, extract tool name
-    # patterns from it. eval-run's agent resolves complex matches to
-    # concrete patterns in tool_handlers.yaml before execution.
-    handlers = []
-    hook_matchers = set()
-    for tool_cfg in config.inputs.tools:
-        handler = {"match": tool_cfg.match}
-        # Extract simple tool name patterns from match text
-        patterns = _extract_tool_patterns(tool_cfg.match)
-        handler["patterns"] = patterns
-        if tool_cfg.prompt:
-            handler["prompt"] = tool_cfg.prompt
-        if tool_cfg.prompt_file:
-            handler["prompt_file"] = tool_cfg.prompt_file
-        handlers.append(handler)
-        hook_matchers.update(patterns)
-
-    # Write tool_handlers.yaml
-    handler_data = {"handlers": handlers}
-    if config.models.hook:
-        handler_data["hook_model"] = config.models.hook
-    with open(workspace / "tool_handlers.yaml", "w") as f:
-        yaml.dump(handler_data, f, default_flow_style=False)
-
-    # Copy interceptor script
-    hooks_dir = workspace / "hooks"
-    hooks_dir.mkdir(exist_ok=True)
-    interceptor_src = Path(__file__).parent / "tools.py"
-    if interceptor_src.exists():
-        shutil.copy2(interceptor_src, hooks_dir / "tools.py")
-
-    # Generate .claude/settings.json with PreToolUse hooks
-    # Don't overwrite if symlinked from project — create alongside
-    settings_dir = workspace / ".claude"
-    settings_dir.mkdir(parents=True, exist_ok=True)
-
-    settings = {"hooks": {"PreToolUse": []}}
-    for matcher in sorted(hook_matchers):
-        settings["hooks"]["PreToolUse"].append(
-            {
-                "matcher": matcher,
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": f"python3 {workspace}/hooks/tools.py",
-                    }
-                ],
-            }
-        )
-
-    # Carry over permissions (allow, deny, additionalDirectories)
-    _carry_over_permissions(settings)
-
-    _merge_harness_permissions(settings, config)
-
-    # Grant access to the project root so symlinked resources (skills,
-    # scripts, context) can be read by the sandbox.
-    project_root = str(Path.cwd().resolve())
-    settings.setdefault("permissions", {}).setdefault(
-        "additionalDirectories", []
-    ).append(project_root)
-
-    # Add SubagentStop hook to capture background agent transcripts.
-    # The hook copies each subagent's .jsonl file to workspace/subagents/.
-    # Requires session persistence ON (the runner must NOT pass
-    # --no-session-persistence) so transcript files survive until the hook fires.
-    from agent_eval.agent.stream_capture import setup_subagent_hook
-
-    subagent_dir = str((workspace / "subagents").resolve())
-    setup_subagent_hook(settings, subagent_dir)
-
-    # Inject execution.env into settings
-    _inject_env(settings, config)
-
-    # Apply user-provided runner.settings last so they can override defaults
-    _apply_runner_settings(settings, config)
-
-    with open(settings_dir / "settings.json", "w") as f:
-        _json.dump(settings, f, indent=2)
-
-    print(f"HOOKS: {len(hook_matchers)} tool interceptors configured")
 
 
 if __name__ == "__main__":

--- a/tests/e2e/fixtures/otel-smoke-cases/math-001/input.yaml
+++ b/tests/e2e/fixtures/otel-smoke-cases/math-001/input.yaml
@@ -1,0 +1,2 @@
+prompt: "What is 2+2? Reply with just the number, nothing else."
+expected: "4"

--- a/tests/e2e/fixtures/otel-smoke-cases/math-002/input.yaml
+++ b/tests/e2e/fixtures/otel-smoke-cases/math-002/input.yaml
@@ -1,0 +1,2 @@
+prompt: "What is the capital of France? Reply with just the city name, nothing else."
+expected: "Paris"

--- a/tests/e2e/fixtures/otel-smoke-opencode-cases/math-001/input.yaml
+++ b/tests/e2e/fixtures/otel-smoke-opencode-cases/math-001/input.yaml
@@ -1,0 +1,2 @@
+prompt: "What is 2+2? Reply with just the number, nothing else."
+expected: "4"

--- a/tests/e2e/fixtures/otel-smoke-opencode-cases/math-002/input.yaml
+++ b/tests/e2e/fixtures/otel-smoke-opencode-cases/math-002/input.yaml
@@ -1,0 +1,2 @@
+prompt: "What is the capital of France? Reply with just the city name, nothing else."
+expected: "Paris"

--- a/tests/e2e/test_otel_mlflow.py
+++ b/tests/e2e/test_otel_mlflow.py
@@ -1,0 +1,246 @@
+"""E2E tests for OTel traces landing in MLflow.
+
+Validates the full pipeline: agent → OTel (protobuf) → MLflow OTLP endpoint
+→ traces queryable via MLflow API. Also verifies that OTel-derived data
+matches what the local JSON receiver captures for judges.
+
+Requires: ANTHROPIC_API_KEY, local mlflow server (started by fixture).
+Run with: python3 -m pytest tests/e2e/test_otel_mlflow.py -v -s -m e2e
+"""
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.e2e
+
+FIXTURES = Path(__file__).parent / "fixtures"
+CASES_DIR = FIXTURES / "otel-smoke-cases"
+
+
+@pytest.fixture(scope="module")
+def mlflow_server():
+    """Start a local MLflow server for the test module."""
+    tmpdir = tempfile.mkdtemp()
+    db_uri = f"sqlite:///{tmpdir}/mlflow.db"
+    port = 5199
+
+    proc = subprocess.Popen(
+        ["mlflow", "server",
+         "--backend-store-uri", db_uri,
+         "--host", "127.0.0.1",
+         "--port", str(port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    # Wait for server to be ready
+    import urllib.request
+    for _ in range(30):
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=1)
+            break
+        except Exception:
+            time.sleep(0.5)
+    else:
+        proc.kill()
+        pytest.fail("MLflow server failed to start")
+
+    yield {
+        "url": f"http://127.0.0.1:{port}",
+        "port": port,
+        "db_uri": db_uri,
+    }
+
+    os.kill(proc.pid, signal.SIGTERM)
+    proc.wait(timeout=10)
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture
+def mlflow_experiment(mlflow_server):
+    """Create a fresh MLflow experiment for each test."""
+    import mlflow
+    mlflow.set_tracking_uri(mlflow_server["url"])
+    exp_name = f"otel-test-{int(time.time())}"
+    exp_id = mlflow.create_experiment(exp_name)
+    return exp_id
+
+
+def _load_case(case_id):
+    return yaml.safe_load((CASES_DIR / case_id / "input.yaml").read_text())
+
+
+class TestClaudeCodeMLflowTraces:
+    """Verify Claude Code OTel spans land in MLflow correctly."""
+
+    def test_traces_appear_in_mlflow(self, mlflow_server, mlflow_experiment):
+        """Agent OTel spans are ingested by MLflow OTLP endpoint."""
+        from agent_eval.agent import RUNNERS
+        from agent_eval.config import OTelConfig
+
+        case = _load_case("math-001")
+
+        runner_cls = RUNNERS["claude-code"]
+        # No OTel config on runner — we set env vars directly to point
+        # at MLflow's OTLP endpoint (protobuf, not our JSON receiver)
+        runner = runner_cls(effort="low")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "workspace"
+            workspace.mkdir()
+
+            # Inject OTel env vars pointing at MLflow
+            orig_env = os.environ.copy()
+            os.environ["OTEL_TRACES_EXPORTER"] = "otlp"
+            os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = mlflow_server["url"]
+            os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+            os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = \
+                f"x-mlflow-experiment-id={mlflow_experiment}"
+            os.environ["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+            os.environ["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
+            os.environ["OTEL_LOG_USER_PROMPTS"] = "1"
+            os.environ["OTEL_LOG_TOOL_DETAILS"] = "1"
+
+            try:
+                result = runner.run_skill(
+                    skill_name="",
+                    args=case["prompt"],
+                    workspace=workspace,
+                    model="sonnet",
+                    timeout_s=60,
+                )
+            finally:
+                # Restore env
+                os.environ.clear()
+                os.environ.update(orig_env)
+
+            assert result.exit_code == 0
+            assert case["expected"].lower() in result.stdout.lower()
+
+            # Wait for BatchSpanProcessor flush + MLflow ingestion
+            time.sleep(3)
+
+            # Query MLflow for traces
+            import mlflow
+            mlflow.set_tracking_uri(mlflow_server["url"])
+            traces = mlflow.search_traces(
+                experiment_ids=[mlflow_experiment],
+            )
+            assert len(traces) > 0, "No traces found in MLflow"
+
+    def test_mlflow_traces_have_spans(self, mlflow_server, mlflow_experiment):
+        """MLflow traces contain expected span structure."""
+        from agent_eval.agent import RUNNERS
+
+        case = _load_case("math-002")
+
+        runner_cls = RUNNERS["claude-code"]
+        runner = runner_cls(effort="low")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "workspace"
+            workspace.mkdir()
+
+            orig_env = os.environ.copy()
+            os.environ["OTEL_TRACES_EXPORTER"] = "otlp"
+            os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = mlflow_server["url"]
+            os.environ["OTEL_EXPORTER_OTLP_PROTOCOL"] = "http/protobuf"
+            os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = \
+                f"x-mlflow-experiment-id={mlflow_experiment}"
+            os.environ["CLAUDE_CODE_ENABLE_TELEMETRY"] = "1"
+            os.environ["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] = "1"
+            os.environ["OTEL_LOG_USER_PROMPTS"] = "1"
+            os.environ["OTEL_LOG_TOOL_DETAILS"] = "1"
+
+            try:
+                result = runner.run_skill(
+                    skill_name="",
+                    args=case["prompt"],
+                    workspace=workspace,
+                    model="sonnet",
+                    timeout_s=60,
+                )
+            finally:
+                os.environ.clear()
+                os.environ.update(orig_env)
+
+            assert result.exit_code == 0
+
+            time.sleep(3)
+
+            import mlflow
+            from mlflow import MlflowClient
+
+            mlflow.set_tracking_uri(mlflow_server["url"])
+            client = MlflowClient()
+            traces = mlflow.search_traces(
+                experiment_ids=[mlflow_experiment],
+            )
+            assert len(traces) > 0
+
+            # Get trace details
+            trace_id = traces.iloc[0]["trace_id"]
+            trace = client.get_trace(trace_id)
+            assert trace is not None
+
+    def test_otel_and_stream_json_agree(self, mlflow_server, mlflow_experiment):
+        """OTel tokens/turns match stream-json extraction."""
+        from agent_eval.agent import RUNNERS
+        from agent_eval.config import OTelConfig
+        from agent_eval.otel.span_mapper import get_span_mapper
+
+        case = _load_case("math-001")
+
+        runner_cls = RUNNERS["claude-code"]
+        otel = OTelConfig(enabled=True, content=True)
+        runner = runner_cls(otel_config=otel, effort="low", log_prefix="e2e")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "workspace"
+            workspace.mkdir()
+            output_dir = Path(tmpdir) / "output"
+            output_dir.mkdir()
+
+            # Also set MLflow OTLP env vars (agent exports to BOTH
+            # our JSON receiver via runner OTel config AND MLflow via env)
+            orig_env = os.environ.copy()
+            os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = \
+                f"x-mlflow-experiment-id={mlflow_experiment}"
+
+            try:
+                result = runner.run_skill(
+                    skill_name="",
+                    args=case["prompt"],
+                    workspace=workspace,
+                    model="sonnet",
+                    timeout_s=60,
+                    output_dir=output_dir,
+                )
+            finally:
+                os.environ.clear()
+                os.environ.update(orig_env)
+
+            assert result.exit_code == 0
+
+            # Local OTel receiver data
+            otel_path = output_dir / "otel_spans.json"
+            assert otel_path.exists()
+
+            resource_spans = json.loads(otel_path.read_text()).get("resourceSpans", [])
+            mapper = get_span_mapper("claude-code")
+            otel_usage = mapper.extract_usage(resource_spans)
+
+            # Stream-json data (from RunResult)
+            assert result.token_usage is not None
+            assert otel_usage["token_usage"]["input"] == result.token_usage["input"]
+            assert otel_usage["token_usage"]["output"] == result.token_usage["output"]
+            assert otel_usage["num_turns"] == result.num_turns

--- a/tests/e2e/test_otel_smoke.py
+++ b/tests/e2e/test_otel_smoke.py
@@ -1,0 +1,217 @@
+"""E2E smoke tests for OTel trace capture with Claude Code and OpenCode.
+
+These tests invoke real API calls and are skipped by default.
+Run with: python3 -m pytest tests/e2e/test_otel_smoke.py -v -s -m e2e
+
+Claude Code test requires ANTHROPIC_API_KEY.
+OpenCode test requires GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent_eval.agent import RUNNERS
+from agent_eval.config import EvalConfig, OTelConfig, RunnerConfig
+from agent_eval.otel.span_mapper import get_span_mapper, parse_opencode_events
+
+pytestmark = pytest.mark.e2e
+
+FIXTURES = Path(__file__).parent / "fixtures"
+CASES_DIR = FIXTURES / "otel-smoke-cases"
+OPENCODE_CASES_DIR = FIXTURES / "otel-smoke-opencode-cases"
+
+
+def _load_case(cases_dir, case_id):
+    return yaml.safe_load((cases_dir / case_id / "input.yaml").read_text())
+
+
+class TestClaudeCodeOTel:
+    """Validate OTel pipeline: receiver → spans → ClaudeCodeSpanMapper → events."""
+
+    def test_otel_spans_captured(self):
+        """Claude Code exports OTel spans that the receiver collects."""
+        runner_cls = RUNNERS["claude-code"]
+        otel = OTelConfig(enabled=True, content=True)
+        runner = runner_cls(otel_config=otel, effort="low")
+
+        case = _load_case(CASES_DIR, "math-001")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "workspace"
+            workspace.mkdir()
+            output_dir = Path(tmpdir) / "output"
+            output_dir.mkdir()
+
+            result = runner.run_skill(
+                skill_name="",
+                args=case["prompt"],
+                workspace=workspace,
+                model="sonnet",
+                timeout_s=60,
+                output_dir=output_dir,
+            )
+
+            assert result.exit_code == 0
+            assert case["expected"].lower() in result.stdout.lower()
+
+            otel_path = output_dir / "otel_spans.json"
+            assert otel_path.exists(), "otel_spans.json not written"
+
+            data = json.loads(otel_path.read_text())
+            resource_spans = data.get("resourceSpans", [])
+            assert len(resource_spans) > 0, "No ResourceSpans received"
+
+    def test_span_mapper_produces_events(self):
+        """ClaudeCodeSpanMapper converts spans to canonical event format."""
+        runner_cls = RUNNERS["claude-code"]
+        otel = OTelConfig(enabled=True, content=True)
+        runner = runner_cls(otel_config=otel, effort="low")
+
+        case = _load_case(CASES_DIR, "math-002")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "workspace"
+            workspace.mkdir()
+            output_dir = Path(tmpdir) / "output"
+            output_dir.mkdir()
+
+            result = runner.run_skill(
+                skill_name="",
+                args=case["prompt"],
+                workspace=workspace,
+                model="sonnet",
+                timeout_s=60,
+                output_dir=output_dir,
+            )
+
+            assert result.exit_code == 0
+
+            otel_path = output_dir / "otel_spans.json"
+            resource_spans = json.loads(otel_path.read_text()).get("resourceSpans", [])
+
+            mapper = get_span_mapper("claude-code")
+            events = mapper.map_spans(resource_spans)
+            usage = mapper.extract_usage(resource_spans)
+
+            assert len(events) >= 2, f"Expected >=2 events, got {len(events)}"
+
+            types = [e["type"] for e in events]
+            assert "system" in types
+            assert "result" in types
+
+            assert usage["num_turns"] >= 1
+            assert usage["resolved_model"] is not None
+            assert usage["token_usage"]["input"] > 0
+            assert usage["token_usage"]["output"] > 0
+
+    def test_otel_usage_matches_stream_json(self):
+        """OTel-extracted token counts match stream-json extraction."""
+        runner_cls = RUNNERS["claude-code"]
+        otel = OTelConfig(enabled=True, content=True)
+        runner = runner_cls(otel_config=otel, effort="low", log_prefix="e2e")
+
+        case = _load_case(CASES_DIR, "math-001")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "workspace"
+            workspace.mkdir()
+            output_dir = Path(tmpdir) / "output"
+            output_dir.mkdir()
+
+            result = runner.run_skill(
+                skill_name="",
+                args=case["prompt"],
+                workspace=workspace,
+                model="sonnet",
+                timeout_s=60,
+                output_dir=output_dir,
+            )
+
+            assert result.exit_code == 0
+
+            otel_path = output_dir / "otel_spans.json"
+            resource_spans = json.loads(otel_path.read_text()).get("resourceSpans", [])
+            mapper = get_span_mapper("claude-code")
+            otel_usage = mapper.extract_usage(resource_spans)
+
+            assert otel_usage["token_usage"]["input"] == result.token_usage["input"]
+            assert otel_usage["token_usage"]["output"] == result.token_usage["output"]
+            assert otel_usage["num_turns"] == result.num_turns
+
+
+@pytest.mark.skipif(
+    not os.environ.get("GOOGLE_CLOUD_PROJECT"),
+    reason="GOOGLE_CLOUD_PROJECT not set",
+)
+class TestOpenCodeOTel:
+    """Validate OpenCode runner with JSON event fallback."""
+
+    def test_json_events_extracted(self):
+        """OpenCode JSON stdout events are parsed into canonical format."""
+        runner_cls = RUNNERS["opencode"]
+        otel = OTelConfig(enabled=True)
+        runner = runner_cls(otel_config=otel)
+
+        case = _load_case(OPENCODE_CASES_DIR, "math-001")
+        model = "google-vertex-anthropic/claude-sonnet-4-6@default"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "workspace"
+            workspace.mkdir()
+            output_dir = Path(tmpdir) / "output"
+            output_dir.mkdir()
+
+            result = runner.run_skill(
+                skill_name="",
+                args=case["prompt"],
+                workspace=workspace,
+                model=model,
+                timeout_s=60,
+                output_dir=output_dir,
+            )
+
+            assert result.exit_code == 0
+            assert case["expected"].lower() in result.stdout.lower()
+
+            events = parse_opencode_events(result.stdout)
+            assert len(events) >= 2
+
+            types = [e["type"] for e in events]
+            assert "assistant" in types
+            assert "result" in types
+
+    def test_usage_extracted_from_events(self):
+        """Token usage and cost are extracted from step_finish events."""
+        runner_cls = RUNNERS["opencode"]
+        otel = OTelConfig(enabled=True)
+        runner = runner_cls(otel_config=otel)
+
+        case = _load_case(OPENCODE_CASES_DIR, "math-002")
+        model = "google-vertex-anthropic/claude-sonnet-4-6@default"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "workspace"
+            workspace.mkdir()
+            output_dir = Path(tmpdir) / "output"
+            output_dir.mkdir()
+
+            result = runner.run_skill(
+                skill_name="",
+                args=case["prompt"],
+                workspace=workspace,
+                model=model,
+                timeout_s=60,
+                output_dir=output_dir,
+            )
+
+            assert result.exit_code == 0
+            assert result.cost_usd is not None and result.cost_usd > 0
+            assert result.num_turns is not None and result.num_turns >= 1
+            assert result.token_usage is not None
+            assert result.token_usage["output"] > 0

--- a/tests/test_opencode_runner.py
+++ b/tests/test_opencode_runner.py
@@ -1,0 +1,103 @@
+"""Tests for the OpenCode runner."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent_eval.agent.opencode import OpenCodeRunner
+from agent_eval.config import EvalConfig, OTelConfig, RunnerConfig
+
+
+class TestOpenCodeRunnerConfig:
+
+    def test_from_config(self, tmp_path):
+        config_yaml = tmp_path / "eval.yaml"
+        config_yaml.write_text("""
+name: test
+runner:
+  type: opencode
+  otel:
+    enabled: true
+""")
+        config = EvalConfig.from_yaml(config_yaml)
+        runner = OpenCodeRunner.from_config(config)
+        assert runner.name == "opencode"
+
+    def test_name_property(self):
+        runner = OpenCodeRunner()
+        assert runner.name == "opencode"
+
+
+class TestOpenCodeRunnerEnv:
+
+    def test_build_env_inherits_full_env(self):
+        runner = OpenCodeRunner()
+        with patch.dict("os.environ", {"PATH": "/bin", "HOME": "/home", "SECRET": "x"}):
+            env = runner._build_env(otel_port=None, workspace=Path("/tmp"))
+        assert "PATH" in env
+        assert "HOME" in env
+        assert "SECRET" in env
+
+    def test_build_env_extra_env_literal(self):
+        runner = OpenCodeRunner(env={"GCP_PROJECT": "my-project"})
+        with patch.dict("os.environ", {"PATH": "/bin"}, clear=True):
+            env = runner._build_env(otel_port=None, workspace=Path("/tmp"))
+        assert env["GCP_PROJECT"] == "my-project"
+
+    def test_build_env_extra_env_dollar_ref(self):
+        runner = OpenCodeRunner(env={"GCP_PROJECT": "$MY_PROJECT"})
+        with patch.dict("os.environ", {"PATH": "/bin", "MY_PROJECT": "resolved-project"}, clear=True):
+            env = runner._build_env(otel_port=None, workspace=Path("/tmp"))
+        assert env["GCP_PROJECT"] == "resolved-project"
+
+    def test_build_env_extra_env_dollar_ref_missing(self):
+        runner = OpenCodeRunner(env={"GCP_PROJECT": "$MISSING_VAR"})
+        with patch.dict("os.environ", {"PATH": "/bin"}, clear=True):
+            env = runner._build_env(otel_port=None, workspace=Path("/tmp"))
+        assert "GCP_PROJECT" not in env
+
+    def test_build_env_injects_otel(self):
+        otel = OTelConfig(enabled=True, resource_attributes={"env": "eval"})
+        runner = OpenCodeRunner(otel_config=otel)
+        with patch.dict("os.environ", {"PATH": "/bin"}, clear=True):
+            env = runner._build_env(otel_port=12345, workspace=Path("/tmp"))
+        assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://127.0.0.1:12345"
+        assert env["OTEL_EXPORTER_OTLP_PROTOCOL"] == "http/json"
+        assert env["OTEL_RESOURCE_ATTRIBUTES"] == "env=eval"
+
+    def test_build_env_no_otel_when_no_port(self):
+        otel = OTelConfig(enabled=True)
+        runner = OpenCodeRunner(otel_config=otel)
+        with patch.dict("os.environ", {"PATH": "/bin"}, clear=True):
+            env = runner._build_env(otel_port=None, workspace=Path("/tmp"))
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in env
+
+
+class TestOpenCodeRunnerProgress:
+
+    def test_extract_text_progress(self):
+        import json
+        line = json.dumps({"type": "text", "part": {"text": "Analyzing code..."}})
+        assert OpenCodeRunner._extract_progress(line) == "Analyzing code..."
+
+    def test_extract_tool_progress(self):
+        import json
+        line = json.dumps({"type": "tool_call", "name": "bash"})
+        assert OpenCodeRunner._extract_progress(line) == "Tool: bash"
+
+    def test_invalid_json_returns_empty(self):
+        assert OpenCodeRunner._extract_progress("not json") == ""
+
+    def test_long_text_skipped(self):
+        import json
+        line = json.dumps({"type": "text", "part": {"text": "x" * 200}})
+        assert OpenCodeRunner._extract_progress(line) == ""
+
+
+class TestOpenCodeRunnerRegistry:
+
+    def test_registered_in_runners(self):
+        from agent_eval.agent import RUNNERS
+        assert "opencode" in RUNNERS
+        assert RUNNERS["opencode"] is OpenCodeRunner

--- a/tests/test_otel_receiver.py
+++ b/tests/test_otel_receiver.py
@@ -1,0 +1,184 @@
+"""Tests for the in-process OTLP/HTTP receiver."""
+
+import json
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from agent_eval.otel.receiver import OTLPReceiver
+
+
+@pytest.fixture
+def receiver(tmp_path):
+    """Provide a started receiver that auto-stops after the test."""
+    r = OTLPReceiver(output_dir=tmp_path)
+    r.start()
+    yield r
+    try:
+        r.stop(flush_timeout_s=2)
+    except RuntimeError:
+        pass  # already stopped
+
+
+def _post_traces(endpoint, resource_spans):
+    """Send a /v1/traces POST with the given ResourceSpans list."""
+    payload = json.dumps({"resourceSpans": resource_spans}).encode()
+    req = urllib.request.Request(
+        f"{endpoint}/v1/traces",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        return resp.status
+
+
+def _make_resource_span(service_name="test", span_name="test.span"):
+    """Build a minimal OTLP ResourceSpans object."""
+    return {
+        "resource": {
+            "attributes": [
+                {"key": "service.name", "value": {"stringValue": service_name}},
+            ],
+        },
+        "scopeSpans": [{
+            "scope": {"name": "test"},
+            "spans": [{
+                "traceId": "0" * 32,
+                "spanId": "0" * 16,
+                "name": span_name,
+                "kind": 1,
+                "startTimeUnixNano": "1000000000",
+                "endTimeUnixNano": "2000000000",
+                "attributes": [],
+                "status": {},
+            }],
+        }],
+    }
+
+
+class TestOTLPReceiverLifecycle:
+
+    def test_start_assigns_port(self, tmp_path):
+        r = OTLPReceiver(output_dir=tmp_path)
+        port = r.start()
+        assert isinstance(port, int)
+        assert port > 0
+        r.stop()
+
+    def test_endpoint_property(self, receiver):
+        assert receiver.endpoint.startswith("http://127.0.0.1:")
+
+    def test_endpoint_before_start_raises(self, tmp_path):
+        r = OTLPReceiver(output_dir=tmp_path)
+        with pytest.raises(RuntimeError):
+            _ = r.endpoint
+
+    def test_stop_before_start_raises(self, tmp_path):
+        r = OTLPReceiver(output_dir=tmp_path)
+        with pytest.raises(RuntimeError):
+            r.stop()
+
+    def test_stop_writes_output_file(self, tmp_path):
+        r = OTLPReceiver(output_dir=tmp_path)
+        r.start()
+        path = r.stop()
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert "resourceSpans" in data
+
+    def test_stop_creates_output_dir(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "c"
+        r = OTLPReceiver(output_dir=nested)
+        r.start()
+        path = r.stop()
+        assert path.exists()
+
+
+class TestOTLPReceiverTraces:
+
+    def test_single_post(self, receiver, tmp_path):
+        rs = _make_resource_span()
+        status = _post_traces(receiver.endpoint, [rs])
+        assert status == 200
+        assert receiver.span_count == 1
+
+        path = receiver.stop()
+        data = json.loads(path.read_text())
+        assert len(data["resourceSpans"]) == 1
+        assert data["resourceSpans"][0]["resource"] == rs["resource"]
+
+    def test_multiple_posts(self, receiver, tmp_path):
+        for i in range(5):
+            _post_traces(receiver.endpoint, [_make_resource_span(span_name=f"span-{i}")])
+        assert receiver.span_count == 5
+
+        path = receiver.stop()
+        data = json.loads(path.read_text())
+        assert len(data["resourceSpans"]) == 5
+
+    def test_batch_post(self, receiver, tmp_path):
+        spans = [_make_resource_span(span_name=f"span-{i}") for i in range(3)]
+        _post_traces(receiver.endpoint, spans)
+        assert receiver.span_count == 3
+
+    def test_empty_resource_spans(self, receiver, tmp_path):
+        _post_traces(receiver.endpoint, [])
+        assert receiver.span_count == 0
+        path = receiver.stop()
+        data = json.loads(path.read_text())
+        assert data["resourceSpans"] == []
+
+    def test_concurrent_posts(self, receiver, tmp_path):
+        n = 20
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futs = [
+                pool.submit(_post_traces, receiver.endpoint,
+                            [_make_resource_span(span_name=f"span-{i}")])
+                for i in range(n)
+            ]
+            for f in futs:
+                assert f.result() == 200
+        assert receiver.span_count == n
+
+
+class TestOTLPReceiverErrors:
+
+    def test_wrong_path_returns_404(self, receiver):
+        req = urllib.request.Request(
+            f"{receiver.endpoint}/v1/metrics",
+            data=b'{}',
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req)
+        assert exc_info.value.code == 404
+
+    def test_wrong_content_type_returns_415(self, receiver):
+        req = urllib.request.Request(
+            f"{receiver.endpoint}/v1/traces",
+            data=b'\x00\x01\x02',
+            headers={"Content-Type": "application/x-protobuf"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req)
+        assert exc_info.value.code == 415
+
+    def test_invalid_json_returns_400(self, receiver):
+        req = urllib.request.Request(
+            f"{receiver.endpoint}/v1/traces",
+            data=b'not json',
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(req)
+        assert exc_info.value.code == 400
+
+    def test_span_count_zero_before_any_post(self, tmp_path):
+        r = OTLPReceiver(output_dir=tmp_path)
+        assert r.span_count == 0

--- a/tests/test_span_mapper.py
+++ b/tests/test_span_mapper.py
@@ -1,0 +1,302 @@
+"""Tests for OTel span-to-event mappers."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_eval.otel.span_mapper import (
+    ClaudeCodeSpanMapper,
+    OpenCodeSpanMapper,
+    get_span_mapper,
+    _nano_to_iso,
+    _get_attr,
+)
+
+
+def _attr(key, value):
+    """Build an OTLP attribute entry."""
+    if isinstance(value, bool):
+        return {"key": key, "value": {"boolValue": value}}
+    if isinstance(value, int):
+        return {"key": key, "value": {"intValue": value}}
+    if isinstance(value, float):
+        return {"key": key, "value": {"doubleValue": value}}
+    return {"key": key, "value": {"stringValue": str(value)}}
+
+
+def _span(name, span_id, parent_id=None, start_ns=1000000000,
+          end_ns=2000000000, attributes=None, events=None):
+    """Build an OTLP span dict."""
+    s = {
+        "traceId": "a" * 32,
+        "spanId": span_id,
+        "name": name,
+        "kind": 1,
+        "startTimeUnixNano": str(start_ns),
+        "endTimeUnixNano": str(end_ns),
+        "attributes": attributes or [],
+        "events": events or [],
+        "status": {},
+    }
+    if parent_id:
+        s["parentSpanId"] = parent_id
+    return s
+
+
+def _wrap_resource_spans(*spans):
+    """Wrap spans in a ResourceSpans structure."""
+    return [{
+        "resource": {"attributes": [_attr("service.name", "test")]},
+        "scopeSpans": [{"scope": {"name": "test"}, "spans": list(spans)}],
+    }]
+
+
+class TestHelpers:
+
+    def test_nano_to_iso(self):
+        assert _nano_to_iso("1000000000") == "1970-01-01T00:00:01.000Z"
+        assert _nano_to_iso(1000000000) == "1970-01-01T00:00:01.000Z"
+        assert _nano_to_iso(None) == ""
+        assert _nano_to_iso("invalid") == ""
+
+    def test_get_attr(self):
+        attrs = [
+            _attr("model", "opus"),
+            _attr("tokens", 100),
+            _attr("enabled", True),
+        ]
+        assert _get_attr(attrs, "model") == "opus"
+        assert _get_attr(attrs, "tokens") == 100
+        assert _get_attr(attrs, "enabled") is True
+        assert _get_attr(attrs, "missing") is None
+        assert _get_attr(attrs, "missing", "default") == "default"
+        assert _get_attr(None, "model") is None
+
+
+class TestClaudeCodeSpanMapper:
+
+    def test_empty_spans(self):
+        mapper = ClaudeCodeSpanMapper()
+        assert mapper.map_spans([]) == []
+
+    def test_system_init_event(self):
+        """First interaction span produces a system/init event."""
+        mapper = ClaudeCodeSpanMapper()
+        spans = _wrap_resource_spans(
+            _span("claude_code.interaction", "s1", start_ns=1000000000),
+            _span("claude_code.llm_request", "s2", parent_id="s1",
+                   start_ns=1100000000,
+                   attributes=[_attr("model", "claude-opus-4-6")]),
+        )
+        events = mapper.map_spans(spans)
+        init = [e for e in events if e["type"] == "system"]
+        assert len(init) == 1
+        assert init[0]["subtype"] == "init"
+        assert init[0]["model"] == "claude-opus-4-6"
+
+    def test_tool_span_produces_two_events(self):
+        """A tool span produces an assistant event (tool_use) and a tool_result."""
+        mapper = ClaudeCodeSpanMapper()
+        tool_output_event = {
+            "name": "tool.output",
+            "attributes": [
+                _attr("tool.input", json.dumps({"file_path": "/test.py"})),
+                _attr("tool.output", "file content here"),
+            ],
+        }
+        spans = _wrap_resource_spans(
+            _span("claude_code.interaction", "s1"),
+            _span("claude_code.tool", "s2", parent_id="s1",
+                   start_ns=1100000000, end_ns=1200000000,
+                   attributes=[_attr("tool_name", "Read")],
+                   events=[tool_output_event]),
+        )
+        events = mapper.map_spans(spans)
+        assistants = [e for e in events if e["type"] == "assistant" and e.get("tools")]
+        results = [e for e in events if e["type"] == "tool_result"]
+
+        assert len(assistants) == 1
+        assert assistants[0]["tools"][0]["name"] == "Read"
+        assert assistants[0]["tools"][0]["id"] == "s2"
+
+        assert len(results) == 1
+        assert results[0]["tool_use_id"] == "s2"
+        assert results[0]["tool_name"] == "Read"
+        assert results[0]["content"] == "file content here"
+        assert results[0]["is_error"] is False
+
+    def test_tool_error_detection(self):
+        """A failed tool execution sets is_error=True on the result."""
+        mapper = ClaudeCodeSpanMapper()
+        spans = _wrap_resource_spans(
+            _span("claude_code.interaction", "s1"),
+            _span("claude_code.tool", "s2", parent_id="s1",
+                   attributes=[_attr("tool_name", "Bash")]),
+            _span("claude_code.tool.execution", "s3", parent_id="s2",
+                   attributes=[_attr("success", False)]),
+        )
+        events = mapper.map_spans(spans)
+        results = [e for e in events if e["type"] == "tool_result"]
+        assert results[0]["is_error"] is True
+
+    def test_subagent_spans_tagged(self):
+        """Spans with agent_id get parent_tool_use_id tags."""
+        mapper = ClaudeCodeSpanMapper()
+        spans = _wrap_resource_spans(
+            _span("claude_code.interaction", "s1"),
+            _span("claude_code.tool", "s2", parent_id="s1",
+                   attributes=[
+                       _attr("tool_name", "Agent"),
+                       _attr("agent_id", "agent-1"),
+                       _attr("parent_agent_id", "main"),
+                   ]),
+        )
+        events = mapper.map_spans(spans)
+        tool_events = [e for e in events if e.get("agent_id")]
+        assert len(tool_events) >= 1
+        assert tool_events[0]["agent_id"] == "agent-1"
+
+    def test_result_event_appended(self):
+        """A synthetic result event is always appended."""
+        mapper = ClaudeCodeSpanMapper()
+        spans = _wrap_resource_spans(
+            _span("claude_code.interaction", "s1"),
+        )
+        events = mapper.map_spans(spans)
+        results = [e for e in events if e["type"] == "result"]
+        assert len(results) == 1
+
+    def test_extract_usage(self):
+        """Token usage is aggregated from llm_request spans."""
+        mapper = ClaudeCodeSpanMapper()
+        spans = _wrap_resource_spans(
+            _span("claude_code.llm_request", "s1",
+                   attributes=[
+                       _attr("model", "claude-opus-4-6"),
+                       _attr("input_tokens", 500),
+                       _attr("output_tokens", 200),
+                       _attr("cache_read_tokens", 100),
+                       _attr("cache_creation_tokens", 50),
+                       _attr("gen_ai.response.id", "msg-1"),
+                   ]),
+            _span("claude_code.llm_request", "s2",
+                   start_ns=2000000000,
+                   attributes=[
+                       _attr("model", "claude-opus-4-6"),
+                       _attr("input_tokens", 300),
+                       _attr("output_tokens", 100),
+                       _attr("gen_ai.response.id", "msg-2"),
+                   ]),
+        )
+        usage = mapper.extract_usage(spans)
+        assert usage["token_usage"]["input"] == 800
+        assert usage["token_usage"]["output"] == 300
+        assert usage["token_usage"]["cache_read"] == 100
+        assert usage["num_turns"] == 2
+        assert usage["resolved_model"] == "claude-opus-4-6"
+        assert usage["models_used"] == ["claude-opus-4-6"]
+        assert usage["per_model_turns"]["claude-opus-4-6"] == 2
+
+    def test_api_bodies_integration(self, tmp_path):
+        """Assistant text is extracted from API body response files."""
+        mapper = ClaudeCodeSpanMapper()
+        bodies_dir = tmp_path / "bodies"
+        bodies_dir.mkdir()
+        (bodies_dir / "001_response.json").write_text(json.dumps({
+            "id": "req-123",
+            "content": [
+                {"type": "text", "text": "Hello from Claude"},
+                {"type": "tool_use", "name": "Read", "id": "tu1"},
+            ],
+        }))
+
+        spans = _wrap_resource_spans(
+            _span("claude_code.interaction", "s1"),
+            _span("claude_code.llm_request", "s2", parent_id="s1",
+                   attributes=[
+                       _attr("request_id", "req-123"),
+                       _attr("model", "opus"),
+                       _attr("output_tokens", 50),
+                   ]),
+        )
+        events = mapper.map_spans(spans, api_bodies_dir=bodies_dir)
+        assistant_events = [e for e in events if e["type"] == "assistant"]
+        assert any("Hello from Claude" in e.get("text", "") for e in assistant_events)
+
+
+class TestOpenCodeSpanMapper:
+
+    def test_empty_spans(self):
+        mapper = OpenCodeSpanMapper()
+        assert mapper.map_spans([]) == []
+
+    def test_stream_text_span(self):
+        mapper = OpenCodeSpanMapper()
+        spans = _wrap_resource_spans(
+            _span("ai.streamText", "s1",
+                   attributes=[
+                       _attr("gen_ai.request.model", "claude-sonnet-4-6"),
+                       _attr("gen_ai.completion", "Here is the answer."),
+                       _attr("gen_ai.usage.input_tokens", 100),
+                       _attr("gen_ai.usage.output_tokens", 50),
+                   ]),
+        )
+        events = mapper.map_spans(spans)
+        init = [e for e in events if e["type"] == "system"]
+        assert init[0]["model"] == "claude-sonnet-4-6"
+
+        assistants = [e for e in events if e["type"] == "assistant"]
+        assert assistants[0]["text"] == "Here is the answer."
+
+    def test_tool_call_span(self):
+        mapper = OpenCodeSpanMapper()
+        spans = _wrap_resource_spans(
+            _span("ai.toolCall", "s1",
+                   start_ns=1000000000, end_ns=2000000000,
+                   attributes=[
+                       _attr("ai.toolCall.name", "bash"),
+                       _attr("ai.toolCall.id", "tc-1"),
+                       _attr("ai.toolCall.args", json.dumps({"command": "ls"})),
+                       _attr("ai.toolCall.result", "file1.txt\nfile2.txt"),
+                   ]),
+        )
+        events = mapper.map_spans(spans)
+        tool_events = [e for e in events if e["type"] == "assistant" and e.get("tools")]
+        assert tool_events[0]["tools"][0]["name"] == "bash"
+        assert tool_events[0]["tools"][0]["input"] == {"command": "ls"}
+
+        results = [e for e in events if e["type"] == "tool_result"]
+        assert results[0]["tool_name"] == "bash"
+        assert results[0]["content"] == "file1.txt\nfile2.txt"
+
+    def test_extract_usage(self):
+        mapper = OpenCodeSpanMapper()
+        spans = _wrap_resource_spans(
+            _span("ai.streamText", "s1",
+                   attributes=[
+                       _attr("gen_ai.request.model", "claude-sonnet-4-6"),
+                       _attr("gen_ai.usage.input_tokens", 200),
+                       _attr("gen_ai.usage.output_tokens", 100),
+                   ]),
+        )
+        usage = mapper.extract_usage(spans)
+        assert usage["token_usage"]["input"] == 200
+        assert usage["token_usage"]["output"] == 100
+        assert usage["num_turns"] == 1
+        assert usage["resolved_model"] == "claude-sonnet-4-6"
+
+
+class TestSpanMapperRegistry:
+
+    def test_get_claude_code_mapper(self):
+        mapper = get_span_mapper("claude-code")
+        assert isinstance(mapper, ClaudeCodeSpanMapper)
+
+    def test_get_opencode_mapper(self):
+        mapper = get_span_mapper("opencode")
+        assert isinstance(mapper, OpenCodeSpanMapper)
+
+    def test_unknown_type_defaults_to_claude(self):
+        mapper = get_span_mapper("unknown")
+        assert isinstance(mapper, ClaudeCodeSpanMapper)

--- a/tests/test_workspace_setup.py
+++ b/tests/test_workspace_setup.py
@@ -1,0 +1,252 @@
+"""Tests for runner-specific workspace setup."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_eval.agent.base import EvalRunner
+from agent_eval.agent.claude_code import ClaudeCodeRunner
+from agent_eval.agent.opencode import OpenCodeRunner
+from agent_eval.config import EvalConfig
+
+
+def _make_config(tmp_path, yaml_text):
+    """Write eval.yaml and return parsed config."""
+    p = tmp_path / "eval.yaml"
+    p.write_text(yaml_text)
+    return EvalConfig.from_yaml(p)
+
+
+class TestBaseRunnerNoOp:
+
+    def test_setup_workspace_is_noop(self, tmp_path):
+        """Base EvalRunner.setup_workspace does nothing."""
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, "name: test\n")
+
+        # Can't instantiate ABC directly, so check via a subclass
+        # that doesn't override setup_workspace
+        from agent_eval.agent.cli_runner import CliRunner
+        runner = CliRunner(command="echo test")
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        # No files created
+        assert not (ws / ".claude").exists()
+        assert not (ws / "opencode.json").exists()
+
+
+class TestClaudeCodeWorkspaceSetup:
+
+    def test_writes_settings_json(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, "name: test\n")
+
+        runner = ClaudeCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        settings_path = ws / ".claude" / "settings.json"
+        assert settings_path.exists()
+        settings = json.loads(settings_path.read_text())
+        assert "hooks" in settings
+
+    def test_subagent_hook_configured(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, "name: test\n")
+
+        runner = ClaudeCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        settings = json.loads((ws / ".claude" / "settings.json").read_text())
+        assert "SubagentStop" in settings.get("hooks", {})
+
+    def test_tool_hooks_when_inputs_tools(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, """
+name: test
+inputs:
+  tools:
+    - match: AskUserQuestion interactions
+      prompt: Answer yes
+""")
+
+        runner = ClaudeCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        settings = json.loads((ws / ".claude" / "settings.json").read_text())
+        assert "PreToolUse" in settings.get("hooks", {})
+        assert (ws / "tool_handlers.yaml").exists()
+
+    def test_tool_hooks_copies_interceptor(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        # Create a fake interceptor source
+        interceptor = tmp_path / "tools.py"
+        interceptor.write_text("# interceptor")
+
+        config = _make_config(tmp_path, """
+name: test
+inputs:
+  tools:
+    - match: Bash commands
+      prompt: Allow all
+""")
+
+        runner = ClaudeCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path,
+                               interceptor_src=interceptor)
+
+        assert (ws / "hooks" / "tools.py").exists()
+        assert (ws / "hooks" / "tools.py").read_text() == "# interceptor"
+
+    def test_project_root_in_additional_dirs(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, "name: test\n")
+
+        runner = ClaudeCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        settings = json.loads((ws / ".claude" / "settings.json").read_text())
+        dirs = settings.get("permissions", {}).get("additionalDirectories", [])
+        assert str(tmp_path.resolve()) in dirs
+
+    def test_harness_permissions_merged(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, """
+name: test
+permissions:
+  allow:
+    - Skill
+    - Agent
+""")
+
+        runner = ClaudeCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        settings = json.loads((ws / ".claude" / "settings.json").read_text())
+        allow = settings.get("permissions", {}).get("allow", [])
+        assert "Skill" in allow
+        assert "Agent" in allow
+
+    def test_env_injected(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, """
+name: test
+execution:
+  env:
+    MY_VAR: hello
+""")
+
+        runner = ClaudeCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        settings = json.loads((ws / ".claude" / "settings.json").read_text())
+        assert settings.get("env", {}).get("MY_VAR") == "hello"
+
+    def test_runner_settings_applied(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, """
+name: test
+runner:
+  type: claude-code
+  settings:
+    custom_key: custom_value
+""")
+
+        runner = ClaudeCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        settings = json.loads((ws / ".claude" / "settings.json").read_text())
+        assert settings.get("custom_key") == "custom_value"
+
+
+class TestOpenCodeWorkspaceSetup:
+
+    def test_writes_opencode_json(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, "name: test\nrunner:\n  type: opencode\n")
+
+        runner = OpenCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        assert (ws / "opencode.json").exists()
+        data = json.loads((ws / "opencode.json").read_text())
+        assert "$schema" in data
+
+    def test_denies_task(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, "name: test\nrunner:\n  type: opencode\n")
+
+        runner = OpenCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        data = json.loads((ws / "opencode.json").read_text())
+        assert data["permission"]["task"] == "deny"
+
+    def test_translates_deny_permissions(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, """
+name: test
+runner:
+  type: opencode
+permissions:
+  deny:
+    - mcp__atlassian
+""")
+
+        runner = OpenCodeRunner(permissions={"deny": ["mcp__atlassian"]})
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        data = json.loads((ws / "opencode.json").read_text())
+        assert data["permission"]["mcp__atlassian"] == "deny"
+
+    def test_includes_otel(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, """
+name: test
+runner:
+  type: opencode
+  otel:
+    enabled: true
+""")
+
+        from agent_eval.config import OTelConfig
+        runner = OpenCodeRunner(otel_config=OTelConfig(enabled=True))
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        data = json.loads((ws / "opencode.json").read_text())
+        assert data.get("experimental", {}).get("openTelemetry") is True
+
+    def test_no_otel_when_disabled(self, tmp_path):
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, "name: test\nrunner:\n  type: opencode\n")
+
+        runner = OpenCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        data = json.loads((ws / "opencode.json").read_text())
+        assert "experimental" not in data
+
+    def test_no_claude_settings(self, tmp_path):
+        """OpenCode should NOT write .claude/settings.json."""
+        ws = tmp_path / "workspace"
+        ws.mkdir()
+        config = _make_config(tmp_path, "name: test\nrunner:\n  type: opencode\n")
+
+        runner = OpenCodeRunner()
+        runner.setup_workspace(ws, config, project_root=tmp_path)
+
+        assert not (ws / ".claude" / "settings.json").exists()


### PR DESCRIPTION
## Summary

- Add OpenTelemetry-based trace capture as a universal instrumentation layer for agent evaluation
- Introduce OpenCode (anomalyco/opencode) as a new runner, validated end-to-end with rfe-creator skills on Vertex AI
- OTel spans from eval runs also land in MLflow via its OTLP endpoint, so eval and production tracing use the same data

## Changes

**OTel infrastructure** (`agent_eval/otel/`):
- `receiver.py`: Lightweight in-process OTLP/HTTP receiver (stdlib-only), collects spans per case into `otel_spans.json`
- `span_mapper.py`: `SpanMapper` ABC with `ClaudeCodeSpanMapper` and `OpenCodeSpanMapper` — converts runtime-specific OTel spans to canonical event format for judges
- `OTelConfig` dataclass in `config.py` with `runner.otel.enabled` (default: false)

**OpenCode runner** (`agent_eval/agent/opencode.py`):
- Invokes `opencode run --format json` with OTel and AI SDK telemetry enabled
- Extracts usage/cost from JSON stdout events (OTel span flush blocked by upstream bug: anomalyco/opencode#30087, fix submitted as anomalyco/opencode#30089)
- Supports `execution.env` with `$VAR` resolution for GCP credentials
- Discovers and invokes Agent Skills from `.claude/skills/`

**Pipeline integration**:
- `collect.py`: Prefers `otel_spans.json` over stream-json stdout when available; falls back to OpenCode JSON event parsing
- `execute.py`: Passes `output_dir` to runners, copies `otel_spans.json` to case output
- All runners updated with `output_dir` parameter on `run_skill()`
- ClaudeCodeRunner: OTel env keys in `_SAFE_ENV_KEYS`, receiver lifecycle wrapping `run_skill()`

## Test plan

- [x] 46 unit tests: OTLP receiver (lifecycle, concurrent POSTs, errors), span mappers (both runtimes, usage extraction, API body integration), OpenCode runner (config, env, progress)
- [x] 8 E2E tests: Claude Code OTel pipeline, OpenCode JSON events, MLflow OTLP ingestion, cross-source token count validation
- [x] Full rfe-creator eval run with OpenCode + Opus on Vertex AI: 20 cases → 24 RFEs (2 splits), all structurally valid
- [ ] Run full test suite: `python3 -m pytest tests/ -v --ignore=tests/e2e`
- [ ] Run E2E tests: `python3 -m pytest tests/e2e/ -v -s -m e2e` (requires API keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry tracing support for comprehensive trace capture during skill execution.
  * Introduced the new "opencode" runner type for executing OpenCode-based skills.
  * Added ability to export traces to output directories for artifact collection and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->