### PR TITLE
fix(trace_builder): return server trace ID from _log_trace to fix FK failures

### DIFF
--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -857,8 +857,11 @@ def log_trace(trace_dict):
         client = MlflowClient()
         # No public API for logging pre-built traces as of MLflow 3.5.
         # _log_trace is the only way to submit a Trace object.
-        client._log_trace(trace)
-        return trace_dict["info"]["trace_id"]
+        # IMPORTANT: _log_trace returns a backend-generated trace ID that
+        # differs from the client-provided trace_dict["info"]["trace_id"].
+        # Always return the backend ID so downstream FK operations succeed.
+        server_trace_id = client._log_trace(trace)
+        return server_trace_id or trace_dict["info"]["trace_id"]
     except Exception as e:
         print(f"WARNING: failed to log trace: {e}", file=sys.stderr)
         return None

--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -861,7 +861,14 @@ def log_trace(trace_dict):
         # differs from the client-provided trace_dict["info"]["trace_id"].
         # Always return the backend ID so downstream FK operations succeed.
         server_trace_id = client._log_trace(trace)
-        return server_trace_id or trace_dict["info"]["trace_id"]
+        if not server_trace_id:
+            print(
+                "WARNING: _log_trace returned no backend ID; falling back to "
+                "client trace_id — downstream log_feedback may hit FK errors.",
+                file=sys.stderr,
+            )
+            return trace_dict["info"]["trace_id"]
+        return server_trace_id
     except Exception as e:
         print(f"WARNING: failed to log trace: {e}", file=sys.stderr)
         return None


### PR DESCRIPTION
Fixes #95

## Problem
`MlflowClient._log_trace()` returns a backend-generated trace ID that differs from the client-side ID. The return value was discarded, so `log_feedback` referenced an unknown ID and failed with `FOREIGN KEY constraint failed`.

## Change
Capture and return the server-generated trace ID:
```python
server_trace_id = client._log_trace(trace)
return server_trace_id or trace_dict["info"]["trace_id"]
```

## Testing
Verified that judge assessments now appear in the MLflow Quality tab after this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trace ID retrieval now returns the backend-generated identifier when available.
  * If the backend fails to produce an ID, a warning is emitted and the original trace ID is used as a fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->