### PR TITLE
fix(eval-run): validate baseline run-id exists in preflight check

### DIFF
--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -89,16 +89,18 @@ Before setting up the workspace, verify the project's artifact directories are c
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/scripts/preflight.py \
   --config <config> \
-  [--run-id <id>]
+  [--run-id <id>] \
+  [--baseline <baseline-id>]
 ```
 
-The script checks `tmp/` state files and whether `$AGENT_EVAL_RUNS_DIR/<eval-name>/<id>` already has results from a previous run.
+The script checks `tmp/` state files, whether `$AGENT_EVAL_RUNS_DIR/<eval-name>/<id>` already has results from a previous run, and (if `--baseline` is given) that the baseline run-id exists under the same eval-name directory.
 
 - **If `CLEAN`**: proceed to workspace setup.
 - **If `DIRTY`**: report the findings to the user and ask what to do:
   - **Force clean**: run `preflight.py --clean --force` to delete all stale artifacts, then proceed.
   - **Change run-id**: append a version suffix (e.g., `2026-04-11-opus-v2`) and re-check. This avoids overwriting previous run results but still requires cleaning project artifacts — re-run preflight with `--clean` and the new run-id.
   - **Abort**: let the user handle cleanup manually.
+- **If `MISSING_BASELINE` (exit 2)**: the baseline run-id wasn't found at `$AGENT_EVAL_RUNS_DIR/<eval-name>/<baseline>`. The script lists nearby run-ids — confirm the correct one with the user (typo, or did they mean a different date/variant?) before retrying.
 
 ## Step 3: Prepare Workspace
 

--- a/skills/eval-run/scripts/preflight.py
+++ b/skills/eval-run/scripts/preflight.py
@@ -17,6 +17,9 @@ Usage:
 
     # Also check if eval/runs/<id> already exists
     python3 ${CLAUDE_SKILL_DIR}/scripts/preflight.py --config eval.yaml --run-id 2026-04-11-opus
+
+    # Also verify a baseline run-id exists (exit 2 if not, lists nearby runs)
+    python3 ${CLAUDE_SKILL_DIR}/scripts/preflight.py --config eval.yaml --baseline 2026-04-10-opus
 """
 
 import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
@@ -65,12 +68,33 @@ def main():
                         help="Skip confirmation prompt (for non-interactive use)")
     parser.add_argument("--run-id", default=None,
                         help="Also check if eval/runs/<id> already exists")
+    parser.add_argument("--baseline", default=None,
+                        help="Verify the given baseline run-id exists before continuing")
     args = parser.parse_args()
 
     config = EvalConfig.from_yaml(args.config)
     project_root = Path.cwd()
     runs_base = Path(os.environ.get("AGENT_EVAL_RUNS_DIR", "eval/runs"))
     runs_dir = runs_base / config.skill if config.skill else runs_base
+
+    # 0. Baseline existence — fail fast before any expensive setup
+    if args.baseline:
+        baseline_path = project_root / runs_dir / args.baseline
+        if not (baseline_path.exists() and any(baseline_path.iterdir())):
+            print(f"MISSING_BASELINE: {runs_dir}/{args.baseline}", file=sys.stderr)
+            # List nearby runs to help typo recovery
+            runs_root = project_root / runs_dir
+            if runs_root.exists():
+                siblings = sorted(p.name for p in runs_root.iterdir() if p.is_dir())
+                if siblings:
+                    print(f"Available runs in {runs_dir}/:", file=sys.stderr)
+                    for s in siblings[-20:]:
+                        print(f"  {s}", file=sys.stderr)
+                else:
+                    print(f"No runs found in {runs_dir}/", file=sys.stderr)
+            else:
+                print(f"Runs directory does not exist: {runs_dir}/", file=sys.stderr)
+            sys.exit(2)
 
     dirty = {}  # path_label -> list of files
 

--- a/skills/eval-run/scripts/preflight.py
+++ b/skills/eval-run/scripts/preflight.py
@@ -80,11 +80,11 @@ def main():
     # 0. Baseline existence — fail fast before any expensive setup
     if args.baseline:
         baseline_path = project_root / runs_dir / args.baseline
-        if not (baseline_path.exists() and any(baseline_path.iterdir())):
+        if not (baseline_path.is_dir() and any(baseline_path.iterdir())):
             print(f"MISSING_BASELINE: {runs_dir}/{args.baseline}", file=sys.stderr)
             # List nearby runs to help typo recovery
             runs_root = project_root / runs_dir
-            if runs_root.exists():
+            if runs_root.is_dir():
                 siblings = sorted(p.name for p in runs_root.iterdir() if p.is_dir())
                 if siblings:
                     print(f"Available runs in {runs_dir}/:", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Adds `--baseline` argument to `preflight.py` that verifies a baseline run-id exists before expensive workspace setup
- Exits with code 2 (`MISSING_BASELINE`) if the baseline directory is missing or empty, listing up to 20 nearby run-ids for typo recovery
- Documents the new flag and exit status in `SKILL.md`

## Test plan
- [ ] Run `preflight.py --config eval.yaml --baseline <existing-id>` — should pass through normally
- [ ] Run `preflight.py --config eval.yaml --baseline nonexistent` — should exit 2, list available runs
- [ ] Run `preflight.py --config eval.yaml` without `--baseline` — behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `--baseline` flag to preflight checks for validating baseline run existence.
  * When baseline is missing, nearby available runs are listed as alternatives.

* **Documentation**
  * Updated preflight check documentation with new baseline flag usage and error handling details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->