### PR TITLE
feat: change runner.env from list to dict with $VAR resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ runner:
   # effort: high              # Reasoning effort: low | medium | high | xhigh | max
   # settings: {}              # Arbitrary Claude Code settings merged into workspace
   # plugin_dirs: []           # Directories to load plugins from
-  # env: [CUSTOM_AUTH_TOKEN]   # Extra env var names to forward to subprocess
+  # env:                       # Extra env vars for subprocess ($VAR resolves from caller)
+  #   CUSTOM_AUTH_TOKEN: "$CUSTOM_AUTH_TOKEN"
   # system_prompt: |          # Appended to Claude CLI system prompt
   #   Custom instructions for the skill run.
 

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -59,7 +59,7 @@ class ClaudeCodeRunner(EvalRunner):
         permissions: Optional[dict] = None,
         subagent_model: Optional[str] = None,
         plugin_dirs: Optional[list] = None,
-        env: Optional[list] = None,
+        env: Optional[dict] = None,
         system_prompt: Optional[str] = None,
         mlflow_experiment: Optional[str] = None,
         mlflow_tracking_uri: Optional[str] = None,
@@ -69,7 +69,7 @@ class ClaudeCodeRunner(EvalRunner):
         self._permissions = permissions or {}
         self._subagent_model = subagent_model
         self._plugin_dirs = plugin_dirs or []
-        self._env = env or []
+        self._env = env or {}
         self._system_prompt = system_prompt
         self._mlflow_experiment = mlflow_experiment
         self._mlflow_tracking_uri = mlflow_tracking_uri
@@ -345,8 +345,14 @@ class ClaudeCodeRunner(EvalRunner):
 
     def _build_env(self):
         """Build subprocess environment with allowlisted keys only."""
-        allowed = self._SAFE_ENV_KEYS | set(self._env)
-        env = {k: v for k, v in os.environ.items() if k in allowed}
+        env = {k: v for k, v in os.environ.items() if k in self._SAFE_ENV_KEYS}
+        for k, v in self._env.items():
+            if isinstance(v, str) and v.startswith("$"):
+                resolved = os.environ.get(v[1:])
+                if resolved is not None:
+                    env[k] = resolved
+            else:
+                env[k] = str(v)
         if self._subagent_model:
             env["CLAUDE_CODE_SUBAGENT_MODEL"] = self._subagent_model
         if self._mlflow_experiment:

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -347,6 +347,8 @@ class ClaudeCodeRunner(EvalRunner):
         """Build subprocess environment with allowlisted keys only."""
         env = {k: v for k, v in os.environ.items() if k in self._SAFE_ENV_KEYS}
         for k, v in self._env.items():
+            if v is None:
+                continue
             if isinstance(v, str) and v.startswith("$"):
                 resolved = os.environ.get(v[1:])
                 if resolved is not None:

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -135,15 +135,16 @@ class RunnerConfig:
     Other fields are runner-specific; unused fields are harmless for runners
     that don't read them.
 
-    env: extra environment variable *names* to forward from the caller's
-    environment into the runner subprocess.  Additive to the runner's
-    built-in safe defaults (Claude Code allowlist).
+    env: extra environment variables injected into the runner subprocess.
+    Keys are variable names, values are literal strings or ``$VAR``
+    references resolved from the caller's environment.  Additive to the
+    runner's built-in safe defaults (Claude Code allowlist).
     """
     type: str = "claude-code"
     command: Optional[Union[str, list]] = None  # CLI runner: command template
     settings: dict = field(default_factory=dict)
     plugin_dirs: list = field(default_factory=list)
-    env: list = field(default_factory=list)
+    env: dict = field(default_factory=dict)
     system_prompt: Optional[str] = None
     effort: Optional[str] = None  # Claude Code: low | medium | high | xhigh | max
 
@@ -318,7 +319,7 @@ class EvalConfig:
             command=command,
             settings=runner_raw.get("settings", {}) or {},
             plugin_dirs=runner_raw.get("plugin_dirs", []) or [],
-            env=runner_raw.get("env", []) or [],
+            env=runner_raw.get("env", {}) or {},
             system_prompt=runner_raw.get("system_prompt"),
             effort=runner_raw.get("effort"),
         )

--- a/docs/opaque-cli-runner-contract.md
+++ b/docs/opaque-cli-runner-contract.md
@@ -129,7 +129,7 @@ Judges get an `outputs` dict with these keys (all populated from the above sourc
 |---|---|---|
 | Inherits caller's env | Full `os.environ` (see security note below) | Filtered to safe allowlist |
 | `execution.env` vars | Injected via `_build_env()` with `$VAR` resolution | Injected into `.claude/settings.json` env block |
-| `runner.env` | No effect (full env already inherited) | Forwards additional env var names on top of safe allowlist |
+| `runner.env` | No effect (full env already inherited) | Injects explicit key/value pairs on top of safe allowlist (`$VAR` resolved from caller) |
 
 **Security note on environment inheritance:** The opaque CLI runner inherits the
 full caller environment because commands are provided by the eval author (not

--- a/eval.yaml
+++ b/eval.yaml
@@ -26,7 +26,8 @@ runner:
   # effort: high                 # Reasoning effort: low | medium | high | xhigh | max
   # settings: {}                 # Claude Code settings merged into workspace
   # plugin_dirs: []              # Plugin dirs for sub-skills the evaluated skill calls
-  # env: [CUSTOM_AUTH_TOKEN]      # Extra env var names to forward to subprocess
+  # env:                          # Extra env vars for subprocess ($VAR resolves from caller)
+  #   CUSTOM_AUTH_TOKEN: "$CUSTOM_AUTH_TOKEN"
   # system_prompt: ""            # Appended to harness system prompt
 
 # Models — defaults for each role (CLI flags override)

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -47,7 +47,8 @@ runner:
   type: claude-code         # Discriminator: claude-code, opencode, etc.
   # settings: {}            # Runner-specific settings overrides
   # plugin_dirs: []         # Plugin dirs the evaluated skill needs
-  # env: [CUSTOM_AUTH_TOKEN] # Extra env var names to forward to the runner
+  # env:                     # Extra env vars for the runner ($VAR resolves from caller)
+  #   CUSTOM_AUTH_TOKEN: "$CUSTOM_AUTH_TOKEN"
   # system_prompt: ""       # Appended to harness system prompt
   # effort: high            # Claude Code reasoning effort: low | medium | high | xhigh | max
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,14 +44,14 @@ runner:
   plugin_dirs:
     - /tmp/p
   env:
-    - FOO
+    FOO: "$FOO"
   settings:
     a: 1
   system_prompt: "be careful"
 """))
     assert cfg.runner.type == "claude-code"
     assert cfg.runner.plugin_dirs == ["/tmp/p"]
-    assert cfg.runner.env == ["FOO"]
+    assert cfg.runner.env == {"FOO": "$FOO"}
     assert cfg.runner.settings == {"a": 1}
     assert cfg.runner.system_prompt == "be careful"
 


### PR DESCRIPTION
## Summary

- Changes `runner.env` from a list of env var names to a dict of key/value pairs, enabling explicit values (e.g., pointing skills at a vLLM endpoint while judges use real Anthropic)
- Values starting with `$` are resolved from the caller's environment, matching the `execution.env` pattern
- `_SAFE_ENV_KEYS` still auto-forward from the caller's env as before

Example:
```yaml
runner:
  env:
    ANTHROPIC_BASE_URL: "https://my-vllm-server"
    ANTHROPIC_AUTH_TOKEN: "$VLLM_TOKEN"
```

Follow-up to #105.

## Test plan

- [x] All 294 unit tests pass
- [ ] Verify split self-hosted setup (vLLM for skills, real Anthropic for judges) works with explicit `runner.env` values
- [ ] Verify `$VAR` resolution works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variables now support explicit key-value mapping with variable resolution syntax (`$VAR`), replacing the previous list-based format.

* **Documentation**
  * Updated configuration examples and documentation to reflect the new environment variable specification format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->