### PR TITLE
fix(eval-run): include cache tokens in input token metric

### DIFF
--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1003,7 +1003,7 @@ def _render_model_usage(run_result, baseline_result=None):
         turns = usage.get("num_turns")
         total_in = inp + cr + cw
         total_tokens = total_in + out
-        if key == "input":         return inp or None
+        if key == "input":         return total_in or None
         if key == "output":        return out or None
         if key == "cache_read":    return cr or None
         if key == "cache_create":  return cw or None
@@ -1107,7 +1107,7 @@ def _render_model_usage(run_result, baseline_result=None):
         return ""
 
     metrics = [
-        ("Input tokens", "input"),
+        ("Input tokens (total)", "input"),
         ("Output tokens", "output"),
         ("Cache read", "cache_read"),
         ("Cache write", "cache_create"),


### PR DESCRIPTION
## Summary
- Fixes the "Input tokens" metric in the HTML report to include cache read and cache write tokens, reflecting actual total input cost
- Relabels the metric from "Input tokens" to "Input tokens (total)" for clarity

## Test plan
- [ ] Generate a report with `report.py` for a run that has cache usage — verify "Input tokens (total)" shows the sum of input + cache_read + cache_write
- [ ] Verify the baseline comparison column (if present) also reflects the corrected metric

🤖 Generated with [Claude Code](https://claude.com/claude-code)