### PR TITLE
fix(eval-run): reflow soft-wrapped paragraphs in HTML report

### DIFF
--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1613,10 +1613,26 @@ def _md_to_html(md_text):
             i += 1
             continue
 
-        # Paragraph
+        # Paragraph — accumulate consecutive non-blank lines into a single
+        # <p> so that soft-wrapped source lines reflow to the container width
+        # instead of each becoming its own (artificially narrow) paragraph.
         _close_lists()
-        out.append(f"<p>{_inline(stripped)}</p>")
+        para_lines = [stripped]
         i += 1
+        while i < len(lines):
+            nxt = lines[i].strip()
+            if not nxt:
+                break
+            # Stop at anything that begins a different block-level construct.
+            if (nxt.startswith("```")
+                    or (nxt.startswith("|") and "|" in nxt[1:])
+                    or nxt.startswith(("### ", "## ", "# ", "- "))
+                    or re.match(r'^(\d+)\.\s(.+)', nxt)
+                    or nxt in ("---", "***", "___")):
+                break
+            para_lines.append(nxt)
+            i += 1
+        out.append(f"<p>{_inline(' '.join(para_lines))}</p>")
 
     _close_lists()
     return "\n".join(out)

--- a/tests/test_report_markdown.py
+++ b/tests/test_report_markdown.py
@@ -1,0 +1,65 @@
+"""Tests for the report markdown renderer (skills/eval-run/scripts/report.py).
+
+Focus: _md_to_html paragraph handling. Soft-wrapped source lines must be
+joined into a single <p> so analysis.md paragraphs reflow to the container
+width instead of each wrapped line becoming its own narrow paragraph.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "eval-run" / "scripts"))
+
+from report import _md_to_html
+
+
+def test_wrapped_paragraph_joins_into_single_p():
+    md = "This is a paragraph\nthat was hard-wrapped\nacross three lines."
+    html = _md_to_html(md)
+    assert html.count("<p>") == 1
+    assert "<p>This is a paragraph that was hard-wrapped across three lines.</p>" in html
+
+
+def test_blank_line_separates_paragraphs():
+    md = "First paragraph\nstill first.\n\nSecond paragraph\nstill second."
+    html = _md_to_html(md)
+    assert html.count("<p>") == 2
+    assert "<p>First paragraph still first.</p>" in html
+    assert "<p>Second paragraph still second.</p>" in html
+
+
+def test_single_line_paragraph_unchanged():
+    assert _md_to_html("Just one line.") == "<p>Just one line.</p>"
+
+
+def test_paragraph_stops_at_block_constructs():
+    # A paragraph immediately followed (no blank line) by each block type must
+    # not absorb that block.
+    md = (
+        "Lead paragraph here\n"
+        "wrapped a bit.\n"
+        "## A heading\n"
+        "Para before list\n"
+        "- item one\n"
+        "- item two\n"
+        "Para before table\n"
+        "| A | B |\n"
+        "|---|---|\n"
+        "| 1 | 2 |\n"
+    )
+    html = _md_to_html(md)
+    assert "<p>Lead paragraph here wrapped a bit.</p>" in html
+    assert "<h2>A heading</h2>" in html
+    assert "<p>Para before list</p>" in html
+    assert "<ul>" in html and "<li>item one</li>" in html
+    assert "<p>Para before table</p>" in html
+    assert "<table>" in html
+
+
+def test_paragraph_stops_at_fenced_code():
+    md = "Some prose\nthat wraps.\n```\ncode line\n```\n"
+    html = _md_to_html(md)
+    assert "<p>Some prose that wraps.</p>" in html
+    assert "code line" in html
+    assert html.count("<p>") == 1


### PR DESCRIPTION
## Summary

The HTML report's markdown renderer (`_md_to_html` in `report.py`) emitted one `<p>` per source line. Hard-wrapped paragraphs in `analysis.md` rendered as a stack of artificially narrow paragraphs instead of reflowing to the container width.

This change accumulates consecutive non-blank lines into a single `<p>`, stopping at any line that begins a different block-level construct (fenced code, table, heading, list, ordered list, horizontal rule) — mirroring the detection logic already used above in the same function.

## Test plan

Added `tests/test_report_markdown.py` covering:
- [x] Wrapped lines join into a single `<p>`
- [x] Blank lines still separate paragraphs
- [x] Single-line paragraphs unchanged
- [x] Paragraph accumulation stops at each block construct (heading, list, table)
- [x] Paragraph accumulation stops at fenced code

All 248 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Markdown paragraph rendering to merge soft-wrapped lines into single, reflowed paragraphs instead of treating each line separately
  * Better paragraph boundary detection before code blocks, headings, and lists

* **Tests**
  * Added comprehensive test coverage for Markdown-to-HTML paragraph formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->