### PR TITLE
fix(trace_builder): populate mlflow.llm.cost and gateway.endpointId for cost charts

### DIFF
--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -733,18 +733,24 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
     # individual LLM spans grouped by mlflow.llm.model.  Distribute
     # each model's total cost evenly across its LLM spans so the
     # chart totals match run_result.per_model_usage.
+    #
+    # Fallback: when per_model_usage is absent (older Claude Code versions
+    # don't include modelUsage in the result event), distribute the total
+    # cost_usd evenly across all LLM spans so the Cost Over Time chart
+    # shows a non-zero value instead of $0.00.
+    llm_spans = [s for s in spans
+                 if s["attributes"].get("mlflow.spanType") == json.dumps("LLM")]
     if per_model_usage:
         # Count LLM spans per model
         model_span_counts = {}
-        for span in spans:
-            if span["attributes"].get("mlflow.spanType") == json.dumps("LLM"):
-                m = span["attributes"].get("mlflow.llm.model")
-                if m:
-                    try:
-                        m = json.loads(m)
-                    except (json.JSONDecodeError, TypeError):
-                        pass
-                    model_span_counts[m] = model_span_counts.get(m, 0) + 1
+        for span in llm_spans:
+            m = span["attributes"].get("mlflow.llm.model")
+            if m:
+                try:
+                    m = json.loads(m)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+                model_span_counts[m] = model_span_counts.get(m, 0) + 1
 
         # Build per-model cost-per-span
         # Normalize model names: per_model_usage keys may use "@"
@@ -761,19 +767,49 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
                 model_cost_per_span[normalized] = m_cost / m_count
 
         # Set mlflow.llm.cost on each LLM span
-        for span in spans:
-            if span["attributes"].get("mlflow.spanType") == json.dumps("LLM"):
-                m = span["attributes"].get("mlflow.llm.model")
-                if m:
-                    try:
-                        m = json.loads(m)
-                    except (json.JSONDecodeError, TypeError):
-                        pass
-                    per_span_cost = model_cost_per_span.get(m)
-                    if per_span_cost:
-                        span["attributes"]["mlflow.llm.cost"] = json.dumps({
-                            "total_cost": per_span_cost,
-                        })
+        spans_with_cost = 0
+        for span in llm_spans:
+            m = span["attributes"].get("mlflow.llm.model")
+            if m:
+                try:
+                    m = json.loads(m)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+                per_span_cost = model_cost_per_span.get(m)
+                if per_span_cost:
+                    span["attributes"]["mlflow.llm.cost"] = json.dumps({
+                        "total_cost": per_span_cost,
+                    })
+                    spans_with_cost += 1
+
+        # If per_model_usage was present but no spans matched (e.g. model name
+        # not captured in stream events), fall back to even distribution.
+        # Also inject mlflow.llm.model so the store populates dimension_attributes,
+        # which the Cost Breakdown chart groups by.
+        if spans_with_cost == 0 and cost_usd and llm_spans:
+            cost_per_span = cost_usd / len(llm_spans)
+            # Use first model from per_model_usage if there's exactly one
+            fallback_model = (
+                next(iter(per_model_usage)) if len(per_model_usage) == 1 else None
+            )
+            for span in llm_spans:
+                span["attributes"]["mlflow.llm.cost"] = json.dumps({
+                    "total_cost": cost_per_span,
+                })
+                if fallback_model and not span["attributes"].get("mlflow.llm.model"):
+                    span["attributes"]["mlflow.llm.model"] = json.dumps(fallback_model)
+
+    elif cost_usd and llm_spans:
+        # Fallback: no per-model breakdown — distribute total cost evenly
+        # across all LLM spans so Cost Over Time / Cost Breakdown populate.
+        cost_per_span = cost_usd / len(llm_spans)
+        fallback_model = model  # from run_result
+        for span in llm_spans:
+            span["attributes"]["mlflow.llm.cost"] = json.dumps({
+                "total_cost": cost_per_span,
+            })
+            if fallback_model and not span["attributes"].get("mlflow.llm.model"):
+                span["attributes"]["mlflow.llm.model"] = json.dumps(fallback_model)
 
     # ── Trace metadata ──────────────────────────────────────────
     trace_metadata = {}
@@ -795,6 +831,12 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
         })
     if session_id:
         trace_metadata["mlflow.trace.session"] = session_id
+    # Inject a synthetic gateway endpoint ID so that MLflow's "Cost Over Time"
+    # and "Cost Breakdown" charts (which join on mlflow.gateway.endpointId) can
+    # aggregate cost from our eval traces.  The value is namespaced to avoid
+    # collision with real AI Gateway endpoints.
+    if cost_usd:
+        trace_metadata["mlflow.gateway.endpointId"] = f"eval-harness/{run_id}"
 
     return {
         "info": {

--- a/tests/test_per_model_cost.py
+++ b/tests/test_per_model_cost.py
@@ -311,8 +311,8 @@ class TestModelNameNormalization:
         assert all(c is not None and c["total_cost"] > 0
                    for c in sonnet_costs)
 
-    def test_no_per_model_usage_no_span_cost(self, tmp_path):
-        """Without per_model_usage, LLM spans get no mlflow.llm.cost."""
+    def test_no_per_model_usage_cost_distributed_evenly(self, tmp_path):
+        """Without per_model_usage, cost_usd is distributed evenly across LLM spans."""
         events = [
             make_system_init(),
             make_assistant("msg_001", text="Hello."),
@@ -328,8 +328,14 @@ class TestModelNameNormalization:
         trace = build_trace(stdout, run_result,
                             run_id="test", experiment_id="exp-1")
         spans = trace["data"]["spans"]
-        for s in _get_llm_spans(spans):
-            assert "mlflow.llm.cost" not in s["attributes"]
+        llm_spans = _get_llm_spans(spans)
+        assert len(llm_spans) > 0, "expected at least one LLM span"
+        total_cost = sum(
+            json.loads(s["attributes"]["mlflow.llm.cost"])["total_cost"]
+            for s in llm_spans
+            if "mlflow.llm.cost" in s["attributes"]
+        )
+        assert total_cost == pytest.approx(1.00)
 
 
 class TestTraceCostMetadata:


### PR DESCRIPTION
Fixes #97

## Problem
MLflow Cost Breakdown and Cost Over Time charts showed $0.00 for all eval traces despite cost_usd being logged.

Two root causes:
1. `mlflow.gateway.endpointId` was never set — MLflow cost charts join on this field and silently exclude traces without it
2. When `per_model_usage` is absent (older Claude Code omits modelUsage), the `mlflow.llm.cost` distribution was skipped entirely

## Changes
- Inject `mlflow.gateway.endpointId = eval-harness/{run_id}` when cost_usd is present
- Add fallback distributing cost_usd evenly across LLM spans when per_model_usage is missing

## Testing
Verified Cost Breakdown donut and Cost Over Time charts now show non-zero values across 3 evaluated skills.
<img width="1600" height="1000" alt="hc-03-cost" src="https://github.com/user-attachments/assets/984120b2-901a-4775-9d0e-0b4c73209688" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate cost attribution and fallback distribution for model usage across evaluation traces, ensuring costs appear in MLflow “Cost Over Time” and “Cost Breakdown” charts.
  * Synthetic trace metadata added (when cost present) to enable aggregation and visibility of evaluation costs.

* **Tests**
  * Updated test expectations to require even distribution of run cost across spans when per-model usage is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->