### PR TITLE
fix(score): use final result text as conversation content for judges

### DIFF
--- a/agent_eval/events.py
+++ b/agent_eval/events.py
@@ -161,6 +161,7 @@ def _parse_user_tool_results(obj, tool_id_to_name, result_cap):
 def _parse_result_event(obj):
     return {
         "type": "result",
+        "text": obj.get("result", ""),   # final skill output text
         "cost_usd": obj.get("total_cost_usd"),
         "num_turns": obj.get("num_turns"),
         "timestamp": None,

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -196,9 +196,17 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
         record["events"] = []
 
     # --- Conversation text (convenience key for check judges) ---
+    # Prefer the result event's final output text over concatenating all
+    # intermediate assistant turns, which bloats the context with tool calls
+    # and reasoning text.
     if record["events"]:
         from agent_eval.events import extract_conversation_text
-        record["conversation"] = extract_conversation_text(record["events"])
+        result_events = [e for e in record["events"]
+                         if e.get("type") == "result" and e.get("text")]
+        if result_events:
+            record["conversation"] = result_events[-1]["text"]
+        else:
+            record["conversation"] = extract_conversation_text(record["events"])
     else:
         record["conversation"] = ""
 
@@ -485,7 +493,7 @@ _SCORE_SYSTEM_PROMPT = (
     "Return a JSON object with 'score' (integer 1-5) and 'rationale' (string).")
 
 
-def _call_judge_llm(prompt, model, system_prompt, images=None, max_tokens=1024):
+def _call_judge_llm(prompt, model, system_prompt, images=None, max_tokens=4096):
     """Call the Anthropic API with a judge prompt. Returns raw response text."""
     client = _get_anthropic_client()
     if images:
@@ -507,6 +515,10 @@ def _call_judge_llm(prompt, model, system_prompt, images=None, max_tokens=1024):
         system=system_prompt,
         messages=[{"role": "user", "content": user_message}],
     )
+    # Retry with doubled budget if the model hit the token limit mid-response.
+    if response.stop_reason == "max_tokens" and max_tokens < 16384:
+        return _call_judge_llm(prompt, model, system_prompt,
+                               images=images, max_tokens=max_tokens * 2)
     return response.content[0].text.strip()
 
 


### PR DESCRIPTION
Fixes #94

## Problem
Judges were receiving a concatenation of all assistant turns (tool calls, reasoning, intermediate outputs) instead of the final skill output.

## Changes
- `events.py`: extract `text` from the result event (`result.text`)
- `score.py`: prefer `result.text` over `extract_conversation_text()` when present

## Testing
Verified with sprint-health-check, sprint-planning, and sprint-retrospective skills — judges now score the final output text rather than intermediate tool calls.

<img width="1600" height="1000" alt="hc-07-span-detail" src="https://github.com/user-attachments/assets/1ec1cfea-9cbc-4680-8ef1-8830281b8c00" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Result events now include final skill output text for better visibility into evaluation results.
  * Enhanced conversation context extraction from event streams by prioritizing recent skill outputs.
  * Increased token budget for LLM judge responses to enable more detailed evaluations.
  * Added automatic retry mechanism for LLM responses that reach token limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->