### PR TITLE
fix(log_results): handle AsyncExportQueue rename in MLflow >=3.13

### DIFF
--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -264,12 +264,26 @@ def main():
                     print(f"TRACE: {main_trace_id} ({num_spans} spans, {duration_s:.0f}s)")
 
     # Flush async queue so traces are committed before linking/feedback.
+    # The class was renamed between MLflow versions:
+    #   <=3.12: AsyncExportQueue   >=3.13: AsyncTraceExportQueue
     if trace_ids:
-        try:
-            from mlflow.tracing.export.async_export_queue import AsyncExportQueue
-            AsyncExportQueue.get_instance().flush(timeout_sec=30)
-        except Exception as e:
-            print(f"WARNING: trace export flush failed: {e}", file=sys.stderr)
+        flushed = False
+        for _cls_name in ("AsyncTraceExportQueue", "AsyncExportQueue"):
+            try:
+                import importlib
+                _mod = importlib.import_module(
+                    "mlflow.tracing.export.async_export_queue"
+                )
+                _cls = getattr(_mod, _cls_name, None)
+                if _cls and hasattr(_cls, "get_instance"):
+                    _cls.get_instance().flush(timeout_sec=30)
+                    flushed = True
+                    break
+            except Exception:
+                pass
+        if not flushed:
+            import time
+            time.sleep(3)  # last-resort: give the async export time to finish
 
     if not main_trace_id and case_trace_map:
         main_trace_id = next(iter(case_trace_map.values()))


### PR DESCRIPTION
Fixes #96

## Problem
`AsyncExportQueue` was renamed to `AsyncTraceExportQueue` in MLflow 3.13. The hardcoded import silently failed, skipping the trace flush before `log_feedback` ran.

## Change
Try both class names; fall back to `time.sleep(3)` as a last resort.

## Testing
Verified on MLflow 3.5 (AsyncExportQueue) and 3.13+ (AsyncTraceExportQueue).

<img width="1600" height="1000" alt="hc-06-traces" src="https://github.com/user-attachments/assets/e3f1587f-5a68-4243-982e-087306a562ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced trace data export robustness with improved version compatibility and more resilient error handling for trace flushing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->