### PR TITLE
fix: skip workspace.files in batch mode to prevent silent overwrites

### DIFF
--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -89,6 +89,14 @@ def main():
 
     # ── Batch mode (below) ───────────────────────────────────────
 
+    if config.dataset.workspace.files:
+        print(
+            "WARNING: dataset.workspace.files is ignored in batch mode — "
+            "files are per-case but batch mode uses a shared workspace. "
+            "Use execution.mode: case instead.",
+            file=sys.stderr,
+        )
+
     # Create output directories from config
     for output in config.outputs:
         if output.path and output.path != ".":
@@ -119,9 +127,6 @@ def main():
         else:
             batch_entries.append(input_content)
             case_order.append({"case_id": case_dir.name, "entry_count": 1})
-
-        # Copy input files directory if present
-        _copy_input_files(case_dir, workspace, config)
 
     # Write batch.yaml
     with open(workspace / "batch.yaml", "w") as f:


### PR DESCRIPTION
## Summary

- Skip `_copy_input_files` in batch mode and emit a stderr warning when `dataset.workspace.files` is configured
- In batch mode all cases share a single workspace root, so per-case files would silently overwrite each other when two cases provide the same relative path (e.g., both have `src/main.py`)
- Workspace files are inherently per-case — users should use `execution.mode: case` instead

Follow-up to #70. Closes #111.

## Test plan

- [x] All 306 existing tests pass
- [ ] Verify warning is emitted when running a batch-mode eval with `dataset.workspace.files` configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Batch mode now alerts users when workspace file settings are configured, warning that these settings will be ignored during batch processing and recommending case execution mode as an alternative.

* **Bug Fixes**
  * Streamlined batch mode execution by removing unnecessary input file directory copies, retaining only essential case-specific content for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->