### PR TITLE
feat: replace runner.env_strip with runner.env for additive env forwarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ skills/eval-check/ # Skill: full-harness configuration health check
 Skills projects create an `eval.yaml` config file with:
 - `skill` — skill to evaluate
 - `execution` — `mode` (`case` or `batch`), `arguments` template with `{field}` placeholders, optional `timeout`/`max_budget_usd`/`parallelism` (concurrent case execution), and `env` for injecting environment variables into workspaces (`$VAR` syntax resolves from caller's env)
-- `runner` — `type` discriminator (`claude-code`, etc.) plus runner-specific `effort`/`settings`/`plugin_dirs`/`env_strip`/`system_prompt`
+- `runner` — `type` discriminator (`claude-code`, etc.) plus runner-specific `effort`/`settings`/`plugin_dirs`/`env`/`system_prompt`
 - `models` — defaults for `skill`/`subagent`/`judge`/`hook` roles (CLI flags override). `hook` is the model for LLM-based AskUserQuestion answering.
 - `mlflow` — `experiment`, optional `tracking_uri`/`tags`
 - `permissions` — `allow`/`deny` tool patterns for headless execution

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ runner:
   # effort: high              # Reasoning effort: low | medium | high | xhigh | max
   # settings: {}              # Arbitrary Claude Code settings merged into workspace
   # plugin_dirs: []           # Directories to load plugins from
-  # env_strip: [JIRA_TOKEN]   # Env vars to strip from subprocess
+  # env: [CUSTOM_AUTH_TOKEN]   # Extra env var names to forward to subprocess
   # system_prompt: |          # Appended to Claude CLI system prompt
   #   Custom instructions for the skill run.
 
@@ -265,7 +265,7 @@ thresholds:
 - **`context`** — list of file paths loaded and appended to the LLM judge prompt as supplementary material (rubrics, guidelines, examples).
 - **`module`** / **`function`** — external Python code judge for complex validation.
 - **`permissions`** — tool access patterns (`allow`/`deny`) for headless execution. Generic across runners — each runner translates to its platform's mechanism.
-- **`runner`** — `type` discriminator selects the runner implementation; remaining fields (`effort`, `settings`, `plugin_dirs`, `env_strip`, `system_prompt`) are runner-specific and ignored by other runners.
+- **`runner`** — `type` discriminator selects the runner implementation; remaining fields (`effort`, `settings`, `plugin_dirs`, `env`, `system_prompt`) are runner-specific and ignored by other runners.
 - **`models`** — `skill`/`subagent`/`judge`/`hook` defaults, overridable per-judge or via CLI flags. `hook` is the model used for LLM-based AskUserQuestion answering.
 - **`mlflow`** — `experiment` (and optional `tracking_uri`/`tags`) for result logging.
 - **`thresholds`** — per-judge regression detection. Valid keys: `min_mean` (minimum average score), `min_pass_rate` (minimum fraction of cases passing, 0.0–1.0), `min_win_rate` (minimum pairwise win rate).

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -45,7 +45,7 @@ class ClaudeCodeRunner(EvalRunner):
         return cls(
             permissions=config.permissions,
             plugin_dirs=resolved_plugin_dirs,
-            env_strip=config.runner.env_strip,
+            env=config.runner.env,
             system_prompt=config.runner.system_prompt,
             subagent_model=overrides.get("subagent_model"),
             mlflow_experiment=overrides.get("mlflow_experiment"),
@@ -59,7 +59,7 @@ class ClaudeCodeRunner(EvalRunner):
         permissions: Optional[dict] = None,
         subagent_model: Optional[str] = None,
         plugin_dirs: Optional[list] = None,
-        env_strip: Optional[list] = None,
+        env: Optional[list] = None,
         system_prompt: Optional[str] = None,
         mlflow_experiment: Optional[str] = None,
         mlflow_tracking_uri: Optional[str] = None,
@@ -69,7 +69,7 @@ class ClaudeCodeRunner(EvalRunner):
         self._permissions = permissions or {}
         self._subagent_model = subagent_model
         self._plugin_dirs = plugin_dirs or []
-        self._env_strip = env_strip or []
+        self._env = env or []
         self._system_prompt = system_prompt
         self._mlflow_experiment = mlflow_experiment
         self._mlflow_tracking_uri = mlflow_tracking_uri
@@ -331,20 +331,22 @@ class ClaudeCodeRunner(EvalRunner):
     # Environment keys safe to forward to evaluated skills
     _SAFE_ENV_KEYS = {
         "PATH", "HOME", "USER", "SHELL", "LANG", "LC_ALL", "TERM",
-        "ANTHROPIC_API_KEY", "ANTHROPIC_VERTEX_PROJECT_ID", "CLOUD_ML_REGION",
-        "CLAUDE_CODE_USE_VERTEX",
+        "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL", "ANTHROPIC_VERTEX_PROJECT_ID",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL", "ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        "CLOUD_ML_REGION", "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_AUTO_COMPACT_WINDOW", "CLAUDE_CODE_SUBAGENT_MODEL",
         "GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT",
         "CLOUDSDK_CONFIG", "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
         "MLFLOW_TRACKING_URI", "MLFLOW_EXPERIMENT_NAME",
-        "CLAUDE_CODE_SUBAGENT_MODEL",
         "AGENT_EVAL_RUNS_DIR",
     }
 
     def _build_env(self):
         """Build subprocess environment with allowlisted keys only."""
-        env = {k: v for k, v in os.environ.items() if k in self._SAFE_ENV_KEYS}
-        for key in self._env_strip:
-            env.pop(key, None)
+        allowed = self._SAFE_ENV_KEYS | set(self._env)
+        env = {k: v for k, v in os.environ.items() if k in allowed}
         if self._subagent_model:
             env["CLAUDE_CODE_SUBAGENT_MODEL"] = self._subagent_model
         if self._mlflow_experiment:

--- a/agent_eval/agent/cli_runner.py
+++ b/agent_eval/agent/cli_runner.py
@@ -43,7 +43,6 @@ class CliRunner(EvalRunner):
         return cls(
             command=config.runner.command,
             env=config.execution.env,
-            env_strip=config.runner.env_strip,
             log_prefix=log_prefix,
             subagent_model=overrides.get("subagent_model"),
             effort=overrides.get("effort", config.runner.effort),
@@ -54,7 +53,6 @@ class CliRunner(EvalRunner):
         self,
         command: Union[str, list],
         env: Optional[dict] = None,
-        env_strip: Optional[list] = None,
         log_prefix: Optional[str] = None,
         subagent_model: Optional[str] = None,
         effort: Optional[str] = None,
@@ -70,7 +68,6 @@ class CliRunner(EvalRunner):
                 f"runner.command must be a string or list, got {type(command).__name__}")
         self._command = command
         self._extra_env = env or {}
-        self._env_strip = env_strip or []
         self._log_prefix = log_prefix
         self._subagent_model = subagent_model or ""
         self._effort = effort or ""
@@ -222,10 +219,8 @@ class CliRunner(EvalRunner):
         return _sub(self._command)
 
     def _build_env(self) -> dict:
-        """Build subprocess environment: inherit env, apply strip list, add extras."""
+        """Build subprocess environment: inherit env, add extras."""
         env = os.environ.copy()
-        for key in self._env_strip:
-            env.pop(key, None)
         for k, v in self._extra_env.items():
             if isinstance(v, str) and v.startswith("$"):
                 resolved = os.environ.get(v[1:])

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -134,12 +134,16 @@ class RunnerConfig:
     type: discriminator selecting the runner implementation (e.g. claude-code).
     Other fields are runner-specific; unused fields are harmless for runners
     that don't read them.
+
+    env: extra environment variable *names* to forward from the caller's
+    environment into the runner subprocess.  Additive to the runner's
+    built-in safe defaults (Claude Code allowlist).
     """
     type: str = "claude-code"
     command: Optional[Union[str, list]] = None  # CLI runner: command template
     settings: dict = field(default_factory=dict)
     plugin_dirs: list = field(default_factory=list)
-    env_strip: list = field(default_factory=list)
+    env: list = field(default_factory=list)
     system_prompt: Optional[str] = None
     effort: Optional[str] = None  # Claude Code: low | medium | high | xhigh | max
 
@@ -314,7 +318,7 @@ class EvalConfig:
             command=command,
             settings=runner_raw.get("settings", {}) or {},
             plugin_dirs=runner_raw.get("plugin_dirs", []) or [],
-            env_strip=runner_raw.get("env_strip", []) or [],
+            env=runner_raw.get("env", []) or [],
             system_prompt=runner_raw.get("system_prompt"),
             effort=runner_raw.get("effort"),
         )

--- a/agent_eval/evalhub/adapter.py
+++ b/agent_eval/evalhub/adapter.py
@@ -256,7 +256,7 @@ class AgentEvalAdapter(FrameworkAdapter):
                 permissions=eval_config.permissions,
                 system_prompt=eval_config.runner.system_prompt,
                 plugin_dirs=eval_config.runner.plugin_dirs,
-                env_strip=eval_config.runner.env_strip,
+                env=eval_config.runner.env,
                 effort=eval_config.runner.effort,
             )
 

--- a/docs/opaque-cli-runner-contract.md
+++ b/docs/opaque-cli-runner-contract.md
@@ -129,14 +129,13 @@ Judges get an `outputs` dict with these keys (all populated from the above sourc
 |---|---|---|
 | Inherits caller's env | Full `os.environ` (see security note below) | Filtered to safe allowlist |
 | `execution.env` vars | Injected via `_build_env()` with `$VAR` resolution | Injected into `.claude/settings.json` env block |
-| `runner.env_strip` | Strips named keys from subprocess env | Strips named keys from subprocess env |
+| `runner.env` | No effect (full env already inherited) | Forwards additional env var names on top of safe allowlist |
 
 **Security note on environment inheritance:** The opaque CLI runner inherits the
 full caller environment because commands are provided by the eval author (not
-untrusted input). Use `runner.env_strip` to remove sensitive keys (e.g.,
-`ANTHROPIC_API_KEY`) when the external command doesn't need them. The Claude Code
-runner uses a strict allowlist because it executes arbitrary agent-generated tool
-calls.
+untrusted input). The Claude Code runner uses a strict allowlist because it
+executes arbitrary agent-generated tool calls. Use `runner.env` to forward
+additional env vars (e.g., `ANTHROPIC_AUTH_TOKEN`) beyond the built-in defaults.
 
 ## Features that don't work with the opaque CLI runner
 

--- a/eval.yaml
+++ b/eval.yaml
@@ -26,7 +26,7 @@ runner:
   # effort: high                 # Reasoning effort: low | medium | high | xhigh | max
   # settings: {}                 # Claude Code settings merged into workspace
   # plugin_dirs: []              # Plugin dirs for sub-skills the evaluated skill calls
-  # env_strip: [JIRA_TOKEN]      # Env vars to remove from subprocess
+  # env: [CUSTOM_AUTH_TOKEN]      # Extra env var names to forward to subprocess
   # system_prompt: ""            # Appended to harness system prompt
 
 # Models — defaults for each role (CLI flags override)

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -47,7 +47,7 @@ runner:
   type: claude-code         # Discriminator: claude-code, opencode, etc.
   # settings: {}            # Runner-specific settings overrides
   # plugin_dirs: []         # Plugin dirs the evaluated skill needs
-  # env_strip: [JIRA_TOKEN] # Env vars to remove before launching the runner
+  # env: [CUSTOM_AUTH_TOKEN] # Extra env var names to forward to the runner
   # system_prompt: ""       # Appended to harness system prompt
   # effort: high            # Claude Code reasoning effort: low | medium | high | xhigh | max
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,7 +43,7 @@ runner:
   type: claude-code
   plugin_dirs:
     - /tmp/p
-  env_strip:
+  env:
     - FOO
   settings:
     a: 1
@@ -51,7 +51,7 @@ runner:
 """))
     assert cfg.runner.type == "claude-code"
     assert cfg.runner.plugin_dirs == ["/tmp/p"]
-    assert cfg.runner.env_strip == ["FOO"]
+    assert cfg.runner.env == ["FOO"]
     assert cfg.runner.settings == {"a": 1}
     assert cfg.runner.system_prompt == "be careful"
 


### PR DESCRIPTION
## Summary

- Replaces the subtractive `runner.env_strip` with an additive `runner.env` list — users can now forward additional env var names from the caller's environment into the runner subprocess
- Expands `_SAFE_ENV_KEYS` with common Claude Code vars: `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_DEFAULT_*_MODEL`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`
- Removes `env_strip` from the CLI runner entirely (it inherits the full environment by design)

Closes #103

## Test plan

- [x] All 294 unit tests pass
- [ ] Verify self-hosted setup works with `runner.env: [ANTHROPIC_AUTH_TOKEN, ANTHROPIC_BASE_URL]` in eval.yaml
- [ ] Verify existing eval.yaml configs without `runner.env` still work (empty default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)