### PR TITLE
feat: add eval-compare skill for cross-model comparison reports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,11 @@ skills/eval-mlflow/      # Skill: MLflow integration
 skills/eval-optimize/    # Skill: automated refinement loop
   SKILL.md               # Composes with /eval-run via Skill tool
 
+skills/eval-compare/     # Skill: cross-model/cross-run comparison report
+  SKILL.md               # Discover runs, generate tabbed HTML, LLM analysis sections
+  scripts/
+    compare.py           # Discover run artifacts + generate comparison report HTML
+
 skills/eval-check/ # Skill: full-harness configuration health check
   SKILL.md               # Scans all skills, commands, CLAUDE.md, hooks for overlap and issues
   scripts/
@@ -112,6 +117,7 @@ The `schema` descriptions are documentation for the LLM agents and judges. Scrip
 /eval-review --run-id <id>             # Review: interactive human feedback + changes
 /eval-mlflow --run-id <id>             # MLflow: sync dataset, log results
 /eval-optimize --model opus            # Optimize: automated refinement loop
+/eval-compare <input-dir>              # Compare: tabbed HTML report across models/runs
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install -e ./agent-eval-harness
 claude --plugin-dir ./agent-eval-harness
 ```
 
-This makes all eval skills available: `/eval-setup`, `/eval-analyze`, `/eval-dataset`, `/eval-run`, `/eval-review`, `/eval-mlflow`, `/eval-optimize`, and `/eval-check`.
+This makes all eval skills available: `/eval-setup`, `/eval-analyze`, `/eval-dataset`, `/eval-run`, `/eval-review`, `/eval-mlflow`, `/eval-optimize`, `/eval-compare`, and `/eval-check`.
 
 ### 2. Set up environment
 
@@ -469,6 +469,17 @@ Execute the evaluation suite: prepare workspace, run the skill headlessly, colle
 /eval-run --model opus --no-judge               # Skip LLM judges
 ```
 
+### /eval-compare
+
+Compare evaluation results across multiple models or runs. Scans a directory of eval run artifacts (`summary.yaml`, `run_result.json`, `report.html`) and produces a self-contained tabbed HTML comparison report with model cards, quality/cost tables, per-case breakdowns, embedded per-run reports, and LLM-written analysis (Bottom Line, Where Each Model Shined, Shared Weaknesses, Recommendations).
+
+```
+/eval-compare <input-dir>                          # Discover runs and generate the report
+/eval-compare <input-dir> --output <dir>           # Custom output directory
+/eval-compare <input-dir> --title "Opus vs Sonnet" # Custom report title
+/eval-compare <input-dir> --overview "<context>"   # Add a context paragraph
+```
+
 ### /eval-review
 
 Interactive human review of eval results. Presents judge scores and outputs, collects qualitative feedback, analyzes patterns, and proposes SKILL.md changes.
@@ -532,7 +543,8 @@ skills/
   eval-review/           # Interactive human review
   eval-mlflow/           # MLflow integration
   eval-optimize/         # Automated refinement loop
-  eval-check/    # Full-harness configuration health check
+  eval-compare/          # Cross-run / cross-model comparison report
+  eval-check/            # Full-harness configuration health check
 ```
 
 ## Agent Support

--- a/skills/eval-compare/SKILL.md
+++ b/skills/eval-compare/SKILL.md
@@ -7,11 +7,13 @@ allowed-tools: Read, Write, Bash, Glob, Grep, AskUserQuestion
 
 You are an eval comparison report generator. You take a directory of eval run results and produce a self-contained HTML comparison report with LLM-generated analysis. You do not run evaluations or modify source data.
 
+**IMPORTANT: Follow the steps below sequentially. Do not explore the filesystem, run `ls`, `find`, or otherwise investigate the input directory. The scripts handle all discovery. Just run the commands as written.**
+
 ## Step 0: Parse Arguments
 
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `<input-dir>` | yes | — | Directory containing run subdirectories, each with `summary.yaml` and `run_result.json` |
+| `<input-dir>` | yes | — | Directory to scan recursively for eval runs (any subdirectory containing `summary.yaml`) |
 | `--output <path>` | no | `<input-dir>/comparison-report` | Output directory for the HTML report |
 | `--title <text>` | no | `Model Comparison` | Report title |
 | `--overview <text>` | no | auto-generated | Context paragraph shown at the top of the report |
@@ -24,7 +26,7 @@ Run the discovery script to find all valid eval runs:
 python3 ${CLAUDE_SKILL_DIR}/scripts/compare.py discover <input-dir>
 ```
 
-This scans subdirectories for `summary.yaml` + `run_result.json` pairs and prints a JSON manifest of discovered runs with model names, costs, and judge scores.
+This recursively scans for directories containing `summary.yaml` and prints a JSON manifest of discovered runs with model names, costs, and judge scores. Just pass the input directory — do not search for files yourself.
 
 If no valid runs are found, report the error and stop.
 
@@ -42,18 +44,40 @@ This produces:
 - `<output-dir>/index.html` — the comparison report
 - Copies of any `eval-report-summary.html` files into model subdirectories for iframe embedding
 
-## Step 3: Write the Bottom Line
+## Step 3: Write Analysis Sections
 
-Read the discovery JSON from Step 1 and the summary.yaml files to understand the full picture. Then edit the generated `<output-dir>/index.html` to replace the auto-generated "Bottom Line" content (inside `<div class="verdict">`) with your own analysis.
+Using the discovery JSON from Step 1, read each run's `summary.yaml` (paths are in the `"dir"` field of each discovered run) to understand the full picture — per-case scores, judge breakdowns, cost data, variance across runs. Then edit the generated `<output-dir>/index.html` to replace placeholder content and add badges.
 
-Cover:
+### Model Card Badges
 
-- Which model delivers the best value (quality vs cost tradeoff)
-- Notable per-case differences (where one model excels or struggles)
-- Variance concerns for models with multiple runs
-- Any surprising findings (e.g., a cheaper model outperforming, cost blowups)
+Add a badge `<div>` to model cards based on your analysis. Not every model needs a badge — only add one when it clearly applies. Available badge styles:
 
-Keep it to 3-5 sentences. Use `<p>` tags. Write for someone who hasn't seen the raw data.
+- **Best Value** (green): The model with the best quality-to-cost ratio. A model scoring within a small margin of the top but costing significantly less IS the best value — don't just pick the highest raw score. Quality parity at lower cost wins.
+  `<div class="badge" style="background: var(--green); color: #000;">Best Value</div>`
+- **Best Quality** (green): Only use when one model's quality scores are **significantly** higher than all others. If the top models are within ~0.2 of each other, don't award this badge — the difference isn't meaningful. This badge should be rare; "Best Value" is usually the more useful signal.
+  `<div class="badge" style="background: var(--green); color: #000;">Best Quality</div>`
+- **Highly Variable** (yellow): A model with multiple runs whose scores diverge significantly across runs (e.g., same case scoring 1 in one run and 4 in another).
+  `<div class="badge" style="background: var(--yellow); color: #000;">Highly Variable</div>`
+- **Not Viable** (red): A model that fundamentally fails the task — very low scores, missing outputs, can't invoke the skill reliably.
+  `<div class="badge" style="background: var(--red); color: #000;">Not Viable</div>`
+
+Insert the badge `<div>` right after the opening `<div class="card"...>` tag. Also add `style="border-color: var(--green);"` (or `--yellow`/`--red`) to the card's outer div.
+
+### Bottom Line (`<div class="verdict">`)
+
+Replace the placeholder with a concise summary — 3 sentences maximum. State which model is the best choice and why, note any models that aren't viable, and call out the most important tradeoff. Do not list every model individually. Write for someone who hasn't seen the raw data. Use `<p>` tags.
+
+### Where Each Model Shined (`<div id="model-strengths">`)
+
+Replace the placeholder `<p>` with per-model subsections. For each model, write a `<h3>` with the model name and 2-3 sentences highlighting its unique strengths. What cases did it handle best? What patterns show it excelling? What is it uniquely good at compared to the others?
+
+### Shared Weaknesses (`<div id="shared-weaknesses">`)
+
+Replace the placeholder `<p>` with an HTML table (Issue | Impact | Affected Cases) listing weaknesses that appear across ALL or most models. Look at per-case scores to find cases where every model scored poorly or failed. These are skill-level issues, not model-level.
+
+### Recommendations (`<div id="recommendations">`)
+
+Replace the placeholder `<p>` with 3-5 actionable bullet points (`<ul><li>`). Cover: which model to use for production, when alternatives make sense, and what to improve in the skill itself based on the shared weaknesses.
 
 ## Step 4: Present Summary
 

--- a/skills/eval-compare/SKILL.md
+++ b/skills/eval-compare/SKILL.md
@@ -52,7 +52,7 @@ Using the discovery JSON from Step 1, read each run's `summary.yaml` (paths are 
 
 Add a badge `<div>` to model cards based on your analysis. Not every model needs a badge — only add one when it clearly applies. Available badge styles:
 
-- **Best Value** (green): The model with the best quality-to-cost ratio. Consider both quality AND consistency — a model with high variance across runs is NOT a good value even if its average looks competitive. The best value model must be reliable.
+- **Best Value** (green): The best model considering both quality and cost. A model with slightly higher quality but much higher cost is NOT the best value — the cheaper model wins unless the quality difference is substantial. Must also be consistent across runs.
   `<div class="badge" style="background: var(--green); color: #000;">Best Value</div>`
 - **Highly Variable** (yellow): A model with multiple runs whose scores diverge significantly across runs (e.g., same case scoring 1 in one run and 4 in another). A highly variable model should NEVER also be Best Value — inconsistency disqualifies it.
   `<div class="badge" style="background: var(--yellow); color: #000;">Highly Variable</div>`

--- a/skills/eval-compare/SKILL.md
+++ b/skills/eval-compare/SKILL.md
@@ -52,11 +52,9 @@ Using the discovery JSON from Step 1, read each run's `summary.yaml` (paths are 
 
 Add a badge `<div>` to model cards based on your analysis. Not every model needs a badge — only add one when it clearly applies. Available badge styles:
 
-- **Best Value** (green): The model with the best quality-to-cost ratio. A model scoring within a small margin of the top but costing significantly less IS the best value — don't just pick the highest raw score. Quality parity at lower cost wins.
+- **Best Value** (green): The model with the best quality-to-cost ratio. Consider both quality AND consistency — a model with high variance across runs is NOT a good value even if its average looks competitive. The best value model must be reliable.
   `<div class="badge" style="background: var(--green); color: #000;">Best Value</div>`
-- **Best Quality** (green): Only use when one model's quality scores are **significantly** higher than all others. If the top models are within ~0.2 of each other, don't award this badge — the difference isn't meaningful. This badge should be rare; "Best Value" is usually the more useful signal.
-  `<div class="badge" style="background: var(--green); color: #000;">Best Quality</div>`
-- **Highly Variable** (yellow): A model with multiple runs whose scores diverge significantly across runs (e.g., same case scoring 1 in one run and 4 in another).
+- **Highly Variable** (yellow): A model with multiple runs whose scores diverge significantly across runs (e.g., same case scoring 1 in one run and 4 in another). A highly variable model should NEVER also be Best Value — inconsistency disqualifies it.
   `<div class="badge" style="background: var(--yellow); color: #000;">Highly Variable</div>`
 - **Not Viable** (red): A model that fundamentally fails the task — very low scores, missing outputs, can't invoke the skill reliably.
   `<div class="badge" style="background: var(--red); color: #000;">Not Viable</div>`
@@ -83,7 +81,7 @@ Replace the placeholder `<p>` with 3-5 actionable bullet points (`<ul><li>`). Co
 
 Show the user:
 - Number of runs discovered, grouped by model
-- Best model by analysis quality and cost
+- Best value model and why
 - Where the report was saved
 
 Suggest opening the report:

--- a/skills/eval-compare/SKILL.md
+++ b/skills/eval-compare/SKILL.md
@@ -42,7 +42,7 @@ If `--overview` was provided, also pass `--overview "<text>"`.
 
 This produces:
 - `<output-dir>/index.html` — the comparison report
-- Copies of any `eval-report-summary.html` files into model subdirectories for iframe embedding
+- Copies of any `report.html` files into model subdirectories for iframe embedding
 
 ## Step 3: Write Analysis Sections
 

--- a/skills/eval-compare/SKILL.md
+++ b/skills/eval-compare/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: eval-compare
+description: "Compare evaluation results across multiple models or runs. Takes a directory of eval run artifacts (summary.yaml, run_result.json, HTML reports) and produces a tabbed HTML comparison report with model cards, quality/cost tables, per-case breakdowns, and embedded original reports. Use when the user wants to compare models, compare runs, produce a model comparison report, or analyze eval results side-by-side."
+user-invocable: true
+allowed-tools: Read, Write, Bash, Glob, Grep, AskUserQuestion
+---
+
+You are an eval comparison report generator. You take a directory of eval run results and produce a self-contained HTML comparison report with LLM-generated analysis. You do not run evaluations or modify source data.
+
+## Step 0: Parse Arguments
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `<input-dir>` | yes | — | Directory containing run subdirectories, each with `summary.yaml` and `run_result.json` |
+| `--output <path>` | no | `<input-dir>/comparison-report` | Output directory for the HTML report |
+| `--title <text>` | no | `Model Comparison` | Report title |
+| `--overview <text>` | no | auto-generated | Context paragraph shown at the top of the report |
+
+## Step 1: Discover Runs
+
+Run the discovery script to find all valid eval runs:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/compare.py discover <input-dir>
+```
+
+This scans subdirectories for `summary.yaml` + `run_result.json` pairs and prints a JSON manifest of discovered runs with model names, costs, and judge scores.
+
+If no valid runs are found, report the error and stop.
+
+## Step 2: Generate Report
+
+Run the report generator:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/compare.py generate <input-dir> --output <output-dir> --title "<title>"
+```
+
+If `--overview` was provided, also pass `--overview "<text>"`.
+
+This produces:
+- `<output-dir>/index.html` — the comparison report
+- Copies of any `eval-report-summary.html` files into model subdirectories for iframe embedding
+
+## Step 3: Write the Bottom Line
+
+Read the discovery JSON from Step 1 and the summary.yaml files to understand the full picture. Then edit the generated `<output-dir>/index.html` to replace the auto-generated "Bottom Line" content (inside `<div class="verdict">`) with your own analysis.
+
+Cover:
+
+- Which model delivers the best value (quality vs cost tradeoff)
+- Notable per-case differences (where one model excels or struggles)
+- Variance concerns for models with multiple runs
+- Any surprising findings (e.g., a cheaper model outperforming, cost blowups)
+
+Keep it to 3-5 sentences. Use `<p>` tags. Write for someone who hasn't seen the raw data.
+
+## Step 4: Present Summary
+
+Show the user:
+- Number of runs discovered, grouped by model
+- Best model by analysis quality and cost
+- Where the report was saved
+
+Suggest opening the report:
+```bash
+open <output-dir>/index.html
+```
+
+## Rules
+
+- **Read-only on source data.** Never modify input files. Only write to the output directory.
+- **Graceful degradation.** If a run is missing `run_result.json`, still include it with available data from `summary.yaml`. If an HTML report is missing, skip the iframe tab for that run.
+- **Aggregate repeated models.** When multiple runs use the same model, show averages with min/max ranges. Each run still gets its own iframe tab.
+- **Highlight best/worst.** In comparison tables, mark the best value green and worst value red for each metric.
+
+$ARGUMENTS

--- a/skills/eval-compare/SKILL.md
+++ b/skills/eval-compare/SKILL.md
@@ -2,7 +2,7 @@
 name: eval-compare
 description: "Compare evaluation results across multiple models or runs. Takes a directory of eval run artifacts (summary.yaml, run_result.json, HTML reports) and produces a tabbed HTML comparison report with model cards, quality/cost tables, per-case breakdowns, and embedded original reports. Use when the user wants to compare models, compare runs, produce a model comparison report, or analyze eval results side-by-side."
 user-invocable: true
-allowed-tools: Read, Write, Bash, Glob, Grep, AskUserQuestion
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 
 You are an eval comparison report generator. You take a directory of eval run results and produce a self-contained HTML comparison report with LLM-generated analysis. You do not run evaluations or modify source data.
@@ -16,7 +16,7 @@ You are an eval comparison report generator. You take a directory of eval run re
 | `<input-dir>` | yes | — | Directory to scan recursively for eval runs (any subdirectory containing `summary.yaml`) |
 | `--output <path>` | no | `<input-dir>/comparison-report` | Output directory for the HTML report |
 | `--title <text>` | no | `Model Comparison` | Report title |
-| `--overview <text>` | no | auto-generated | Context paragraph shown at the top of the report |
+| `--overview <text>` | no | none (section omitted) | Context paragraph shown at the top of the report |
 
 ## Step 1: Discover Runs
 
@@ -42,7 +42,7 @@ If `--overview` was provided, also pass `--overview "<text>"`.
 
 This produces:
 - `<output-dir>/index.html` — the comparison report
-- Copies of any `report.html` files into model subdirectories for iframe embedding
+- Copies of any `report.html` files into per-run subdirectories (named by a unique run slug) for iframe embedding
 
 ## Step 3: Write Analysis Sections
 
@@ -92,7 +92,7 @@ open <output-dir>/index.html
 ## Rules
 
 - **Read-only on source data.** Never modify input files. Only write to the output directory.
-- **Graceful degradation.** If a run is missing `run_result.json`, still include it with available data from `summary.yaml`. If an HTML report is missing, skip the iframe tab for that run.
+- **Graceful degradation.** If a run is missing `run_result.json`, still include it with available data from `summary.yaml`. If an HTML report is missing, the run's tab shows a "No HTML report available" message instead of an iframe.
 - **Aggregate repeated models.** When multiple runs use the same model, show averages with min/max ranges. Each run still gets its own iframe tab.
 - **Highlight best/worst.** In comparison tables, mark the best value green and worst value red for each metric.
 

--- a/skills/eval-compare/scripts/compare.py
+++ b/skills/eval-compare/scripts/compare.py
@@ -13,6 +13,7 @@ import sys
 from collections import defaultdict
 from html import escape
 from pathlib import Path
+from urllib.parse import quote
 
 import yaml
 
@@ -29,6 +30,8 @@ def load_json(path):
 
 def discover_runs(input_dir):
     input_dir = Path(input_dir)
+    if not input_dir.exists() or not input_dir.is_dir():
+        raise NotADirectoryError(f"Input directory not found: {input_dir}")
     runs = []
     for d in sorted(input_dir.iterdir()):
         if not d.is_dir():
@@ -375,7 +378,7 @@ def generate_report(runs, title, overview, output_dir):
     html += '<div class="tab-content active" id="tab-comparison">\n<div class="page">\n'
 
     if overview:
-        html += f'<div class="overview">{overview}</div>\n'
+        html += f'<div class="overview">{escape(overview)}</div>\n'
 
     # Bottom Line: auto-generated summary, agent replaces with LLM analysis in Step 3
     html += '<div class="verdict">\n<h2>Bottom Line</h2>\n<p>'
@@ -516,7 +519,7 @@ def generate_report(runs, title, overview, output_dir):
             r = model_runs[0]
             html += f'<div class="tab-content" id="tab-{escape(m)}">\n'
             if r["html_report"]:
-                html += f'  <iframe class="iframe-wrap" src="{r["name"]}/eval-report-summary.html"></iframe>\n'
+                html += f'  <iframe class="iframe-wrap" src="{quote(r['name'], safe='')}/eval-report-summary.html"></iframe>\n'
             else:
                 html += '  <div class="page"><p>No HTML report available for this run.</p></div>\n'
             html += '</div>\n\n'
@@ -526,13 +529,13 @@ def generate_report(runs, title, overview, output_dir):
             for j, r in enumerate(model_runs):
                 active = " active" if j == 0 else ""
                 act_style = f"color:var(--accent); border-bottom-color:var(--accent);" if j == 0 else ""
-                html += f'    <button class="{active}" data-sub="{j}" style="{act_style}">Run {j + 1} ({r["name"]})</button>\n'
+                html += f'    <button class="{active}" data-sub="{j}" style="{act_style}">Run {j + 1} ({escape(r["name"])})</button>\n'
             html += '  </div>\n'
             for j, r in enumerate(model_runs):
                 display = "" if j == 0 else ' style="display:none;"'
                 html += f'  <div class="sub-panel" data-model="{escape(m)}" data-idx="{j}"{display}>\n'
                 if r["html_report"]:
-                    html += f'    <iframe class="iframe-wrap" src="{r["name"]}/eval-report-summary.html"></iframe>\n'
+                    html += f'    <iframe class="iframe-wrap" src="{quote(r['name'], safe='')}/eval-report-summary.html"></iframe>\n'
                 else:
                     html += '    <div class="page"><p>No HTML report available.</p></div>\n'
                 html += '  </div>\n'
@@ -579,7 +582,11 @@ document.querySelectorAll('.sub-bar').forEach(bar => {
 
 
 def cmd_discover(args):
-    runs = discover_runs(args.input_dir)
+    try:
+        runs = discover_runs(args.input_dir)
+    except NotADirectoryError as e:
+        print(json.dumps({"error": str(e), "runs": []}))
+        sys.exit(1)
     if not runs:
         print(json.dumps({"error": "No valid runs found", "runs": []}))
         sys.exit(1)
@@ -598,11 +605,16 @@ def cmd_discover(args):
 
 
 def cmd_generate(args):
-    runs = discover_runs(args.input_dir)
+    try:
+        runs = discover_runs(args.input_dir)
+    except NotADirectoryError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
     if not runs:
         print("ERROR: No valid runs found", file=sys.stderr)
         sys.exit(1)
-    path = generate_report(runs, args.title, args.overview, args.output)
+    output_dir = args.output or str(Path(args.input_dir) / "comparison-report")
+    path = generate_report(runs, args.title, args.overview, output_dir)
     groups = group_by_model(runs)
     print(f"Report generated: {path}")
     print(f"Runs: {len(runs)} across {len(groups)} models")
@@ -623,7 +635,7 @@ def main():
 
     p_generate = sub.add_parser("generate")
     p_generate.add_argument("input_dir")
-    p_generate.add_argument("--output", required=True)
+    p_generate.add_argument("--output", default=None)
     p_generate.add_argument("--title", default="Model Comparison")
     p_generate.add_argument("--overview", default=None)
 

--- a/skills/eval-compare/scripts/compare.py
+++ b/skills/eval-compare/scripts/compare.py
@@ -33,12 +33,8 @@ def discover_runs(input_dir):
     if not input_dir.exists() or not input_dir.is_dir():
         raise NotADirectoryError(f"Input directory not found: {input_dir}")
     runs = []
-    for d in sorted(input_dir.iterdir()):
-        if not d.is_dir():
-            continue
-        summary_path = d / "summary.yaml"
-        if not summary_path.exists():
-            continue
+    for summary_path in sorted(input_dir.rglob("summary.yaml")):
+        d = summary_path.parent
         summary = load_yaml(summary_path)
         run = {
             "dir": str(d),
@@ -110,6 +106,37 @@ def get_all_judge_names(runs):
         for k in (r["summary"].get("judges") or {}):
             names.add(k)
     return sorted(names)
+
+
+def _is_pass_rate(judge_name, value, runs):
+    """Heuristic: a judge is pass-rate style if all its per-case values are 0 or 1."""
+    if value is None:
+        return False
+    for r in runs:
+        for case in (r["summary"].get("per_case") or {}).values():
+            j = case.get(judge_name, {})
+            v = j.get("value")
+            if v is not None and v not in (0, 1, True, False, 0.0, 1.0):
+                return False
+    return True
+
+
+def pick_card_judges(all_judges, model_aggs, models, max_judges=4):
+    """Pick the most interesting judges for model cards.
+
+    Ranks by variance across models — judges where all models score identically
+    (e.g. pass_rate=1.0 everywhere) are least interesting.
+    """
+    scored = []
+    for judge in all_judges:
+        values = [model_aggs[m].get(f"judge_{judge}", {}).get("avg") for m in models]
+        clean = [v for v in values if v is not None]
+        if not clean:
+            continue
+        spread = max(clean) - min(clean) if len(clean) > 1 else 0
+        scored.append((spread, judge))
+    scored.sort(key=lambda x: (-x[0], x[1]))
+    return [j for _, j in scored[:max_judges]]
 
 
 def get_all_case_names(runs):
@@ -250,6 +277,14 @@ tbody tr:hover { background: rgba(255,255,255,0.02); }
 .worst { background: rgba(248,81,73,0.06); color: var(--red); }
 .insight { background: var(--surface2); border-left: 3px solid var(--accent); padding: 14px 18px;
            margin: 14px 0; border-radius: 0 6px 6px 0; font-size: 14px; line-height: 1.6; }
+.analysis-section { background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+            padding: 24px 28px; margin-bottom: 28px; }
+.analysis-section h2 { font-size: 17px; font-weight: 600; margin-bottom: 14px; padding-bottom: 8px;
+             border-bottom: 1px solid var(--border); }
+.analysis-section h3 { font-size: 15px; font-weight: 600; margin: 16px 0 8px; }
+.analysis-section p { font-size: 14px; line-height: 1.7; margin-bottom: 8px; }
+.analysis-section table { margin: 12px 0; }
+.analysis-section .placeholder { color: var(--text-muted); font-style: italic; }
 .iframe-wrap { width: 100%; height: calc(100vh - 90px); border: none; }
 .run-link { padding: 8px 16px; background: var(--surface); border-bottom: 1px solid var(--border); font-size: 12px; }
 .sub-bar { display: flex; align-items: center; gap: 4px; padding: 8px 16px;
@@ -319,11 +354,15 @@ def generate_report(runs, title, overview, output_dir):
     output_dir.mkdir(parents=True, exist_ok=True)
 
     groups = group_by_model(runs)
-    # Sort models: best analysis quality first
-    models = sorted(groups.keys(),
-                    key=lambda m: aggregate([get_judge_mean(r, "analysis_quality")
-                                             for r in groups[m]]).get("avg") or 0,
-                    reverse=True)
+    all_judges_for_sort = get_all_judge_names(runs)
+    first_judge = all_judges_for_sort[0] if all_judges_for_sort else None
+    if first_judge:
+        models = sorted(groups.keys(),
+                        key=lambda m: aggregate([get_judge_mean(r, first_judge)
+                                                 for r in groups[m]]).get("avg") or 0,
+                        reverse=True)
+    else:
+        models = sorted(groups.keys())
 
     model_aggs = {}
     for m, model_runs in groups.items():
@@ -335,8 +374,11 @@ def generate_report(runs, title, overview, output_dir):
             agg[f"judge_{judge}"] = aggregate([get_judge_mean(r, judge) for r in model_runs])
         model_aggs[m] = agg
 
-    best_quality_model = max(models, key=lambda m: (model_aggs[m].get("judge_analysis_quality", {}).get("avg") or 0))
-    cheapest_model = min(models, key=lambda m: (model_aggs[m]["cost_usd"].get("avg") or float("inf")))
+    all_judges = get_all_judge_names(runs)
+    card_judges = pick_card_judges(all_judges, model_aggs, models)
+    primary_judge = card_judges[0] if card_judges else None
+
+    # Badges are added by the LLM agent in Step 3, not auto-computed
 
     # Copy HTML reports
     for r in runs:
@@ -380,24 +422,15 @@ def generate_report(runs, title, overview, output_dir):
     if overview:
         html += f'<div class="overview">{escape(overview)}</div>\n'
 
-    # Bottom Line: auto-generated summary, agent replaces with LLM analysis in Step 3
-    html += '<div class="verdict">\n<h2>Bottom Line</h2>\n<p>'
-    for m in models:
-        agg = model_aggs[m]
-        aq = agg.get("judge_analysis_quality", {}).get("avg")
-        cost = agg["cost_usd"].get("avg")
-        parts = []
-        if aq is not None:
-            parts.append(f"{aq:.2f}/5 quality")
-        if cost is not None:
-            parts.append(f"${cost:.2f}/run")
-        detail = ", ".join(parts)
-        html += f'<strong>{escape(short_name(m))}</strong>: {detail}. '
-    html += "</p>\n</div>\n\n"
+    # Bottom Line: placeholder for LLM analysis in Step 3
+    html += '<div class="verdict">\n<h2>Bottom Line</h2>\n'
+    html += '<p class="placeholder">Analysis pending — will be replaced with a per-model verdict.</p>\n'
+    html += "</div>\n\n"
 
     # Pre-compute all values for relative coloring
-    all_aq = [model_aggs[m].get("judge_analysis_quality", {}).get("avg") for m in models]
-    all_rs = [model_aggs[m].get("judge_revert_scoring_accuracy", {}).get("avg") for m in models]
+    judge_all_values = {}
+    for judge in card_judges:
+        judge_all_values[judge] = [model_aggs[m].get(f"judge_{judge}", {}).get("avg") for m in models]
     all_cost = [model_aggs[m]["cost_usd"].get("avg") for m in models]
     all_wall = [model_aggs[m]["wall_clock_s"].get("avg") for m in models]
 
@@ -408,15 +441,7 @@ def generate_report(runs, title, overview, output_dir):
         c = color_for(m)
         extra_style = ""
         badge = ""
-        if m == best_quality_model and m == cheapest_model:
-            extra_style = f' style="border-color: var(--green);"'
-            badge = '<div class="badge" style="background: var(--green); color: #000;">Best Value</div>'
-        elif m == best_quality_model:
-            extra_style = f' style="border-color: var(--green);"'
-            badge = '<div class="badge" style="background: var(--green); color: #000;">Best Quality</div>'
 
-        aq = agg.get("judge_analysis_quality", {}).get("avg")
-        rs = agg.get("judge_revert_scoring_accuracy", {}).get("avg")
         cost = agg["cost_usd"].get("avg")
         turns = agg["num_turns"].get("avg")
         out_tok = agg["output_tokens"].get("avg")
@@ -429,8 +454,13 @@ def generate_report(runs, title, overview, output_dir):
             html += f' <span style="font-size:11px; color:var(--text-muted); font-weight:400;">({n} runs avg)</span>'
         html += '</h3>\n  <div class="stats">\n'
 
-        html += f'    <div class="stat"><span class="label">Analysis Quality</span><span class="value {_rank_color(aq, all_aq, True)}">{fmt(aq, "num") if aq else "--"}</span></div>\n'
-        html += f'    <div class="stat"><span class="label">Revert Scoring</span><span class="value {_rank_color(rs, all_rs, True)}">{fmt(rs, "num") if rs else "--"}</span></div>\n'
+        for judge in card_judges:
+            jv = agg.get(f"judge_{judge}", {}).get("avg")
+            is_pct = _is_pass_rate(judge, jv, runs)
+            judge_label = judge.replace("_", " ").title()
+            rank_cls = _rank_color(jv, judge_all_values.get(judge, []), True)
+            html += f'    <div class="stat"><span class="label">{escape(judge_label)}</span><span class="value {rank_cls}">{fmt(jv, "pct" if is_pct else "num") if jv is not None else "--"}</span></div>\n'
+
         html += f'    <div class="stat"><span class="label">{"Avg Run Cost" if n > 1 else "Total Cost"}</span><span class="value {_rank_color(cost, all_cost, False)}">{fmt(cost, "usd")}</span></div>\n'
         html += f'    <div class="stat"><span class="label">Wall Clock</span><span class="value {_rank_color(wall, all_wall, False)}">{fmt(wall, "time")}</span></div>\n'
         html += f'    <div class="stat"><span class="label">Output Tokens</span><span class="value">{fmt(out_tok, "tokens")}</span></div>\n'
@@ -458,7 +488,6 @@ def generate_report(runs, title, overview, output_dir):
     html += '</section>\n\n'
 
     # Quality table
-    all_judges = get_all_judge_names(runs)
     html += '<section>\n<h2>Quality Scores</h2>\n'
     quality_rows = []
     for judge in all_judges:
@@ -466,47 +495,85 @@ def generate_report(runs, title, overview, output_dir):
         for m in models:
             agg = model_aggs[m].get(f"judge_{judge}", {})
             v = agg.get("avg")
-            n = agg.get("count", 0)
             values.append(v)
-        is_pass_rate = all(v is not None and v <= 1.0 for v in values if v is not None)
-        ft = "pct" if is_pass_rate and judge not in ("analysis_quality", "revert_scoring_accuracy") else "num"
+        sample_v = next((v for v in values if v is not None), None)
+        ft = "pct" if _is_pass_rate(judge, sample_v, runs) else "num"
         label = judge.replace("_", " ").title()
         quality_rows.append((label, values, ft))
     html += render_comparison_table(models, quality_rows)
     html += '</section>\n\n'
 
-    # Per-case analysis quality
+    # Per-case tables for each judge
     all_cases = get_all_case_names(runs)
     if all_cases:
-        html += '<section>\n<h2>Per-Case Analysis Quality</h2>\n'
-        html += "<table><thead><tr><th>Case</th>"
-        for m in models:
-            html += f"<th>{escape(short_name(m))}</th>"
-        html += "</tr></thead><tbody>"
-        for case in all_cases:
-            case_short = case.replace("case-", "").replace("-", " ", 1).split(" ", 1)
-            label = case_short[1] if len(case_short) > 1 else case
-            html += f"<tr><td>{escape(label)}</td>"
-            values = []
+        for judge in all_judges:
+            # Check if this judge has any variation across models — skip if uniform
+            has_variation = False
+            for case in all_cases:
+                case_values = []
+                for m in models:
+                    scores = [get_case_score(r, case, judge) for r in groups[m]]
+                    agg = aggregate(scores)
+                    case_values.append(agg["avg"])
+                clean = [v for v in case_values if v is not None]
+                if len(clean) >= 2 and max(clean) != min(clean):
+                    has_variation = True
+                    break
+            if not has_variation and len(models) > 1:
+                continue
+
+            judge_label = judge.replace("_", " ").title()
+            is_pct = _is_pass_rate(judge, get_judge_mean(runs[0], judge), runs)
+            html += f'<section>\n<h2>Per-Case: {escape(judge_label)}</h2>\n'
+            html += "<table><thead><tr><th>Case</th>"
             for m in models:
-                scores = [get_case_score(r, case, "analysis_quality") for r in groups[m]]
-                agg = aggregate(scores)
-                values.append(agg["avg"])
-            best_i, worst_i = best_worst_indices(values, True)
-            for i, v in enumerate(values):
-                cls = ""
-                if i == best_i:
-                    cls = ' class="best"'
-                elif i == worst_i:
-                    cls = ' class="worst"'
-                if v is not None:
-                    n = model_aggs[models[i]].get("judge_analysis_quality", {}).get("count", 1)
-                    cell = f"{v:.1f}" if n > 1 else f"{int(v)}"
-                else:
-                    cell = "--"
-                html += f"<td{cls}>{cell}</td>"
-            html += "</tr>"
-        html += "</tbody></table>\n</section>\n\n"
+                html += f"<th>{escape(short_name(m))}</th>"
+            html += "</tr></thead><tbody>"
+            for case in all_cases:
+                case_short = case.replace("case-", "").replace("-", " ", 1).split(" ", 1)
+                label = case_short[1] if len(case_short) > 1 else case
+                html += f"<tr><td>{escape(label)}</td>"
+                values = []
+                for m in models:
+                    scores = [get_case_score(r, case, judge) for r in groups[m]]
+                    agg = aggregate(scores)
+                    values.append(agg["avg"])
+                best_i, worst_i = best_worst_indices(values, True)
+                for i, v in enumerate(values):
+                    cls = ""
+                    if i == best_i:
+                        cls = ' class="best"'
+                    elif i == worst_i:
+                        cls = ' class="worst"'
+                    if v is not None:
+                        n = len(groups[models[i]])
+                        if is_pct:
+                            cell = fmt(v, "pct")
+                        elif n > 1:
+                            cell = f"{v:.1f}"
+                        else:
+                            cell = f"{v:.2f}" if v != int(v) else f"{int(v)}"
+                    else:
+                        cell = "--"
+                    html += f"<td{cls}>{cell}</td>"
+                html += "</tr>"
+            html += "</tbody></table>\n</section>\n\n"
+
+    # LLM analysis placeholder sections — populated by the agent in Step 3
+    html += '<div class="analysis-section" id="model-strengths">\n'
+    html += '<h2>Where Each Model Shined</h2>\n'
+    html += '<p class="placeholder">Analysis pending — will be replaced with per-model strengths.</p>\n'
+    html += '</div>\n\n'
+
+    html += '<div class="analysis-section" id="shared-weaknesses">\n'
+    html += '<h2>Shared Weaknesses Across All Models</h2>\n'
+    html += '<p class="placeholder">Analysis pending — will be replaced with cross-cutting weaknesses.</p>\n'
+    html += '</div>\n\n'
+
+    html += '<div class="analysis-section" id="recommendations">\n'
+    html += '<h2>Recommendations</h2>\n'
+    html += '<p class="placeholder">Analysis pending — will be replaced with actionable recommendations.</p>\n'
+    html += '</div>\n\n'
 
     html += '</div>\n</div>\n\n'
 
@@ -590,14 +657,14 @@ def cmd_discover(args):
     if not runs:
         print(json.dumps({"error": "No valid runs found", "runs": []}))
         sys.exit(1)
+    all_judge_names = get_all_judge_names(runs)
     out = []
     for r in runs:
         entry = {
             "name": r["name"],
             "model": get_model(r),
             "cost_usd": get_metric(r, "cost_usd"),
-            "analysis_quality": get_judge_mean(r, "analysis_quality"),
-            "revert_scoring": get_judge_mean(r, "revert_scoring_accuracy"),
+            "judges": {j: get_judge_mean(r, j) for j in all_judge_names},
             "has_html": r["html_report"] is not None,
         }
         out.append(entry)

--- a/skills/eval-compare/scripts/compare.py
+++ b/skills/eval-compare/scripts/compare.py
@@ -46,7 +46,7 @@ def discover_runs(input_dir):
         result_path = d / "run_result.json"
         if result_path.exists():
             run["run_result"] = load_json(result_path)
-        html_path = d / "eval-report-summary.html"
+        html_path = d / "report.html"
         if html_path.exists():
             run["html_report"] = str(html_path)
         runs.append(run)
@@ -385,7 +385,7 @@ def generate_report(runs, title, overview, output_dir):
         if r["html_report"]:
             dest = output_dir / r["name"]
             dest.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(r["html_report"], dest / "eval-report-summary.html")
+            shutil.copy2(r["html_report"], dest / "report.html")
 
     # Build HTML
     html = f"""<!DOCTYPE html>
@@ -586,7 +586,7 @@ def generate_report(runs, title, overview, output_dir):
             r = model_runs[0]
             html += f'<div class="tab-content" id="tab-{escape(m)}">\n'
             if r["html_report"]:
-                html += f'  <iframe class="iframe-wrap" src="{quote(r['name'], safe='')}/eval-report-summary.html"></iframe>\n'
+                html += f'  <iframe class="iframe-wrap" src="{quote(r['name'], safe='')}/report.html"></iframe>\n'
             else:
                 html += '  <div class="page"><p>No HTML report available for this run.</p></div>\n'
             html += '</div>\n\n'
@@ -602,7 +602,7 @@ def generate_report(runs, title, overview, output_dir):
                 display = "" if j == 0 else ' style="display:none;"'
                 html += f'  <div class="sub-panel" data-model="{escape(m)}" data-idx="{j}"{display}>\n'
                 if r["html_report"]:
-                    html += f'    <iframe class="iframe-wrap" src="{quote(r['name'], safe='')}/eval-report-summary.html"></iframe>\n'
+                    html += f'    <iframe class="iframe-wrap" src="{quote(r['name'], safe='')}/report.html"></iframe>\n'
                 else:
                     html += '    <div class="page"><p>No HTML report available.</p></div>\n'
                 html += '  </div>\n'
@@ -685,11 +685,17 @@ def cmd_generate(args):
     groups = group_by_model(runs)
     print(f"Report generated: {path}")
     print(f"Runs: {len(runs)} across {len(groups)} models")
+    all_judges = get_all_judge_names(runs)
+    first_judge = all_judges[0] if all_judges else None
     for m, model_runs in groups.items():
-        aq = aggregate([get_judge_mean(r, "analysis_quality") for r in model_runs])
         cost = aggregate([get_metric(r, "cost_usd") for r in model_runs])
-        print(f"  {short_name(m)}: {len(model_runs)} run(s), "
-              f"AQ={fmt(aq['avg'], 'num')}, cost={fmt(cost['avg'], 'usd')}")
+        parts = [f"{short_name(m)}: {len(model_runs)} run(s)"]
+        if first_judge:
+            score = aggregate([get_judge_mean(r, first_judge) for r in model_runs])
+            label = first_judge.replace("_", " ").title()
+            parts.append(f"{label}={fmt(score['avg'], 'num')}")
+        parts.append(f"cost={fmt(cost['avg'], 'usd')}")
+        print(f"  {', '.join(parts)}")
 
 
 def main():

--- a/skills/eval-compare/scripts/compare.py
+++ b/skills/eval-compare/scripts/compare.py
@@ -587,7 +587,7 @@ def generate_report(runs, title, overview, output_dir):
             r = model_runs[0]
             html += f'<div class="tab-content" id="tab-{escape(m)}">\n'
             if r["html_report"]:
-                html += f'  <iframe class="iframe-wrap" src="{quote(r['name'], safe='')}/report.html"></iframe>\n'
+                html += f'  <iframe class="iframe-wrap" src="{quote(r["name"], safe="")}/report.html"></iframe>\n'
             else:
                 html += '  <div class="page"><p>No HTML report available for this run.</p></div>\n'
             html += '</div>\n\n'
@@ -603,7 +603,7 @@ def generate_report(runs, title, overview, output_dir):
                 display = "" if j == 0 else ' style="display:none;"'
                 html += f'  <div class="sub-panel" data-model="{escape(m)}" data-idx="{j}"{display}>\n'
                 if r["html_report"]:
-                    html += f'    <iframe class="iframe-wrap" src="{quote(r['name'], safe='')}/report.html"></iframe>\n'
+                    html += f'    <iframe class="iframe-wrap" src="{quote(r["name"], safe="")}/report.html"></iframe>\n'
                 else:
                     html += '    <div class="page"><p>No HTML report available.</p></div>\n'
                 html += '  </div>\n'

--- a/skills/eval-compare/scripts/compare.py
+++ b/skills/eval-compare/scripts/compare.py
@@ -523,7 +523,8 @@ def generate_report(runs, title, overview, output_dir):
                 continue
 
             judge_label = judge.replace("_", " ").title()
-            is_pct = _is_pass_rate(judge, get_judge_mean(runs[0], judge), runs)
+            sample_v = next((get_judge_mean(r, judge) for r in runs if get_judge_mean(r, judge) is not None), None)
+            is_pct = _is_pass_rate(judge, sample_v, runs)
             html += f'<section>\n<h2>Per-Case: {escape(judge_label)}</h2>\n'
             html += "<table><thead><tr><th>Case</th>"
             for m in models:
@@ -662,6 +663,7 @@ def cmd_discover(args):
     for r in runs:
         entry = {
             "name": r["name"],
+            "dir": r["dir"],
             "model": get_model(r),
             "cost_usd": get_metric(r, "cost_usd"),
             "judges": {j: get_judge_mean(r, j) for j in all_judge_names},

--- a/skills/eval-compare/scripts/compare.py
+++ b/skills/eval-compare/scripts/compare.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+"""Compare evaluation results across multiple models or runs.
+
+Usage:
+    compare.py discover <input-dir>
+    compare.py generate <input-dir> --output <dir> [--title TEXT] [--overview TEXT]
+"""
+
+import argparse
+import json
+import shutil
+import sys
+from collections import defaultdict
+from html import escape
+from pathlib import Path
+
+import yaml
+
+
+def load_yaml(path):
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def load_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def discover_runs(input_dir):
+    input_dir = Path(input_dir)
+    runs = []
+    for d in sorted(input_dir.iterdir()):
+        if not d.is_dir():
+            continue
+        summary_path = d / "summary.yaml"
+        if not summary_path.exists():
+            continue
+        summary = load_yaml(summary_path)
+        run = {
+            "dir": str(d),
+            "name": d.name,
+            "summary": summary,
+            "run_result": None,
+            "html_report": None,
+        }
+        result_path = d / "run_result.json"
+        if result_path.exists():
+            run["run_result"] = load_json(result_path)
+        html_path = d / "eval-report-summary.html"
+        if html_path.exists():
+            run["html_report"] = str(html_path)
+        runs.append(run)
+    return runs
+
+
+def get_model(run):
+    if run["run_result"]:
+        return run["run_result"].get("model", "unknown")
+    run_id = run["summary"].get("run_id", "")
+    for token in run_id.split("-"):
+        if token.startswith("claude"):
+            return run_id.split("-", 3)[-1] if "claude" in run_id else "unknown"
+    return "unknown"
+
+
+def get_metric(run, key, default=None):
+    rr = run["run_result"] or {}
+    if key == "cost_usd":
+        return rr.get("cost_usd", default)
+    if key == "num_turns":
+        return rr.get("num_turns", default)
+    if key == "wall_clock_s":
+        return rr.get("wall_clock_s", default)
+    if key == "output_tokens":
+        return (rr.get("token_usage") or {}).get("output", default)
+    if key == "cache_hit_rate":
+        return (run["summary"].get("run_metrics") or {}).get("cache_hit_rate", default)
+    if key == "cost_per_turn":
+        return (run["summary"].get("run_metrics") or {}).get("cost_per_turn_usd", default)
+    if key == "output_tokens_per_turn":
+        return (run["summary"].get("run_metrics") or {}).get("output_tokens_per_turn", default)
+    return default
+
+
+def get_judge_mean(run, judge_name):
+    judges = run["summary"].get("judges", {})
+    j = judges.get(judge_name, {})
+    if isinstance(j, dict):
+        v = j.get("mean")
+        if v is not None:
+            return v
+        return j.get("pass_rate")
+    return None
+
+
+def get_case_score(run, case_name, judge_name):
+    per_case = run["summary"].get("per_case", {})
+    case = per_case.get(case_name, {})
+    judge = case.get(judge_name, {})
+    return judge.get("value")
+
+
+def get_all_judge_names(runs):
+    names = set()
+    for r in runs:
+        for k in (r["summary"].get("judges") or {}):
+            names.add(k)
+    return sorted(names)
+
+
+def get_all_case_names(runs):
+    names = set()
+    for r in runs:
+        for k in (r["summary"].get("per_case") or {}):
+            names.add(k)
+    return sorted(names)
+
+
+def group_by_model(runs):
+    groups = defaultdict(list)
+    for r in runs:
+        groups[get_model(r)].append(r)
+    return dict(groups)
+
+
+def aggregate(values):
+    clean = [v for v in values if v is not None]
+    if not clean:
+        return {"avg": None, "min": None, "max": None, "count": 0}
+    return {
+        "avg": sum(clean) / len(clean),
+        "min": min(clean),
+        "max": max(clean),
+        "count": len(clean),
+    }
+
+
+MODEL_COLORS = {
+    "claude-opus-4-6": "#58a6ff",
+    "claude-opus-4-7": "#bc8cff",
+    "claude-opus-4-8": "#db6d28",
+    "claude-sonnet-4-6": "#f0883e",
+    "claude-sonnet-4-6[1m]": "#f0883e",
+    "claude-haiku-4-5": "#f85149",
+}
+
+MODEL_SHORT = {
+    "claude-opus-4-6": "Opus 4.6",
+    "claude-opus-4-7": "Opus 4.7",
+    "claude-opus-4-8": "Opus 4.8",
+    "claude-sonnet-4-6": "Sonnet 4.6",
+    "claude-sonnet-4-6[1m]": "Sonnet 4.6 [1M]",
+    "claude-haiku-4-5": "Haiku 4.5",
+}
+
+
+def short_name(model):
+    return MODEL_SHORT.get(model, model)
+
+
+def color_for(model):
+    return MODEL_COLORS.get(model, "#8b949e")
+
+
+def fmt(v, fmt_type="num"):
+    if v is None:
+        return "--"
+    if fmt_type == "usd":
+        return f"${v:,.2f}"
+    if fmt_type == "pct":
+        return f"{v * 100:.1f}%"
+    if fmt_type == "int":
+        return f"{int(v):,}"
+    if fmt_type == "time":
+        return f"{int(v / 60)} min"
+    if fmt_type == "tokens":
+        if v >= 1_000_000:
+            return f"{v / 1_000_000:.1f}M"
+        return f"{int(v / 1000)}K"
+    return f"{v:.2f}"
+
+
+def fmt_range(agg, fmt_type="num"):
+    if agg["count"] == 0:
+        return "--"
+    if agg["count"] == 1:
+        return fmt(agg["avg"], fmt_type)
+    return f"{fmt(agg['avg'], fmt_type)} ({fmt(agg['min'], fmt_type)}-{fmt(agg['max'], fmt_type)})"
+
+
+CSS = """
+:root {
+  --bg: #0d1117; --surface: #161b22; --surface2: #1c2333;
+  --border: #30363d; --text: #e6edf3; --text-muted: #8b949e;
+  --accent: #58a6ff; --green: #3fb950; --yellow: #d29922;
+  --red: #f85149; --orange: #db6d28; --purple: #bc8cff;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+       background: var(--bg); color: var(--text); line-height: 1.6; }
+.header { background: linear-gradient(135deg, #1a1e2e 0%, #0d1117 100%);
+           border-bottom: 1px solid var(--border); padding: 24px 32px; }
+.header h1 { font-size: 24px; font-weight: 600; margin-bottom: 4px; }
+.header .subtitle { color: var(--text-muted); font-size: 14px; }
+.tab-bar { display: flex; background: var(--surface); border-bottom: 1px solid var(--border);
+           padding: 0 16px; overflow-x: auto; }
+.tab-bar button { background: none; border: none; color: var(--text-muted); padding: 12px 20px;
+                  cursor: pointer; font-size: 14px; font-weight: 500;
+                  border-bottom: 2px solid transparent; white-space: nowrap; transition: all 0.15s; }
+.tab-bar button:hover { color: var(--text); background: rgba(255,255,255,0.03); }
+.tab-bar button.active { border-bottom-color: var(--accent); }
+.tab-content { display: none; }
+.tab-content.active { display: block; }
+.page { max-width: 1400px; margin: 0 auto; padding: 24px 32px; }
+.overview { background: var(--surface2); border: 1px solid var(--border); border-radius: 10px;
+            padding: 20px 24px; margin-bottom: 20px; font-size: 14px; line-height: 1.7; color: var(--text-muted); }
+.verdict { background: linear-gradient(135deg, rgba(63,185,80,0.08) 0%, rgba(88,166,255,0.06) 100%);
+           border: 1px solid rgba(63,185,80,0.25); border-radius: 12px;
+           padding: 24px 28px; margin-bottom: 28px; }
+.verdict h2 { font-size: 18px; color: var(--green); margin-bottom: 10px; }
+.verdict p { font-size: 15px; line-height: 1.7; }
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+         gap: 16px; margin-bottom: 28px; }
+.card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+        padding: 20px 24px; position: relative; }
+.card .badge { position: absolute; top: -10px; right: 16px; font-size: 11px; font-weight: 700;
+               padding: 3px 10px; border-radius: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
+.card h3 { font-size: 18px; font-weight: 600; margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
+.dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+.stats { display: grid; grid-template-columns: 1fr 1fr; gap: 10px 16px; }
+.stat { display: flex; flex-direction: column; }
+.stat .label { font-size: 11px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; display: block; }
+.stat .value { font-size: 20px; font-weight: 600; font-variant-numeric: tabular-nums; display: block; }
+.green { color: var(--green); } .yellow { color: var(--yellow); }
+.red { color: var(--red); } .muted { color: var(--text-muted); }
+section { margin-bottom: 32px; }
+section h2 { font-size: 17px; font-weight: 600; margin-bottom: 14px; padding-bottom: 8px;
+             border-bottom: 1px solid var(--border); }
+table { width: 100%; border-collapse: collapse; font-size: 13px; }
+thead th { text-align: left; padding: 10px 12px; background: var(--surface);
+           border-bottom: 1px solid var(--border); font-weight: 600; color: var(--text-muted);
+           text-transform: uppercase; font-size: 11px; letter-spacing: 0.5px; }
+tbody td { padding: 10px 12px; border-bottom: 1px solid var(--border); font-variant-numeric: tabular-nums; }
+tbody tr:hover { background: rgba(255,255,255,0.02); }
+.best { background: rgba(63,185,80,0.08); font-weight: 600; color: var(--green); }
+.worst { background: rgba(248,81,73,0.06); color: var(--red); }
+.insight { background: var(--surface2); border-left: 3px solid var(--accent); padding: 14px 18px;
+           margin: 14px 0; border-radius: 0 6px 6px 0; font-size: 14px; line-height: 1.6; }
+.iframe-wrap { width: 100%; height: calc(100vh - 90px); border: none; }
+.run-link { padding: 8px 16px; background: var(--surface); border-bottom: 1px solid var(--border); font-size: 12px; }
+.sub-bar { display: flex; align-items: center; gap: 4px; padding: 8px 16px;
+           background: var(--surface); border-bottom: 1px solid var(--border); }
+.sub-bar button { background: none; border: none; color: var(--text-muted); padding: 6px 14px;
+                  cursor: pointer; font-size: 13px; border-bottom: 2px solid transparent; font-weight: 500; }
+.sub-bar button.active { color: var(--accent); border-bottom-color: var(--accent); }
+@media (max-width: 900px) { .cards { grid-template-columns: 1fr; } .page { padding: 16px; } }
+"""
+
+
+def _rank_color(value, all_values, higher_is_better):
+    """Color a value green/yellow/red based on its rank among all_values."""
+    if value is None:
+        return "muted"
+    clean = sorted([v for v in all_values if v is not None],
+                   reverse=higher_is_better)
+    if len(clean) < 2:
+        return ""
+    if value == clean[0]:
+        return "green"
+    if value == clean[-1]:
+        return "red"
+    return "yellow"
+
+
+def best_worst_indices(values, higher_is_better=True):
+    clean = [(i, v) for i, v in enumerate(values) if v is not None]
+    if len(clean) < 2:
+        return None, None
+    if higher_is_better:
+        best_i = max(clean, key=lambda x: x[1])[0]
+        worst_i = min(clean, key=lambda x: x[1])[0]
+    else:
+        best_i = min(clean, key=lambda x: x[1])[0]
+        worst_i = max(clean, key=lambda x: x[1])[0]
+    if values[best_i] == values[worst_i]:
+        return None, None
+    return best_i, worst_i
+
+
+def render_comparison_table(models, rows, higher_is_better_map=None):
+    if higher_is_better_map is None:
+        higher_is_better_map = {}
+    html = "<table><thead><tr><th>Metric</th>"
+    for m in models:
+        html += f"<th>{escape(short_name(m))}</th>"
+    html += "</tr></thead><tbody>"
+    for label, values, fmt_type in rows:
+        higher = higher_is_better_map.get(label, True)
+        best_i, worst_i = best_worst_indices(values, higher)
+        html += f"<tr><td>{escape(label)}</td>"
+        for i, v in enumerate(values):
+            cls = ""
+            if i == best_i:
+                cls = ' class="best"'
+            elif i == worst_i:
+                cls = ' class="worst"'
+            html += f"<td{cls}>{fmt(v, fmt_type)}</td>"
+        html += "</tr>"
+    html += "</tbody></table>"
+    return html
+
+
+def generate_report(runs, title, overview, output_dir):
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    groups = group_by_model(runs)
+    # Sort models: best analysis quality first
+    models = sorted(groups.keys(),
+                    key=lambda m: aggregate([get_judge_mean(r, "analysis_quality")
+                                             for r in groups[m]]).get("avg") or 0,
+                    reverse=True)
+
+    model_aggs = {}
+    for m, model_runs in groups.items():
+        agg = {}
+        for key in ["cost_usd", "num_turns", "wall_clock_s", "output_tokens",
+                     "cache_hit_rate", "cost_per_turn", "output_tokens_per_turn"]:
+            agg[key] = aggregate([get_metric(r, key) for r in model_runs])
+        for judge in get_all_judge_names(runs):
+            agg[f"judge_{judge}"] = aggregate([get_judge_mean(r, judge) for r in model_runs])
+        model_aggs[m] = agg
+
+    best_quality_model = max(models, key=lambda m: (model_aggs[m].get("judge_analysis_quality", {}).get("avg") or 0))
+    cheapest_model = min(models, key=lambda m: (model_aggs[m]["cost_usd"].get("avg") or float("inf")))
+
+    # Copy HTML reports
+    for r in runs:
+        if r["html_report"]:
+            dest = output_dir / r["name"]
+            dest.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(r["html_report"], dest / "eval-report-summary.html")
+
+    # Build HTML
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{escape(title)}</title>
+<style>{CSS}</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>{escape(title)}</h1>
+  <div class="subtitle">{len(runs)} eval runs across {len(models)} models</div>
+</div>
+
+<div class="tab-bar" id="tabBar">
+  <button class="active" data-tab="comparison" data-color="var(--accent)">Comparison</button>
+"""
+    for m in models:
+        model_runs = groups[m]
+        label = short_name(m)
+        if len(model_runs) > 1:
+            label += f" ({len(model_runs)} runs)"
+        c = color_for(m)
+        html += f'  <button data-tab="{escape(m)}" data-color="{c}">{escape(label)}</button>\n'
+
+    html += "</div>\n\n"
+
+    # Comparison tab
+    html += '<div class="tab-content active" id="tab-comparison">\n<div class="page">\n'
+
+    if overview:
+        html += f'<div class="overview">{overview}</div>\n'
+
+    # Bottom Line: auto-generated summary, agent replaces with LLM analysis in Step 3
+    html += '<div class="verdict">\n<h2>Bottom Line</h2>\n<p>'
+    for m in models:
+        agg = model_aggs[m]
+        aq = agg.get("judge_analysis_quality", {}).get("avg")
+        cost = agg["cost_usd"].get("avg")
+        parts = []
+        if aq is not None:
+            parts.append(f"{aq:.2f}/5 quality")
+        if cost is not None:
+            parts.append(f"${cost:.2f}/run")
+        detail = ", ".join(parts)
+        html += f'<strong>{escape(short_name(m))}</strong>: {detail}. '
+    html += "</p>\n</div>\n\n"
+
+    # Pre-compute all values for relative coloring
+    all_aq = [model_aggs[m].get("judge_analysis_quality", {}).get("avg") for m in models]
+    all_rs = [model_aggs[m].get("judge_revert_scoring_accuracy", {}).get("avg") for m in models]
+    all_cost = [model_aggs[m]["cost_usd"].get("avg") for m in models]
+    all_wall = [model_aggs[m]["wall_clock_s"].get("avg") for m in models]
+
+    # Model cards
+    html += '<div class="cards">\n'
+    for m in models:
+        agg = model_aggs[m]
+        c = color_for(m)
+        extra_style = ""
+        badge = ""
+        if m == best_quality_model and m == cheapest_model:
+            extra_style = f' style="border-color: var(--green);"'
+            badge = '<div class="badge" style="background: var(--green); color: #000;">Best Value</div>'
+        elif m == best_quality_model:
+            extra_style = f' style="border-color: var(--green);"'
+            badge = '<div class="badge" style="background: var(--green); color: #000;">Best Quality</div>'
+
+        aq = agg.get("judge_analysis_quality", {}).get("avg")
+        rs = agg.get("judge_revert_scoring_accuracy", {}).get("avg")
+        cost = agg["cost_usd"].get("avg")
+        turns = agg["num_turns"].get("avg")
+        out_tok = agg["output_tokens"].get("avg")
+        wall = agg["wall_clock_s"].get("avg")
+
+        html += f'<div class="card"{extra_style}>{badge}\n'
+        html += f'  <h3><span class="dot" style="background:{c}"></span> {escape(short_name(m))}'
+        n = len(groups[m])
+        if n > 1:
+            html += f' <span style="font-size:11px; color:var(--text-muted); font-weight:400;">({n} runs avg)</span>'
+        html += '</h3>\n  <div class="stats">\n'
+
+        html += f'    <div class="stat"><span class="label">Analysis Quality</span><span class="value {_rank_color(aq, all_aq, True)}">{fmt(aq, "num") if aq else "--"}</span></div>\n'
+        html += f'    <div class="stat"><span class="label">Revert Scoring</span><span class="value {_rank_color(rs, all_rs, True)}">{fmt(rs, "num") if rs else "--"}</span></div>\n'
+        html += f'    <div class="stat"><span class="label">{"Avg Run Cost" if n > 1 else "Total Cost"}</span><span class="value {_rank_color(cost, all_cost, False)}">{fmt(cost, "usd")}</span></div>\n'
+        html += f'    <div class="stat"><span class="label">Wall Clock</span><span class="value {_rank_color(wall, all_wall, False)}">{fmt(wall, "time")}</span></div>\n'
+        html += f'    <div class="stat"><span class="label">Output Tokens</span><span class="value">{fmt(out_tok, "tokens")}</span></div>\n'
+        html += f'    <div class="stat"><span class="label">Turns</span><span class="value">{fmt(turns, "int")}</span></div>\n'
+        html += '  </div>\n</div>\n'
+    html += '</div>\n\n'
+
+    # Cost table
+    html += '<section>\n<h2>Cost &amp; Efficiency</h2>\n'
+    cost_rows = []
+    for label, key, ft, hib in [
+        ("Total Cost", "cost_usd", "usd", False),
+        ("Output Tokens", "output_tokens", "tokens", False),
+        ("Tokens / Turn", "output_tokens_per_turn", "int", True),
+        ("Total Turns", "num_turns", "int", False),
+        ("Wall Clock", "wall_clock_s", "time", False),
+        ("Cost / Turn", "cost_per_turn", "usd", False),
+        ("Cache Hit Rate", "cache_hit_rate", "pct", True),
+    ]:
+        values = [model_aggs[m][key].get("avg") for m in models]
+        cost_rows.append((label, values, ft))
+    hib_map = {"Total Cost": False, "Output Tokens": False, "Total Turns": False,
+               "Wall Clock": False, "Cost / Turn": False, "Tokens / Turn": True, "Cache Hit Rate": True}
+    html += render_comparison_table(models, cost_rows, hib_map)
+    html += '</section>\n\n'
+
+    # Quality table
+    all_judges = get_all_judge_names(runs)
+    html += '<section>\n<h2>Quality Scores</h2>\n'
+    quality_rows = []
+    for judge in all_judges:
+        values = []
+        for m in models:
+            agg = model_aggs[m].get(f"judge_{judge}", {})
+            v = agg.get("avg")
+            n = agg.get("count", 0)
+            values.append(v)
+        is_pass_rate = all(v is not None and v <= 1.0 for v in values if v is not None)
+        ft = "pct" if is_pass_rate and judge not in ("analysis_quality", "revert_scoring_accuracy") else "num"
+        label = judge.replace("_", " ").title()
+        quality_rows.append((label, values, ft))
+    html += render_comparison_table(models, quality_rows)
+    html += '</section>\n\n'
+
+    # Per-case analysis quality
+    all_cases = get_all_case_names(runs)
+    if all_cases:
+        html += '<section>\n<h2>Per-Case Analysis Quality</h2>\n'
+        html += "<table><thead><tr><th>Case</th>"
+        for m in models:
+            html += f"<th>{escape(short_name(m))}</th>"
+        html += "</tr></thead><tbody>"
+        for case in all_cases:
+            case_short = case.replace("case-", "").replace("-", " ", 1).split(" ", 1)
+            label = case_short[1] if len(case_short) > 1 else case
+            html += f"<tr><td>{escape(label)}</td>"
+            values = []
+            for m in models:
+                scores = [get_case_score(r, case, "analysis_quality") for r in groups[m]]
+                agg = aggregate(scores)
+                values.append(agg["avg"])
+            best_i, worst_i = best_worst_indices(values, True)
+            for i, v in enumerate(values):
+                cls = ""
+                if i == best_i:
+                    cls = ' class="best"'
+                elif i == worst_i:
+                    cls = ' class="worst"'
+                if v is not None:
+                    n = model_aggs[models[i]].get("judge_analysis_quality", {}).get("count", 1)
+                    cell = f"{v:.1f}" if n > 1 else f"{int(v)}"
+                else:
+                    cell = "--"
+                html += f"<td{cls}>{cell}</td>"
+            html += "</tr>"
+        html += "</tbody></table>\n</section>\n\n"
+
+    html += '</div>\n</div>\n\n'
+
+    # Report tabs for each model
+    for m in models:
+        model_runs = groups[m]
+        c = color_for(m)
+
+        if len(model_runs) == 1:
+            r = model_runs[0]
+            html += f'<div class="tab-content" id="tab-{escape(m)}">\n'
+            if r["html_report"]:
+                html += f'  <iframe class="iframe-wrap" src="{r["name"]}/eval-report-summary.html"></iframe>\n'
+            else:
+                html += '  <div class="page"><p>No HTML report available for this run.</p></div>\n'
+            html += '</div>\n\n'
+        else:
+            html += f'<div class="tab-content" id="tab-{escape(m)}">\n'
+            html += f'  <div class="sub-bar" id="subbar-{escape(m)}">\n'
+            for j, r in enumerate(model_runs):
+                active = " active" if j == 0 else ""
+                act_style = f"color:var(--accent); border-bottom-color:var(--accent);" if j == 0 else ""
+                html += f'    <button class="{active}" data-sub="{j}" style="{act_style}">Run {j + 1} ({r["name"]})</button>\n'
+            html += '  </div>\n'
+            for j, r in enumerate(model_runs):
+                display = "" if j == 0 else ' style="display:none;"'
+                html += f'  <div class="sub-panel" data-model="{escape(m)}" data-idx="{j}"{display}>\n'
+                if r["html_report"]:
+                    html += f'    <iframe class="iframe-wrap" src="{r["name"]}/eval-report-summary.html"></iframe>\n'
+                else:
+                    html += '    <div class="page"><p>No HTML report available.</p></div>\n'
+                html += '  </div>\n'
+            html += '</div>\n\n'
+
+    # JavaScript
+    html += """<script>
+document.getElementById('tabBar').addEventListener('click', e => {
+  if (e.target.tagName !== 'BUTTON') return;
+  document.querySelectorAll('.tab-bar button').forEach(b => {
+    b.classList.remove('active'); b.style.color = ''; b.style.borderBottomColor = '';
+  });
+  document.querySelectorAll('.tab-content').forEach(t => t.classList.remove('active'));
+  const c = e.target.dataset.color;
+  e.target.classList.add('active');
+  e.target.style.color = c; e.target.style.borderBottomColor = c;
+  document.getElementById('tab-' + e.target.dataset.tab).classList.add('active');
+});
+const initTab = document.querySelector('.tab-bar button.active');
+if (initTab) { initTab.style.color = initTab.dataset.color; initTab.style.borderBottomColor = initTab.dataset.color; }
+
+document.querySelectorAll('.sub-bar').forEach(bar => {
+  bar.addEventListener('click', e => {
+    if (e.target.tagName !== 'BUTTON') return;
+    bar.querySelectorAll('button').forEach(b => {
+      b.classList.remove('active'); b.style.color = 'var(--text-muted)'; b.style.borderBottomColor = 'transparent';
+    });
+    e.target.classList.add('active');
+    e.target.style.color = 'var(--accent)'; e.target.style.borderBottomColor = 'var(--accent)';
+    const idx = e.target.dataset.sub;
+    const parent = bar.parentElement;
+    parent.querySelectorAll('.sub-panel').forEach(p => p.style.display = 'none');
+    parent.querySelector('.sub-panel[data-idx="' + idx + '"]').style.display = '';
+  });
+});
+</script>
+</body>
+</html>"""
+
+    out_path = output_dir / "index.html"
+    with open(out_path, "w") as f:
+        f.write(html)
+    return str(out_path)
+
+
+def cmd_discover(args):
+    runs = discover_runs(args.input_dir)
+    if not runs:
+        print(json.dumps({"error": "No valid runs found", "runs": []}))
+        sys.exit(1)
+    out = []
+    for r in runs:
+        entry = {
+            "name": r["name"],
+            "model": get_model(r),
+            "cost_usd": get_metric(r, "cost_usd"),
+            "analysis_quality": get_judge_mean(r, "analysis_quality"),
+            "revert_scoring": get_judge_mean(r, "revert_scoring_accuracy"),
+            "has_html": r["html_report"] is not None,
+        }
+        out.append(entry)
+    print(json.dumps({"runs": out}, indent=2))
+
+
+def cmd_generate(args):
+    runs = discover_runs(args.input_dir)
+    if not runs:
+        print("ERROR: No valid runs found", file=sys.stderr)
+        sys.exit(1)
+    path = generate_report(runs, args.title, args.overview, args.output)
+    groups = group_by_model(runs)
+    print(f"Report generated: {path}")
+    print(f"Runs: {len(runs)} across {len(groups)} models")
+    for m, model_runs in groups.items():
+        aq = aggregate([get_judge_mean(r, "analysis_quality") for r in model_runs])
+        cost = aggregate([get_metric(r, "cost_usd") for r in model_runs])
+        print(f"  {short_name(m)}: {len(model_runs)} run(s), "
+              f"AQ={fmt(aq['avg'], 'num')}, cost={fmt(cost['avg'], 'usd')}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command")
+
+    p_discover = sub.add_parser("discover")
+    p_discover.add_argument("input_dir")
+
+    p_generate = sub.add_parser("generate")
+    p_generate.add_argument("input_dir")
+    p_generate.add_argument("--output", required=True)
+    p_generate.add_argument("--title", default="Model Comparison")
+    p_generate.add_argument("--overview", default=None)
+
+    args = parser.parse_args()
+    if args.command == "discover":
+        cmd_discover(args)
+    elif args.command == "generate":
+        cmd_generate(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/eval-compare/scripts/compare.py
+++ b/skills/eval-compare/scripts/compare.py
@@ -298,32 +298,55 @@ def fmt_range(agg, fmt_type="num"):
 
 CSS = """
 :root {
-  --bg: #0d1117; --surface: #161b22; --surface2: #1c2333;
-  --border: #30363d; --text: #e6edf3; --text-muted: #8b949e;
-  --accent: #58a6ff; --green: #3fb950; --yellow: #d29922;
-  --red: #f85149; --orange: #db6d28; --purple: #bc8cff;
+  --bg: #cbd1da; --surface: #ffffff; --surface2: #f1f5f9;
+  --border: #e2e8f0; --text: #0f172a; --text-muted: #64748b;
+  --accent: #2563eb; --green: #16a34a; --yellow: #d97706; --red: #dc2626;
+  --hover: rgba(15,23,42,0.04);
+  --best-bg: #dcfce7; --worst-bg: #fee2e2;
+  --header-1: #ffffff; --header-2: #e2e8f0;
+  --verdict-1: rgba(22,163,74,0.08); --verdict-2: rgba(37,99,235,0.06);
+  --verdict-border: rgba(22,163,74,0.35);
+  color-scheme: light;
+}
+:root[data-theme="dark"] {
+  --bg: #0b1220; --surface: #0f1729; --surface2: #162033;
+  --border: #1e2c44; --text: #e2e8f0; --text-muted: #94a3b8;
+  --accent: #60a5fa; --green: #4ade80; --yellow: #fbbf24; --red: #f87171;
+  --hover: rgba(255,255,255,0.03);
+  --best-bg: rgba(74,222,128,0.10); --worst-bg: rgba(248,113,113,0.10);
+  --header-1: #162033; --header-2: #0b1220;
+  --verdict-1: rgba(74,222,128,0.08); --verdict-2: rgba(96,165,250,0.06);
+  --verdict-border: rgba(74,222,128,0.25);
+  color-scheme: dark;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
+html { background: var(--bg); }
 body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-       background: var(--bg); color: var(--text); line-height: 1.6; }
-.header { background: linear-gradient(135deg, #1a1e2e 0%, #0d1117 100%);
+       background: var(--bg); color: var(--text); line-height: 1.6;
+       transition: background-color .15s ease, color .15s ease; }
+.header { position: relative; background: linear-gradient(135deg, var(--header-1) 0%, var(--header-2) 100%);
            border-bottom: 1px solid var(--border); padding: 24px 32px; }
 .header h1 { font-size: 24px; font-weight: 600; margin-bottom: 4px; }
 .header .subtitle { color: var(--text-muted); font-size: 14px; }
+#theme-toggle { position: absolute; top: 20px; right: 24px; width: 34px; height: 34px;
+                background: var(--surface); border: 1px solid var(--border); color: var(--text);
+                border-radius: 8px; cursor: pointer; font-size: 16px; line-height: 1;
+                display: flex; align-items: center; justify-content: center; transition: border-color .15s; }
+#theme-toggle:hover { border-color: var(--accent); }
 .tab-bar { display: flex; background: var(--surface); border-bottom: 1px solid var(--border);
            padding: 0 16px; overflow-x: auto; }
 .tab-bar button { background: none; border: none; color: var(--text-muted); padding: 12px 20px;
                   cursor: pointer; font-size: 14px; font-weight: 500;
                   border-bottom: 2px solid transparent; white-space: nowrap; transition: all 0.15s; }
-.tab-bar button:hover { color: var(--text); background: rgba(255,255,255,0.03); }
+.tab-bar button:hover { color: var(--text); background: var(--hover); }
 .tab-bar button.active { border-bottom-color: var(--accent); }
 .tab-content { display: none; }
 .tab-content.active { display: block; }
 .page { max-width: 1400px; margin: 0 auto; padding: 24px 32px; }
 .overview { background: var(--surface2); border: 1px solid var(--border); border-radius: 10px;
             padding: 20px 24px; margin-bottom: 20px; font-size: 14px; line-height: 1.7; color: var(--text-muted); }
-.verdict { background: linear-gradient(135deg, rgba(63,185,80,0.08) 0%, rgba(88,166,255,0.06) 100%);
-           border: 1px solid rgba(63,185,80,0.25); border-radius: 12px;
+.verdict { background: linear-gradient(135deg, var(--verdict-1) 0%, var(--verdict-2) 100%);
+           border: 1px solid var(--verdict-border); border-radius: 12px;
            padding: 24px 28px; margin-bottom: 28px; }
 .verdict h2 { font-size: 18px; color: var(--green); margin-bottom: 10px; }
 .verdict p { font-size: 15px; line-height: 1.7; }
@@ -349,9 +372,9 @@ thead th { text-align: left; padding: 10px 12px; background: var(--surface);
            border-bottom: 1px solid var(--border); font-weight: 600; color: var(--text-muted);
            text-transform: uppercase; font-size: 11px; letter-spacing: 0.5px; }
 tbody td { padding: 10px 12px; border-bottom: 1px solid var(--border); font-variant-numeric: tabular-nums; }
-tbody tr:hover { background: rgba(255,255,255,0.02); }
-.best { background: rgba(63,185,80,0.08); font-weight: 600; color: var(--green); }
-.worst { background: rgba(248,81,73,0.06); color: var(--red); }
+tbody tr:hover { background: var(--hover); }
+.best { background: var(--best-bg); font-weight: 600; color: var(--green); }
+.worst { background: var(--worst-bg); color: var(--red); }
 .insight { background: var(--surface2); border-left: 3px solid var(--accent); padding: 14px 18px;
            margin: 14px 0; border-radius: 0 6px 6px 0; font-size: 14px; line-height: 1.6; }
 .analysis-section { background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
@@ -370,6 +393,42 @@ tbody tr:hover { background: rgba(255,255,255,0.02); }
                   cursor: pointer; font-size: 13px; border-bottom: 2px solid transparent; font-weight: 500; }
 .sub-bar button.active { color: var(--accent); border-bottom-color: var(--accent); }
 @media (max-width: 900px) { .cards { grid-template-columns: 1fr; } .page { padding: 16px; } }
+@media print { :root { color-scheme: light; } }
+"""
+
+
+# Set the theme before first paint (avoids a flash). Shares the localStorage key
+# with the per-run eval reports (report.py) so a chosen theme carries across both.
+THEME_SCRIPT = """
+(function () {
+  try {
+    var stored = localStorage.getItem('eval-report-theme');
+    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    document.documentElement.setAttribute('data-theme', stored || (prefersDark ? 'dark' : 'light'));
+  } catch (e) {
+    document.documentElement.setAttribute('data-theme', 'light');
+  }
+})();
+"""
+
+TOGGLE_SCRIPT = """
+(function () {
+  var btn = document.getElementById('theme-toggle');
+  if (!btn) return;
+  function paint() {
+    var t = document.documentElement.getAttribute('data-theme') || 'light';
+    btn.textContent = t === 'dark' ? '\\u2600' : '\\u263E';
+    btn.title = t === 'dark' ? 'Switch to light theme' : 'Switch to dark theme';
+    btn.setAttribute('aria-label', btn.title);
+  }
+  btn.addEventListener('click', function () {
+    var next = (document.documentElement.getAttribute('data-theme') || 'light') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    try { localStorage.setItem('eval-report-theme', next); } catch (e) {}
+    paint();
+  });
+  paint();
+})();
 """
 
 
@@ -483,10 +542,12 @@ def generate_report(runs, title, overview, output_dir):
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{escape(title)}</title>
 <style>{CSS}</style>
+<script>{THEME_SCRIPT}</script>
 </head>
 <body>
 
 <div class="header">
+  <button id="theme-toggle" type="button" aria-label="Toggle theme">&#9728;</button>
   <h1>{escape(title)}</h1>
   <div class="subtitle">{len(runs)} eval runs across {len(models)} models</div>
 </div>
@@ -720,8 +781,7 @@ document.querySelectorAll('.sub-bar').forEach(bar => {
   });
 });
 </script>
-</body>
-</html>"""
+""" + f"<script>{TOGGLE_SCRIPT}</script>\n</body>\n</html>"
 
     out_path = output_dir / "index.html"
     with open(out_path, "w") as f:

--- a/skills/eval-compare/scripts/compare.py
+++ b/skills/eval-compare/scripts/compare.py
@@ -8,6 +8,7 @@ Usage:
 
 import argparse
 import json
+import re
 import shutil
 import sys
 from collections import defaultdict
@@ -19,13 +20,59 @@ import yaml
 
 
 def load_yaml(path):
-    with open(path) as f:
-        return yaml.safe_load(f) or {}
+    """Load a YAML mapping, tolerating unreadable/malformed files.
+
+    Returns {} on any read/parse error or when the document is not a mapping,
+    so a single corrupt summary.yaml never aborts the whole comparison.
+    """
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f)
+    except (OSError, yaml.YAMLError) as e:
+        print(f"WARNING: could not parse {path}: {e}", file=sys.stderr)
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def load_json(path):
-    with open(path) as f:
-        return json.load(f)
+    """Load a JSON object, tolerating unreadable/malformed files.
+
+    Returns None on any read/parse error so the run is treated as missing its
+    run_result.json rather than crashing the whole comparison.
+    """
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"WARNING: could not parse {path}: {e}", file=sys.stderr)
+        return None
+
+
+def _slugify(text):
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", text).strip("-")
+    return slug or "run"
+
+
+def _unique_slug(run_dir, input_dir, used):
+    """Filesystem-safe, unique-per-run identifier.
+
+    Derived from the run directory's path relative to input_dir (not just its
+    basename), so two runs whose parent dirs differ but whose basenames match
+    (e.g. evalA/2026-07-30-opus and evalB/2026-07-30-opus) do not collide when
+    their report.html is copied into the output tree or referenced by iframes.
+    """
+    try:
+        rel = run_dir.relative_to(input_dir)
+    except ValueError:
+        rel = Path(run_dir.name)
+    base = _slugify(rel.as_posix())
+    slug = base
+    i = 2
+    while slug in used:
+        slug = f"{base}-{i}"
+        i += 1
+    used.add(slug)
+    return slug
 
 
 def discover_runs(input_dir):
@@ -33,12 +80,14 @@ def discover_runs(input_dir):
     if not input_dir.exists() or not input_dir.is_dir():
         raise NotADirectoryError(f"Input directory not found: {input_dir}")
     runs = []
+    used_slugs = set()
     for summary_path in sorted(input_dir.rglob("summary.yaml")):
         d = summary_path.parent
         summary = load_yaml(summary_path)
         run = {
             "dir": str(d),
             "name": d.name,
+            "slug": _unique_slug(d, input_dir, used_slugs),
             "summary": summary,
             "run_result": None,
             "html_report": None,
@@ -55,12 +104,19 @@ def discover_runs(input_dir):
 
 def get_model(run):
     if run["run_result"]:
-        return run["run_result"].get("model", "unknown")
-    run_id = run["summary"].get("run_id", "")
-    for token in run_id.split("-"):
-        if token.startswith("claude"):
-            return run_id.split("-", 3)[-1] if "claude" in run_id else "unknown"
-    return "unknown"
+        return run["run_result"].get("model") or "unknown"
+    # No run_result.json: recover the model from the run_id if it embeds a
+    # "claude-..." id (default run_ids can look like "<date>-claude-opus-4-8").
+    # Reconstruct the FULL id so it matches the run_result branch and the
+    # MODEL_COLORS/MODEL_SHORT keys — never a bare "opus-4-8".
+    run_id = run["summary"].get("run_id", "") or ""
+    tokens = run_id.split("-")
+    for i, token in enumerate(tokens):
+        if token == "claude":
+            return "-".join(tokens[i:])
+    # Truly unknown: fall back to the run's own name so distinct runs are not
+    # merged (and averaged) together under a single meaningless "unknown" model.
+    return run.get("name") or "unknown"
 
 
 def get_metric(run, key, default=None):
@@ -108,17 +164,18 @@ def get_all_judge_names(runs):
     return sorted(names)
 
 
-def _is_pass_rate(judge_name, value, runs):
-    """Heuristic: a judge is pass-rate style if all its per-case values are 0 or 1."""
-    if value is None:
-        return False
+def _is_pass_rate(judge_name, runs):
+    """Whether a judge is pass-rate (boolean) style.
+
+    Authoritative, not a value-shape guess: score.py records a ``pass_rate`` for
+    boolean judges and leaves it ``None`` for numeric ones, so a numeric judge
+    whose scores happen to all be 0/1 is no longer mis-rendered as a percentage.
+    """
     for r in runs:
-        for case in (r["summary"].get("per_case") or {}).values():
-            j = case.get(judge_name, {})
-            v = j.get("value")
-            if v is not None and v not in (0, 1, True, False, 0.0, 1.0):
-                return False
-    return True
+        j = (r["summary"].get("judges") or {}).get(judge_name)
+        if isinstance(j, dict) and j.get("pass_rate") is not None:
+            return True
+    return False
 
 
 def pick_card_judges(all_judges, model_aggs, models, max_judges=4):
@@ -170,6 +227,7 @@ MODEL_COLORS = {
     "claude-opus-4-6": "#58a6ff",
     "claude-opus-4-7": "#bc8cff",
     "claude-opus-4-8": "#db6d28",
+    "claude-opus-4-8[1m]": "#db6d28",
     "claude-sonnet-4-6": "#f0883e",
     "claude-sonnet-4-6[1m]": "#f0883e",
     "claude-haiku-4-5": "#f85149",
@@ -179,6 +237,7 @@ MODEL_SHORT = {
     "claude-opus-4-6": "Opus 4.6",
     "claude-opus-4-7": "Opus 4.7",
     "claude-opus-4-8": "Opus 4.8",
+    "claude-opus-4-8[1m]": "Opus 4.8 [1M]",
     "claude-sonnet-4-6": "Sonnet 4.6",
     "claude-sonnet-4-6[1m]": "Sonnet 4.6 [1M]",
     "claude-haiku-4-5": "Haiku 4.5",
@@ -186,7 +245,21 @@ MODEL_SHORT = {
 
 
 def short_name(model):
-    return MODEL_SHORT.get(model, model)
+    """Human-readable model label.
+
+    Falls back to deriving one from a "claude-<family>-<version>[suffix]" id so
+    models not in MODEL_SHORT (e.g. a newly-shipped version) still render cleanly
+    instead of showing the raw id.
+    """
+    if model in MODEL_SHORT:
+        return MODEL_SHORT[model]
+    m = re.match(r"^claude-([a-z]+)-([0-9]+(?:-[0-9]+)*)(\[.*\])?$", model or "")
+    if m:
+        family = m.group(1).capitalize()
+        version = m.group(2).replace("-", ".")
+        suffix = f" {m.group(3).upper()}" if m.group(3) else ""
+        return f"{family} {version}{suffix}"
+    return model
 
 
 def color_for(model):
@@ -203,11 +276,15 @@ def fmt(v, fmt_type="num"):
     if fmt_type == "int":
         return f"{int(v):,}"
     if fmt_type == "time":
+        if v < 60:
+            return f"{int(v)}s"
         return f"{int(v / 60)} min"
     if fmt_type == "tokens":
         if v >= 1_000_000:
             return f"{v / 1_000_000:.1f}M"
-        return f"{int(v / 1000)}K"
+        if v >= 1000:
+            return f"{v / 1000:.1f}K"
+        return f"{int(v)}"
     return f"{v:.2f}"
 
 
@@ -302,7 +379,9 @@ def _rank_color(value, all_values, higher_is_better):
         return "muted"
     clean = sorted([v for v in all_values if v is not None],
                    reverse=higher_is_better)
-    if len(clean) < 2:
+    # Need at least two distinct values to rank; when everything ties, nothing
+    # is uniquely best or worst, so leave it uncolored.
+    if len(clean) < 2 or clean[0] == clean[-1]:
         return ""
     if value == clean[0]:
         return "green"
@@ -326,24 +405,29 @@ def best_worst_indices(values, higher_is_better=True):
     return best_i, worst_i
 
 
-def render_comparison_table(models, rows, higher_is_better_map=None):
-    if higher_is_better_map is None:
-        higher_is_better_map = {}
+def render_comparison_table(models, rows):
+    """Render a metric-by-model table.
+
+    Each row is ``(label, aggs, fmt_type, higher_is_better)`` where ``aggs`` is a
+    per-model list of aggregate() dicts. Best/worst highlighting is computed on
+    each aggregate's ``avg``; cells show ``avg (min-max)`` for models with more
+    than one run (via fmt_range) and just the value for single-run models.
+    """
     html = "<table><thead><tr><th>Metric</th>"
     for m in models:
         html += f"<th>{escape(short_name(m))}</th>"
     html += "</tr></thead><tbody>"
-    for label, values, fmt_type in rows:
-        higher = higher_is_better_map.get(label, True)
+    for label, aggs, fmt_type, higher in rows:
+        values = [a.get("avg") for a in aggs]
         best_i, worst_i = best_worst_indices(values, higher)
         html += f"<tr><td>{escape(label)}</td>"
-        for i, v in enumerate(values):
+        for i, a in enumerate(aggs):
             cls = ""
             if i == best_i:
                 cls = ' class="best"'
             elif i == worst_i:
                 cls = ' class="worst"'
-            html += f"<td{cls}>{fmt(v, fmt_type)}</td>"
+            html += f"<td{cls}>{fmt_range(a, fmt_type)}</td>"
         html += "</tr>"
     html += "</tbody></table>"
     return html
@@ -354,36 +438,40 @@ def generate_report(runs, title, overview, output_dir):
     output_dir.mkdir(parents=True, exist_ok=True)
 
     groups = group_by_model(runs)
-    all_judges_for_sort = get_all_judge_names(runs)
-    first_judge = all_judges_for_sort[0] if all_judges_for_sort else None
-    if first_judge:
-        models = sorted(groups.keys(),
-                        key=lambda m: aggregate([get_judge_mean(r, first_judge)
-                                                 for r in groups[m]]).get("avg") or 0,
-                        reverse=True)
-    else:
-        models = sorted(groups.keys())
+    all_judges = get_all_judge_names(runs)
 
+    # Aggregate per model first (order-independent) so we can rank judges by
+    # cross-model variance before deciding the tab/card order.
     model_aggs = {}
     for m, model_runs in groups.items():
         agg = {}
         for key in ["cost_usd", "num_turns", "wall_clock_s", "output_tokens",
                      "cache_hit_rate", "cost_per_turn", "output_tokens_per_turn"]:
             agg[key] = aggregate([get_metric(r, key) for r in model_runs])
-        for judge in get_all_judge_names(runs):
+        for judge in all_judges:
             agg[f"judge_{judge}"] = aggregate([get_judge_mean(r, judge) for r in model_runs])
         model_aggs[m] = agg
 
-    all_judges = get_all_judge_names(runs)
-    card_judges = pick_card_judges(all_judges, model_aggs, models)
-    primary_judge = card_judges[0] if card_judges else None
+    # The most discriminating judge (highest variance across models) drives both
+    # the card stats and the model ordering — not the alphabetically-first judge.
+    card_judges = pick_card_judges(all_judges, model_aggs, list(groups.keys()))
+    primary_judge = card_judges[0] if card_judges else (all_judges[0] if all_judges else None)
+    if primary_judge:
+        models = sorted(groups.keys(),
+                        key=lambda m: model_aggs[m].get(f"judge_{primary_judge}", {}).get("avg") or 0,
+                        reverse=True)
+    else:
+        models = sorted(groups.keys())
+
+    multi_run = any(len(model_runs) > 1 for model_runs in groups.values())
 
     # Badges are added by the LLM agent in Step 3, not auto-computed
 
-    # Copy HTML reports
+    # Copy HTML reports into a unique per-run subdir (slug), so runs that share a
+    # directory basename don't overwrite each other or alias the same iframe.
     for r in runs:
         if r["html_report"]:
-            dest = output_dir / r["name"]
+            dest = output_dir / r["slug"]
             dest.mkdir(parents=True, exist_ok=True)
             shutil.copy2(r["html_report"], dest / "report.html")
 
@@ -439,15 +527,15 @@ def generate_report(runs, title, overview, output_dir):
     for m in models:
         agg = model_aggs[m]
         c = color_for(m)
-        extra_style = ""
-        badge = ""
 
         cost = agg["cost_usd"].get("avg")
         turns = agg["num_turns"].get("avg")
         out_tok = agg["output_tokens"].get("avg")
         wall = agg["wall_clock_s"].get("avg")
 
-        html += f'<div class="card"{extra_style}>{badge}\n'
+        # The badge <div> and card border-color are injected by the LLM agent
+        # in Step 3 (see SKILL.md); the generator emits a plain card.
+        html += '<div class="card">\n'
         html += f'  <h3><span class="dot" style="background:{c}"></span> {escape(short_name(m))}'
         n = len(groups[m])
         if n > 1:
@@ -456,7 +544,7 @@ def generate_report(runs, title, overview, output_dir):
 
         for judge in card_judges:
             jv = agg.get(f"judge_{judge}", {}).get("avg")
-            is_pct = _is_pass_rate(judge, jv, runs)
+            is_pct = _is_pass_rate(judge, runs)
             judge_label = judge.replace("_", " ").title()
             rank_cls = _rank_color(jv, judge_all_values.get(judge, []), True)
             html += f'    <div class="stat"><span class="label">{escape(judge_label)}</span><span class="value {rank_cls}">{fmt(jv, "pct" if is_pct else "num") if jv is not None else "--"}</span></div>\n'
@@ -468,38 +556,31 @@ def generate_report(runs, title, overview, output_dir):
         html += '  </div>\n</div>\n'
     html += '</div>\n\n'
 
-    # Cost table
+    # Cost table. Labels reflect per-run averages when any model has >1 run
+    # (cells then show "avg (min-max)"); otherwise a single run's own totals.
     html += '<section>\n<h2>Cost &amp; Efficiency</h2>\n'
-    cost_rows = []
-    for label, key, ft, hib in [
-        ("Total Cost", "cost_usd", "usd", False),
-        ("Output Tokens", "output_tokens", "tokens", False),
+    cost_spec = [
+        ("Avg Run Cost" if multi_run else "Total Cost", "cost_usd", "usd", False),
+        ("Avg Output Tokens" if multi_run else "Output Tokens", "output_tokens", "tokens", False),
         ("Tokens / Turn", "output_tokens_per_turn", "int", True),
-        ("Total Turns", "num_turns", "int", False),
+        ("Avg Turns" if multi_run else "Total Turns", "num_turns", "int", False),
         ("Wall Clock", "wall_clock_s", "time", False),
         ("Cost / Turn", "cost_per_turn", "usd", False),
         ("Cache Hit Rate", "cache_hit_rate", "pct", True),
-    ]:
-        values = [model_aggs[m][key].get("avg") for m in models]
-        cost_rows.append((label, values, ft))
-    hib_map = {"Total Cost": False, "Output Tokens": False, "Total Turns": False,
-               "Wall Clock": False, "Cost / Turn": False, "Tokens / Turn": True, "Cache Hit Rate": True}
-    html += render_comparison_table(models, cost_rows, hib_map)
+    ]
+    cost_rows = [(label, [model_aggs[m][key] for m in models], ft, hib)
+                 for label, key, ft, hib in cost_spec]
+    html += render_comparison_table(models, cost_rows)
     html += '</section>\n\n'
 
     # Quality table
     html += '<section>\n<h2>Quality Scores</h2>\n'
     quality_rows = []
     for judge in all_judges:
-        values = []
-        for m in models:
-            agg = model_aggs[m].get(f"judge_{judge}", {})
-            v = agg.get("avg")
-            values.append(v)
-        sample_v = next((v for v in values if v is not None), None)
-        ft = "pct" if _is_pass_rate(judge, sample_v, runs) else "num"
+        aggs = [model_aggs[m].get(f"judge_{judge}", aggregate([])) for m in models]
+        ft = "pct" if _is_pass_rate(judge, runs) else "num"
         label = judge.replace("_", " ").title()
-        quality_rows.append((label, values, ft))
+        quality_rows.append((label, aggs, ft, True))
     html += render_comparison_table(models, quality_rows)
     html += '</section>\n\n'
 
@@ -523,8 +604,7 @@ def generate_report(runs, title, overview, output_dir):
                 continue
 
             judge_label = judge.replace("_", " ").title()
-            sample_v = next((get_judge_mean(r, judge) for r in runs if get_judge_mean(r, judge) is not None), None)
-            is_pct = _is_pass_rate(judge, sample_v, runs)
+            is_pct = _is_pass_rate(judge, runs)
             html += f'<section>\n<h2>Per-Case: {escape(judge_label)}</h2>\n'
             html += "<table><thead><tr><th>Case</th>"
             for m in models:
@@ -532,7 +612,7 @@ def generate_report(runs, title, overview, output_dir):
             html += "</tr></thead><tbody>"
             for case in all_cases:
                 case_short = case.replace("case-", "").replace("-", " ", 1).split(" ", 1)
-                label = case_short[1] if len(case_short) > 1 else case
+                label = case_short[1] if len(case_short) > 1 else case_short[0]
                 html += f"<tr><td>{escape(label)}</td>"
                 values = []
                 for m in models:
@@ -587,7 +667,7 @@ def generate_report(runs, title, overview, output_dir):
             r = model_runs[0]
             html += f'<div class="tab-content" id="tab-{escape(m)}">\n'
             if r["html_report"]:
-                html += f'  <iframe class="iframe-wrap" src="{quote(r["name"], safe="")}/report.html"></iframe>\n'
+                html += f'  <iframe class="iframe-wrap" src="{quote(r["slug"], safe="")}/report.html"></iframe>\n'
             else:
                 html += '  <div class="page"><p>No HTML report available for this run.</p></div>\n'
             html += '</div>\n\n'
@@ -603,7 +683,7 @@ def generate_report(runs, title, overview, output_dir):
                 display = "" if j == 0 else ' style="display:none;"'
                 html += f'  <div class="sub-panel" data-model="{escape(m)}" data-idx="{j}"{display}>\n'
                 if r["html_report"]:
-                    html += f'    <iframe class="iframe-wrap" src="{quote(r["name"], safe="")}/report.html"></iframe>\n'
+                    html += f'    <iframe class="iframe-wrap" src="{quote(r["slug"], safe="")}/report.html"></iframe>\n'
                 else:
                     html += '    <div class="page"><p>No HTML report available.</p></div>\n'
                 html += '  </div>\n'

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,281 @@
+"""Tests for the eval-compare skill (skills/eval-compare/scripts/compare.py).
+
+Covers the parts with real logic: run discovery + unique slugging, tolerant
+file loading, model resolution, aggregation, the authoritative pass-rate check,
+best/worst + rank coloring, number formatting, and an end-to-end
+generate_report smoke test that guards the report.html collision fix.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "eval-compare" / "scripts"))
+
+import compare  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_run(base, rel, *, model="claude-opus-4-8", judges=None, per_case=None,
+              run_metrics=None, run_id=None, with_html=True, with_result=True,
+              cost=1.5, html_marker=None):
+    """Create a run directory (summary.yaml [+ run_result.json + report.html])."""
+    d = base / rel
+    d.mkdir(parents=True, exist_ok=True)
+    summary = {"run_id": run_id or rel.replace("/", "-"), "judges": judges or {}}
+    if per_case is not None:
+        summary["per_case"] = per_case
+    if run_metrics is not None:
+        summary["run_metrics"] = run_metrics
+    (d / "summary.yaml").write_text(yaml.dump(summary))
+    if with_result:
+        (d / "run_result.json").write_text(json.dumps({
+            "model": model, "cost_usd": cost, "num_turns": 10,
+            "wall_clock_s": 120, "token_usage": {"output": 5000},
+        }))
+    if with_html:
+        (d / "report.html").write_text(html_marker or f"<html>{rel}</html>")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# discover_runs + slugging
+# ---------------------------------------------------------------------------
+
+def test_discover_runs_basic_fields(tmp_path):
+    _make_run(tmp_path, "run-a", model="claude-opus-4-8",
+              judges={"quality": {"mean": 4.2}})
+    runs = compare.discover_runs(tmp_path)
+    assert len(runs) == 1
+    r = runs[0]
+    assert r["name"] == "run-a"
+    assert r["run_result"]["model"] == "claude-opus-4-8"
+    assert r["html_report"].endswith("report.html")
+    assert r["slug"]  # populated
+
+
+def test_discover_runs_missing_dir_raises():
+    with pytest.raises(NotADirectoryError):
+        compare.discover_runs("/no/such/dir/really")
+
+
+def test_discover_runs_unique_slug_for_shared_basename(tmp_path):
+    # Two runs at different paths but identical directory basename.
+    _make_run(tmp_path, "evalA/2026-07-30-opus")
+    _make_run(tmp_path, "evalB/2026-07-30-opus")
+    runs = compare.discover_runs(tmp_path)
+    assert len(runs) == 2
+    assert runs[0]["name"] == runs[1]["name"] == "2026-07-30-opus"
+    slugs = {r["slug"] for r in runs}
+    assert len(slugs) == 2, "slugs must be unique across shared basenames"
+
+
+def test_discover_runs_missing_run_result_is_graceful(tmp_path):
+    _make_run(tmp_path, "run-x", with_result=False)
+    runs = compare.discover_runs(tmp_path)
+    assert len(runs) == 1
+    assert runs[0]["run_result"] is None
+
+
+# ---------------------------------------------------------------------------
+# tolerant loaders
+# ---------------------------------------------------------------------------
+
+def test_load_yaml_malformed_returns_empty(tmp_path):
+    p = tmp_path / "bad.yaml"
+    p.write_text("key: [unterminated\n  : nope")
+    assert compare.load_yaml(p) == {}
+
+
+def test_load_yaml_non_mapping_returns_empty(tmp_path):
+    p = tmp_path / "list.yaml"
+    p.write_text("- a\n- b\n")
+    assert compare.load_yaml(p) == {}
+
+
+def test_load_json_malformed_returns_none(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text('{"truncated": ')
+    assert compare.load_json(p) is None
+
+
+def test_discover_runs_survives_one_malformed_summary(tmp_path):
+    _make_run(tmp_path, "good", judges={"quality": {"mean": 3.0}})
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "summary.yaml").write_text("::: not : valid : yaml :::\n- [")
+    runs = compare.discover_runs(tmp_path)
+    # Both are discovered; the bad one just has an empty summary, no crash.
+    assert len(runs) == 2
+
+
+# ---------------------------------------------------------------------------
+# get_model
+# ---------------------------------------------------------------------------
+
+def test_get_model_from_run_result():
+    run = {"run_result": {"model": "claude-sonnet-4-6"}, "summary": {}, "name": "n"}
+    assert compare.get_model(run) == "claude-sonnet-4-6"
+
+
+def test_get_model_fallback_reconstructs_full_claude_id():
+    run = {"run_result": None,
+           "summary": {"run_id": "20260730-143000-claude-opus-4-8"},
+           "name": "20260730-143000-claude-opus-4-8"}
+    # Must match the run_result branch key, not a bare "opus-4-8".
+    assert compare.get_model(run) == "claude-opus-4-8"
+
+
+def test_get_model_fallback_unknown_uses_name_not_merged_bucket():
+    run = {"run_result": None, "summary": {"run_id": "baseline"}, "name": "baseline"}
+    assert compare.get_model(run) == "baseline"
+
+
+# ---------------------------------------------------------------------------
+# aggregate
+# ---------------------------------------------------------------------------
+
+def test_aggregate_values():
+    agg = compare.aggregate([1.0, 3.0, None, 2.0])
+    assert agg["avg"] == 2.0
+    assert agg["min"] == 1.0
+    assert agg["max"] == 3.0
+    assert agg["count"] == 3
+
+
+def test_aggregate_empty():
+    agg = compare.aggregate([None, None])
+    assert agg == {"avg": None, "min": None, "max": None, "count": 0}
+
+
+# ---------------------------------------------------------------------------
+# _is_pass_rate (authoritative via judges[j].pass_rate)
+# ---------------------------------------------------------------------------
+
+def test_is_pass_rate_true_for_boolean_judge():
+    runs = [{"summary": {"judges": {"passes": {"mean": 0.5, "pass_rate": 0.5}}}}]
+    assert compare._is_pass_rate("passes", runs) is True
+
+
+def test_is_pass_rate_false_for_numeric_judge_even_if_all_01():
+    # Numeric judge whose values happen to be 0/1 must NOT be treated as pct.
+    runs = [{"summary": {"judges": {"errors": {"mean": 0.5, "pass_rate": None}}}}]
+    assert compare._is_pass_rate("errors", runs) is False
+
+
+# ---------------------------------------------------------------------------
+# best_worst_indices + _rank_color
+# ---------------------------------------------------------------------------
+
+def test_best_worst_indices_normal():
+    best, worst = compare.best_worst_indices([1.0, 3.0, 2.0], higher_is_better=True)
+    assert best == 1 and worst == 0
+
+
+def test_best_worst_indices_all_equal():
+    assert compare.best_worst_indices([2.0, 2.0, 2.0]) == (None, None)
+
+
+def test_rank_color_all_equal_is_uncolored():
+    assert compare._rank_color(1.0, [1.0, 1.0, 1.0], True) == ""
+
+
+def test_rank_color_best_and_worst():
+    assert compare._rank_color(3.0, [1.0, 2.0, 3.0], True) == "green"
+    assert compare._rank_color(1.0, [1.0, 2.0, 3.0], True) == "red"
+
+
+# ---------------------------------------------------------------------------
+# fmt
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("v,expected", [(45, "45s"), (130, "2 min"), (0, "0s")])
+def test_fmt_time_sub_minute(v, expected):
+    assert compare.fmt(v, "time") == expected
+
+
+@pytest.mark.parametrize("v,expected", [(800, "800"), (1500, "1.5K"), (2_000_000, "2.0M")])
+def test_fmt_tokens(v, expected):
+    assert compare.fmt(v, "tokens") == expected
+
+
+def test_fmt_range_single_vs_multi():
+    assert compare.fmt_range({"avg": 2.0, "min": 2.0, "max": 2.0, "count": 1}, "usd") == "$2.00"
+    ranged = compare.fmt_range({"avg": 2.0, "min": 1.0, "max": 3.0, "count": 2}, "usd")
+    assert ranged == "$2.00 ($1.00-$3.00)"
+
+
+# ---------------------------------------------------------------------------
+# short_name derivation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("model,expected", [
+    ("claude-opus-4-8", "Opus 4.8"),
+    ("claude-opus-4-8[1m]", "Opus 4.8 [1M]"),
+    ("claude-opus-5", "Opus 5"),          # not in map -> derived
+    ("gpt-4o", "gpt-4o"),                  # non-claude -> unchanged
+])
+def test_short_name(model, expected):
+    assert compare.short_name(model) == expected
+
+
+# ---------------------------------------------------------------------------
+# generate_report smoke tests
+# ---------------------------------------------------------------------------
+
+def test_generate_report_two_models(tmp_path):
+    _make_run(tmp_path, "opus", model="claude-opus-4-8",
+              judges={"quality": {"mean": 4.5}}, cost=2.0)
+    _make_run(tmp_path, "sonnet", model="claude-sonnet-4-6",
+              judges={"quality": {"mean": 3.5}}, cost=0.5)
+    runs = compare.discover_runs(tmp_path)
+    out = tmp_path / "report"
+    index = compare.generate_report(runs, "T", None, out)
+    html = Path(index).read_text()
+
+    assert Path(index).exists()
+    assert 'data-tab="claude-opus-4-8"' in html
+    assert 'data-tab="claude-sonnet-4-6"' in html
+    # single-run models -> "Total Cost" label (no multi-run averaging)
+    assert "Total Cost" in html
+    # iframes reference the per-run slug copies, which exist on disk
+    for r in runs:
+        assert (out / r["slug"] / "report.html").exists()
+        assert f'src="{r["slug"]}/report.html"' in html
+
+
+def test_generate_report_shared_basename_no_overwrite(tmp_path):
+    # Two runs of the same model, same directory basename, distinct reports.
+    _make_run(tmp_path, "evalA/2026-07-30-opus", model="claude-opus-4-8",
+              cost=1.0, html_marker="<html>REPORT-A</html>")
+    _make_run(tmp_path, "evalB/2026-07-30-opus", model="claude-opus-4-8",
+              cost=3.0, html_marker="<html>REPORT-B</html>")
+    runs = compare.discover_runs(tmp_path)
+    out = tmp_path / "report"
+    index = compare.generate_report(runs, "T", None, out)
+    html = Path(index).read_text()
+
+    # Both reports survive (no clobber) with their distinct content.
+    copies = sorted(out.glob("*/report.html"))
+    assert len(copies) == 2
+    contents = {c.read_text() for c in copies}
+    assert contents == {"<html>REPORT-A</html>", "<html>REPORT-B</html>"}
+
+    # Grouped as one model with two runs -> multi-run averaging + range.
+    assert "Avg Run Cost" in html
+    assert "$1.00-$3.00" in html
+
+
+def test_generate_report_missing_html_shows_placeholder(tmp_path):
+    _make_run(tmp_path, "opus", model="claude-opus-4-8", with_html=False)
+    runs = compare.discover_runs(tmp_path)
+    out = tmp_path / "report"
+    index = compare.generate_report(runs, "T", None, out)
+    html = Path(index).read_text()
+    assert "No HTML report available" in html


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Takes a directory of eval run artifacts (summary.yaml, run_result.json, HTML reports) and produces a tabbed HTML comparison report with model cards, quality/cost tables, per-case breakdowns, and embedded original reports. Supports multiple runs of the same model with aggregated statistics.

## How Has This Been Tested?

I ran it locally.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `eval-compare` command to generate a self-contained, tabbed HTML comparison report from an eval input directory.
  * Report now embeds per-run `report.html` from uniquely sluggified subfolders; missing HTML shows a “No HTML report available” placeholder.
  * Added run `dir` to the discovery output for easier identification.
* **Bug Fixes**
  * More robust handling of malformed or unreadable inputs (continues with warnings where possible).
  * Pass-rate classification now uses the declared judge pass-rate values.
* **Tests**
  * Added end-to-end coverage for discovery, aggregation, rendering, and missing-report behavior.
* **Documentation**
  * Updated project layout and usage docs for `eval-compare`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->