### PR TITLE
feat: add `agent-eval run` CLI for deterministic eval execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,15 @@ agent_eval/              # Python package (config, runner, state)
     traces.py            # Trace search and input extraction
     trace_builder.py     # Hierarchical trace builder (stream-json → MLflow trace)
   cli/
+    eval_run.py          # agent-eval run CLI (deterministic eval pipeline)
     trace_run.py         # claude-trace CLI (standalone skill tracing)
+  run/
+    preflight.py         # Pre-run cleanup and validation
+    workspace.py         # Workspace creation, batch.yaml, symlinks
+    execute.py           # Skill execution via agent runner
+    collect.py           # Artifact collection + case mapping
+    score.py             # Scoring: inline checks, LLM judges, pairwise, regression
+    report.py            # HTML report generation (scoring summary, per-case details, diffs)
 
 skills/eval-setup/       # Skill: environment setup
   SKILL.md               # Dependencies, MLflow, API keys, directories
@@ -44,14 +52,9 @@ skills/eval-analyze/     # Skill: bootstrap eval config
 skills/eval-dataset/     # Skill: generate test cases
   SKILL.md               # Bootstrap, expand, or extract cases from traces
 
-skills/eval-run/         # Skill: execute eval suite
-  SKILL.md               # Prepare, execute, collect, score, report
+skills/eval-run/         # Skill: execute eval suite (interactive, via Claude Code)
+  SKILL.md               # Orchestrates pipeline/ scripts + analysis + tool interception
   scripts/
-    workspace.py         # Workspace creation, batch.yaml, symlinks
-    execute.py           # Skill execution via agent runner
-    collect.py           # Artifact collection + case mapping
-    score.py             # Scoring: inline checks, LLM judges, pairwise, regression
-    report.py            # HTML report generation (scoring summary, per-case details, diffs)
     tools.py             # PreToolUse hook for tool interception
   prompts/
     analyze-results.md   # Results interpretation prompt

--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ Creates 5 starter test cases based on the skill analysis. Skip this if you alrea
 
 This prepares a workspace, runs the skill (headless or interactive), collects artifacts, scores with judges, and reports results.
 
+### CLI (no Claude Code needed)
+
+For deterministic, scriptable eval runs without Claude Code orchestration:
+
+```bash
+pip install git+https://github.com/opendatahub-io/agent-eval-harness.git
+agent-eval run --config eval.yaml --model opus
+agent-eval run --config eval.yaml --model opus --baseline 2026-06-03-opus --open
+```
+
+This chains the pipeline scripts directly: preflight → workspace → execute → collect → score → report. Same results, no token burn on orchestration.
+
 ## eval.yaml
 
 The harness uses natural language to describe evaluation datasets and skills input/output and spawns LLM sub-agents to interpret them.

--- a/agent_eval/cli/eval_run.py
+++ b/agent_eval/cli/eval_run.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Deterministic eval pipeline — no Claude Code orchestration needed.
+
+Chains the pipeline scripts in sequence: preflight → workspace → execute →
+collect → score → report.  Fails fast on any error.
+
+Usage:
+    agent-eval run --config eval.yaml --model opus
+    agent-eval run --config eval.yaml --model opus --run-id 2026-06-04-opus
+    agent-eval run --config eval.yaml --model opus --baseline 2026-06-03-opus --open
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+from agent_eval.config import EvalConfig
+
+
+def _run_step(label, module, args, *, capture_stdout=False):
+    """Run a pipeline module as a subprocess.
+
+    Returns captured stdout when capture_stdout=True, otherwise None.
+    """
+    print(f"\n{'─' * 60}", file=sys.stderr)
+    print(f"  {label}", file=sys.stderr)
+    print(f"{'─' * 60}", file=sys.stderr)
+    result = subprocess.run(
+        [sys.executable, "-m", module] + args,
+        capture_output=capture_stdout,
+        text=capture_stdout,
+    )
+    if result.returncode != 0:
+        if capture_stdout and result.stderr:
+            print(result.stderr, file=sys.stderr, end="")
+        print(f"\nFAILED: {label} (exit {result.returncode})", file=sys.stderr)
+        sys.exit(result.returncode)
+    if capture_stdout:
+        return result.stdout
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="agent-eval run",
+        description="Run a deterministic eval pipeline: preflight → workspace → "
+                    "execute → collect → score → report.",
+    )
+    parser.add_argument("--config", required=True,
+                        help="Path to eval.yaml")
+    parser.add_argument("--model", default=None,
+                        help="Skill model (default: models.skill from config)")
+    parser.add_argument("--run-id", default=None,
+                        help="Run identifier (default: YYYY-MM-DD-<model>)")
+    parser.add_argument("--baseline", default=None,
+                        help="Baseline run-id for pairwise comparison")
+    parser.add_argument("--cases", nargs="*", default=None,
+                        help="Specific case IDs to run")
+    parser.add_argument("--subagent-model", default=None,
+                        help="Model for subagents")
+    parser.add_argument("--effort", default=None,
+                        choices=["low", "medium", "high", "xhigh", "max"],
+                        help="Claude Code reasoning effort")
+    parser.add_argument("--parallelism", type=int, default=None,
+                        help="Max parallel case executions")
+    parser.add_argument("--open", action="store_true",
+                        help="Open HTML report in browser when done")
+    args = parser.parse_args()
+
+    config = EvalConfig.from_yaml(args.config)
+
+    model = args.model or config.models.skill
+    if not model:
+        print("ERROR: no model specified. Set --model or models.skill in eval.yaml.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    run_id = args.run_id or f"{date.today().isoformat()}-{model}"
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", run_id):
+        print(f"ERROR: run-id must match [A-Za-z0-9._-]+: {run_id!r}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    eval_name = config.skill or config.name
+    runs_base = Path(os.environ.get("AGENT_EVAL_RUNS_DIR", "eval/runs"))
+    output_dir = runs_base / eval_name / run_id
+
+    print(f"Eval: {eval_name}", file=sys.stderr)
+    print(f"Model: {model}", file=sys.stderr)
+    print(f"Run ID: {run_id}", file=sys.stderr)
+    print(f"Output: {output_dir}", file=sys.stderr)
+
+    # 1. Preflight — force clean, no user prompts
+    preflight_args = ["--config", args.config, "--run-id", run_id,
+                      "--clean", "--force"]
+    if args.baseline:
+        preflight_args.extend(["--baseline", args.baseline])
+    _run_step("Preflight", "agent_eval.run.preflight", preflight_args)
+
+    # 2. Workspace — capture stdout to extract workspace path
+    workspace_args = ["--config", args.config, "--run-id", run_id]
+    if args.cases:
+        workspace_args.extend(["--cases"] + args.cases)
+    stdout = _run_step("Workspace", "agent_eval.run.workspace",
+                       workspace_args, capture_stdout=True)
+
+    workspace_path = None
+    for line in stdout.splitlines():
+        if line.startswith("WORKSPACE: "):
+            workspace_path = line.split("WORKSPACE: ", 1)[1].strip()
+            break
+    if not workspace_path:
+        print("ERROR: workspace.py did not emit WORKSPACE path", file=sys.stderr)
+        sys.exit(1)
+    print(f"Workspace: {workspace_path}", file=sys.stderr)
+
+    # 3. Execute
+    execute_args = [
+        "--config", args.config,
+        "--workspace", workspace_path,
+        "--skill", config.skill,
+        "--model", model,
+        "--output", str(output_dir),
+    ]
+    if args.subagent_model:
+        execute_args.extend(["--subagent-model", args.subagent_model])
+    if args.effort:
+        execute_args.extend(["--effort", args.effort])
+    if args.parallelism is not None:
+        execute_args.extend(["--parallelism", str(args.parallelism)])
+    if config.mlflow.experiment:
+        execute_args.extend(["--mlflow-experiment", config.mlflow.experiment])
+    _run_step("Execute", "agent_eval.run.execute", execute_args)
+
+    # 4. Collect
+    collect_args = [
+        "--config", args.config,
+        "--workspace", workspace_path,
+        "--output", str(output_dir),
+    ]
+    _run_step("Collect", "agent_eval.run.collect", collect_args)
+
+    # 5. Score judges
+    score_args = ["judges", "--run-id", run_id, "--config", args.config]
+    _run_step("Score (judges)", "agent_eval.run.score", score_args)
+
+    # 6. Pairwise comparison (if baseline provided)
+    if args.baseline:
+        pairwise_args = ["pairwise",
+                         "--run-id", run_id,
+                         "--baseline", args.baseline,
+                         "--config", args.config]
+        _run_step("Score (pairwise)", "agent_eval.run.score", pairwise_args)
+
+    # 7. Report
+    report_args = ["--run-id", run_id, "--config", args.config]
+    if args.baseline:
+        report_args.extend(["--baseline", args.baseline])
+    if args.open:
+        report_args.append("--open")
+    _run_step("Report", "agent_eval.run.report", report_args)
+
+    print(f"\nDone. Results at: {output_dir}", file=sys.stderr)
+    print(f"Report: {output_dir / 'report.html'}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent_eval/run/collect.py
+++ b/agent_eval/run/collect.py
@@ -11,7 +11,6 @@ Usage:
         --output eval/runs/test-001
 """
 
-import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
 import argparse
 import json

--- a/agent_eval/run/execute.py
+++ b/agent_eval/run/execute.py
@@ -18,7 +18,6 @@ Usage:
         [--mlflow-experiment my-eval]
 """
 
-import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
 import argparse
 import json

--- a/agent_eval/run/preflight.py
+++ b/agent_eval/run/preflight.py
@@ -22,7 +22,6 @@ Usage:
     python3 ${CLAUDE_SKILL_DIR}/scripts/preflight.py --config eval.yaml --baseline 2026-04-10-opus
 """
 
-import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
 import argparse
 import os

--- a/agent_eval/run/report.py
+++ b/agent_eval/run/report.py
@@ -13,7 +13,6 @@ Usage:
         [--open]
 """
 
-import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
 import argparse
 import base64

--- a/agent_eval/run/score.py
+++ b/agent_eval/run/score.py
@@ -11,7 +11,6 @@ Usage:
     python3 ${CLAUDE_SKILL_DIR}/scripts/score.py regression --run-id <id> --config eval.yaml
 """
 
-import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
 import argparse
 import importlib

--- a/agent_eval/run/workspace.py
+++ b/agent_eval/run/workspace.py
@@ -13,7 +13,6 @@ Usage:
         [--symlinks scripts,.claude,CLAUDE.md]
 """
 
-import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
 import argparse
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ all = [
 test = ["pytest>=8.0"]
 
 [project.scripts]
+agent-eval = "agent_eval.cli.eval_run:main"
 claude-trace = "agent_eval.cli.trace_run:main"
 
 [tool.pytest.ini_options]

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -87,7 +87,7 @@ If no cases found, stop and tell the user clearly:
 Before setting up the workspace, verify the project's artifact directories are clean. Skills write to the project directory (not the workspace), so stale artifacts from previous runs contaminate results — wrong IDs, stale run reports, inflated file counts.
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/preflight.py \
+python3 -m agent_eval.run.preflight \
   --config <config> \
   [--run-id <id>] \
   [--baseline <baseline-id>]
@@ -97,7 +97,7 @@ The script checks `tmp/` state files, whether `$AGENT_EVAL_RUNS_DIR/<eval-name>/
 
 - **If `CLEAN`**: proceed to workspace setup.
 - **If `DIRTY`**: report the findings to the user and ask what to do:
-  - **Force clean**: run `preflight.py --clean --force` to delete all stale artifacts, then proceed.
+  - **Force clean**: run `python3 -m agent_eval.run.preflight --clean --force` to delete all stale artifacts, then proceed.
   - **Change run-id**: append a version suffix (e.g., `2026-04-11-opus-v2`) and re-check. This avoids overwriting previous run results but still requires cleaning project artifacts — re-run preflight with `--clean` and the new run-id.
   - **Abort**: let the user handle cleanup manually.
 - **If `MISSING_BASELINE` (exit 2)**: the baseline run-id wasn't found at `$AGENT_EVAL_RUNS_DIR/<eval-name>/<baseline>`. The script lists nearby run-ids — confirm the correct one with the user (typo, or did they mean a different date/variant?) before retrying.
@@ -107,7 +107,7 @@ The script checks `tmp/` state files, whether `$AGENT_EVAL_RUNS_DIR/<eval-name>/
 Create an isolated workspace with the test cases and output directories:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/workspace.py \
+python3 -m agent_eval.run.workspace \
   --config <config> \
   --run-id <id> \
   [--cases <id> [<id> ...]]
@@ -136,7 +136,7 @@ Run the skill headlessly against test cases. In `case` mode (default), execute.p
 The execute script handles CLI construction, streaming progress, and result capture:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
+python3 -m agent_eval.run.execute \
   --config <config> \
   --workspace <workspace_path> \
   --skill <skill_name> \
@@ -194,7 +194,7 @@ If `exit_code` is non-zero, report the failure with the exit code, duration, and
 Distribute workspace outputs into per-case directories so judges can score each case independently:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/collect.py \
+python3 -m agent_eval.run.collect \
   --config <config> \
   --workspace <workspace_path> \
   --output $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>
@@ -215,7 +215,7 @@ Run all configured judges against the collected outputs. Four judge types are su
 If `--no-llm-judges` was specified, skip judges that make LLM API calls (prompt, prompt_file, and LLM builtins). Run deterministic judges only (check, Python builtins, external code).
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/score.py judges \
+python3 -m agent_eval.run.score judges \
   --run-id <id> \
   --config <config>
 ```
@@ -232,7 +232,7 @@ This means judges can check output quality, execution efficiency, AND expected o
 If `--baseline` was specified, also run pairwise comparison:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/score.py pairwise \
+python3 -m agent_eval.run.score pairwise \
   --run-id <id> \
   --baseline <baseline_id> \
   --config <config>
@@ -271,7 +271,7 @@ Write the analysis body as markdown with these sections in order: `## Recommenda
 **Generate HTML report**:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/report.py \
+python3 -m agent_eval.run.report \
   --run-id <id> \
   --config <config> \
   [--baseline <baseline_id>] \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 import pytest
 
-# Add skills script directories to sys.path so tests can import them
+# Add pipeline and skills script directories to sys.path so tests can import them
 _repo_root = Path(__file__).parent.parent
-sys.path.insert(0, str(_repo_root / "skills" / "eval-run" / "scripts"))
+sys.path.insert(0, str(_repo_root / "agent_eval" / "run"))
 sys.path.insert(0, str(_repo_root / "skills" / "eval-mlflow" / "scripts"))
 
 

--- a/tests/test_report_markdown.py
+++ b/tests/test_report_markdown.py
@@ -1,4 +1,4 @@
-"""Tests for the report markdown renderer (skills/eval-run/scripts/report.py).
+"""Tests for the report markdown renderer (agent_eval/run/report.py).
 
 Focus: _md_to_html paragraph handling. Soft-wrapped source lines must be
 joined into a single <p> so analysis.md paragraphs reflow to the container


### PR DESCRIPTION
## Summary

- Moves pipeline scripts from `skills/eval-run/scripts/` into `agent_eval/run/` so they ship with `pip install`
- Adds `agent-eval run` CLI that chains preflight → workspace → execute → collect → score → report deterministically — no Claude Code orchestration needed
- `/eval-run` skill updated to call `python3 -m agent_eval.run.*` instead of `${CLAUDE_SKILL_DIR}/scripts/*`

Usage:
```bash
pip install git+https://github.com/opendatahub-io/agent-eval-harness.git
agent-eval run --config eval.yaml --model opus
agent-eval run --config eval.yaml --model opus --baseline 2026-06-03-opus --open
```

## Test plan

- [x] All 294 unit tests pass
- [x] `python3 -m agent_eval.cli.eval_run --help` shows correct usage
- [x] `python3 -m agent_eval.run.workspace --help` works (scripts importable from package)
- [ ] End-to-end: `agent-eval run --config eval.yaml --model sonnet` produces report
- [ ] `/eval-run` skill still works via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `agent-eval run` CLI command for executing evaluation pipelines deterministically, supporting baseline and pairwise scoring options.

* **Documentation**
  * Added Agent Eval Harness CLI workflow documentation with installation and usage examples.
  * Updated documentation to reflect revised directory structure and pipeline components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->