### PR TITLE
fix: trustworthy LLM judges (structured output, generic pairwise, sampling stability)

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -248,6 +248,9 @@ class JudgeConfig:
     builtin: str = ""
     # Arguments passed as **kwargs to Python judges, Jinja var to LLM judges
     arguments: dict = field(default_factory=dict)
+    # Sampling — run this judge N times per case and reduce (median/majority).
+    # Only meaningful for stochastic (LLM) judges; ignored for deterministic ones.
+    samples: int = 1
 
 
 @dataclass
@@ -484,6 +487,7 @@ class EvalConfig:
                     function=j.get("function", ""),
                     builtin=builtin_val,
                     arguments=args_val,
+                    samples=int(j.get("samples", 1)),
                 )
             )
 

--- a/skills/eval-run/prompts/comparison-judge.md
+++ b/skills/eval-run/prompts/comparison-judge.md
@@ -7,23 +7,19 @@ Evaluate each output across these dimensions:
 3. **Accuracy** — Is the content factually correct and internally consistent?
 4. **Relevance** — Does the output stay focused on what was asked?
 
-For each dimension, assess which output is stronger. Then make an overall judgment.
-
-Be decisive. Only declare "tie" if the outputs are genuinely equivalent across all dimensions — a marginal advantage in any dimension should break the tie.
+Be decisive. Only declare a tie if the outputs are genuinely equivalent across all dimensions — a marginal advantage in any dimension should break the tie.
 
 Be aware that outputs are presented in arbitrary order. Do not let presentation order influence your judgment.
 
-Output your assessment as JSON:
+## Output
+
+Return your judgment with two fields:
+
+- **preferred**: `A`, `B`, or `tie` — the overall winner.
+- **reasoning**: your full analysis. Structure it as one short labeled paragraph per dimension (Completeness, Quality, Accuracy, Relevance), each naming the stronger output and citing specific content from both A and B, followed by a closing sentence that states the overall verdict and why.
+
+Provide exactly these two fields as a single JSON object, e.g.:
 
 ```json
-{
-  "dimensions": {
-    "completeness": {"preferred": "A" or "B" or "tie", "reasoning": "..."},
-    "quality": {"preferred": "A" or "B" or "tie", "reasoning": "..."},
-    "accuracy": {"preferred": "A" or "B" or "tie", "reasoning": "..."},
-    "relevance": {"preferred": "A" or "B" or "tie", "reasoning": "..."}
-  },
-  "reasoning": "Overall comparison reasoning",
-  "preferred": "A" or "B" or "tie"
-}
+{"preferred": "A", "reasoning": "Completeness: ... Quality: ... Accuracy: ... Relevance: ... Overall: A is stronger because ..."}
 ```

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1194,6 +1194,19 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
             metric_name = "—"
             metric_val = "—"
 
+        # Sampling stability (from `score.py judges --repeat N`) — same
+        # treatment as the pairwise row: a confidence suffix on the value.
+        jst = agg.get("stability")
+        if isinstance(jst, dict) and jst.get("samples", 1) > 1 and metric_val != "—":
+            stable, tot = jst.get("stable_cases", 0), jst.get("total_cases", 0)
+            varied = tot - stable
+            if varied == 0:
+                metric_val += (f' <span class="pw-stability">· stable across '
+                               f'{jst["samples"]} samples</span>')
+            else:
+                metric_val += (f' <span class="pw-stability">· {stable}/{tot} stable '
+                               f'across {jst["samples"]} samples ({varied} varied)</span>')
+
         # Baseline
         bl_val = ""
         if has_bl and judge_name in bl_judges:
@@ -1925,6 +1938,19 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
 
             if err:
                 rat = f"ERROR: {err}"
+
+            # Sampling spread (from --repeat): annotate the value when the
+            # judge's samples for this case didn't all agree.
+            jst = jresult.get("stability")
+            if isinstance(jst, dict) and jst.get("samples", 1) > 1 and not jst.get("stable", True):
+                if "min" in jst and "max" in jst:
+                    spread = f"{jst['min']}–{jst['max']}"
+                else:
+                    spread = "/".join(str(v) for v in jst.get("values", []))
+                if spread:
+                    val_html += (f'<br><span class="pw-spread" '
+                                 f'title="per-sample values ({jst["samples"]} samples)">'
+                                 f'{_esc(spread)}</span>')
 
             rat_html = _md_to_html(_normalize_escapes(rat)) if rat else ""
             html += (f'<tr><td>{_esc(jname)}</td><td>{val_html}</td>'

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -586,6 +586,7 @@ details.case > summary:hover { color: var(--accent); }
 .pw-loss { background: var(--danger-soft); color: var(--danger); border-color: var(--danger-border); }
 .pw-tie { background: var(--warning-soft); color: var(--warning); border-color: var(--warning-border); }
 .pw-error { background: var(--neutral-soft); color: var(--text-muted); border-color: var(--neutral-border); }
+.pw-spread { font-size: 0.72em; color: var(--text-muted); font-family: ui-monospace, "SF Mono", Menlo, monospace; }
 .diff-table { width: 100%; border-collapse: collapse; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.82em; table-layout: fixed; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
 .diff-table td { padding: 1px 6px; vertical-align: top; white-space: pre-wrap; word-wrap: break-word; border: 1px solid var(--border); }
 .diff-table .ln { width: 35px; min-width: 35px; color: var(--text-muted); text-align: right; background: var(--surface-2); user-select: none; white-space: nowrap; }
@@ -1281,6 +1282,59 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
     return html
 
 
+def _render_pairwise_stability(summary):
+    """Render judge-stochasticity stats when pairwise was run with --repeat."""
+    pw = summary.get("pairwise") or {}
+    st = pw.get("stability")
+    if not st or st.get("runs", 1) < 2:
+        return ""
+    runs = st.get("runs")
+    tie_counts = st.get("tie_counts", [])
+    wb = st.get("wins_b_counts", [])
+    wa = st.get("wins_a_counts", [])
+    stable = st.get("stable_cases", 0)
+    total = st.get("total_cases", 0)
+    rate = st.get("agreement_rate", 0.0)
+    run_a = _esc(str(pw.get("run_a", "A")))
+    run_b = _esc(str(pw.get("run_b", "B")))
+
+    html = "<h2>Pairwise Stability</h2>\n"
+    html += (f"<p>The pairwise comparison was run <strong>{runs}×</strong> to separate "
+             f"signal from judge stochasticity. "
+             f"<strong>{stable}/{total}</strong> cases gave the identical verdict on every "
+             f"run (<strong>{rate:.0%}</strong> agreement).</p>\n")
+    html += '<table class="scoring-table"><thead><tr><th>Metric</th>'
+    html += "".join(f"<th>run {i+1}</th>" for i in range(runs))
+    html += "</tr></thead><tbody>\n"
+
+    def _row(label, vals):
+        cells = "".join(f"<td>{v}</td>" for v in vals)
+        return f"<tr><td>{label}</td>{cells}</tr>\n"
+
+    html += _row(f"{run_b} wins", wb)
+    if any(wa):
+        html += _row(f"{run_a} wins", wa)
+    html += _row("ties", tie_counts)
+    html += "</tbody></table>\n"
+
+    flipped = st.get("flipped_cases", [])
+    if flipped:
+        html += (f"<p><strong>{len(flipped)} case(s) flipped</strong> across runs "
+                 f"(verdict was not stable — treat as noise / genuinely close):</p>\n")
+        html += '<table class="scoring-table"><thead><tr><th>Case</th>'
+        html += "".join(f"<th>run {i+1}</th>" for i in range(runs))
+        html += "<th>majority</th></tr></thead><tbody>\n"
+        for fc in flipped:
+            vs = fc.get("verdicts", [])
+            badges = "".join(f"<td>{_pairwise_badge(v)}</td>" for v in vs)
+            html += (f"<tr><td>{_esc(fc.get('case_id',''))}</td>{badges}"
+                     f"<td>{_pairwise_badge(fc.get('majority','tie'))}</td></tr>\n")
+        html += "</tbody></table>\n"
+    else:
+        html += "<p>No cases flipped — every verdict was stable across all runs.</p>\n"
+    return html
+
+
 def _render_regressions(summary, config):
     judges = summary.get("judges", {})
     thresholds = config.get("thresholds", {})
@@ -1817,6 +1871,9 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
     pw = summary.get("pairwise", {})
     for pc in pw.get("per_case", []):
         pw_by_case[pc.get("case_id", "")] = pc
+    # Per-case verdict spread across repeated runs (stability), if available.
+    pw_flipped = {fc.get("case_id"): fc.get("verdicts", [])
+                  for fc in (pw.get("stability") or {}).get("flipped_cases", [])}
 
     html = '<h2 class="section-heading">Per-Case Details</h2>\n'
     if baseline_dir:
@@ -1920,8 +1977,14 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
                 pw_reasoning = pw_reasoning.get("reasoning", "")
             pw_reasoning = str(pw_reasoning)
             pw_rat_html = _md_to_html(_normalize_escapes(pw_reasoning)) if pw_reasoning else ""
+            # If this case flipped across repeated runs, show the verdict spread.
+            spread = pw_flipped.get(case_id)
+            verdict_html = _pairwise_badge(pw_winner)
+            if spread:
+                verdict_html += (f'<br><span class="pw-spread" title="verdict per repeat run">'
+                                 f'{_esc("/".join(spread))}</span>')
             html += (f'<tr><td>pairwise</td>'
-                     f'<td>{_pairwise_badge(pw_winner)}</td>'
+                     f'<td>{verdict_html}</td>'
                      f'<td class="rationale">{pw_rat_html}</td></tr>\n')
 
         html += "</table>\n"
@@ -2243,6 +2306,7 @@ def generate_report(config, summary, run_result, run_dir,
     html += _wrap_section(_render_run_config(run_result, baseline_result))
     html += _render_analysis(run_dir, summary, run_result, baseline_summary)
     html += _wrap_section(_render_scoring_summary(summary, config, baseline_summary))
+    html += _wrap_section(_render_pairwise_stability(summary))
     html += _wrap_section(_render_regressions(summary, config))
     html += _wrap_section(_render_shared_outputs(run_dir, config))
     html += _render_per_case(summary, run_dir, config, baseline_dir, review)

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -587,6 +587,7 @@ details.case > summary:hover { color: var(--accent); }
 .pw-tie { background: var(--warning-soft); color: var(--warning); border-color: var(--warning-border); }
 .pw-error { background: var(--neutral-soft); color: var(--text-muted); border-color: var(--neutral-border); }
 .pw-spread { font-size: 0.72em; color: var(--text-muted); font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+.pw-stability { font-size: 0.85em; color: var(--text-muted); font-weight: 400; }
 .diff-table { width: 100%; border-collapse: collapse; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.82em; table-layout: fixed; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
 .diff-table td { padding: 1px 6px; vertical-align: top; white-space: pre-wrap; word-wrap: break-word; border: 1px solid var(--border); }
 .diff-table .ln { width: 35px; min-width: 35px; color: var(--text-muted); text-align: right; background: var(--surface-2); user-select: none; white-space: nowrap; }
@@ -1263,6 +1264,18 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
         pw_val = f"{wins_a}W / {wins_b}L / {ties}T"
         if errors:
             pw_val += f" / {errors}E"
+        # Fold verdict-stability (from `score.py pairwise --repeat N`) into the
+        # same cell — confidence on this tally — rather than a separate section.
+        st = pw.get("stability") or {}
+        n = st.get("runs", 1)
+        if n and n > 1:
+            stable, tot = st.get("stable_cases", 0), st.get("total_cases", 0)
+            flipped = len(st.get("flipped_cases", []))
+            if flipped == 0:
+                pw_val += f' <span class="pw-stability">· stable across {n} samples</span>'
+            else:
+                pw_val += (f' <span class="pw-stability">· {stable}/{tot} stable across '
+                           f'{n} samples ({flipped} flipped)</span>')
         if wins_a > wins_b:
             pw_status_cls, pw_status = "pass", "WIN"
         elif wins_b > wins_a:
@@ -1279,59 +1292,6 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
         html += f'<td>—</td><td><span class="{pw_status_cls}">{pw_status}</span></td></tr>\n'
 
     html += "</table>\n"
-    return html
-
-
-def _render_pairwise_stability(summary):
-    """Render judge-stochasticity stats when pairwise was run with --repeat."""
-    pw = summary.get("pairwise") or {}
-    st = pw.get("stability")
-    if not st or st.get("runs", 1) < 2:
-        return ""
-    runs = st.get("runs")
-    tie_counts = st.get("tie_counts", [])
-    wb = st.get("wins_b_counts", [])
-    wa = st.get("wins_a_counts", [])
-    stable = st.get("stable_cases", 0)
-    total = st.get("total_cases", 0)
-    rate = st.get("agreement_rate", 0.0)
-    run_a = _esc(str(pw.get("run_a", "A")))
-    run_b = _esc(str(pw.get("run_b", "B")))
-
-    html = "<h2>Pairwise Stability</h2>\n"
-    html += (f"<p>The pairwise comparison was run <strong>{runs}×</strong> to separate "
-             f"signal from judge stochasticity. "
-             f"<strong>{stable}/{total}</strong> cases gave the identical verdict on every "
-             f"run (<strong>{rate:.0%}</strong> agreement).</p>\n")
-    html += '<table class="scoring-table"><thead><tr><th>Metric</th>'
-    html += "".join(f"<th>run {i+1}</th>" for i in range(runs))
-    html += "</tr></thead><tbody>\n"
-
-    def _row(label, vals):
-        cells = "".join(f"<td>{v}</td>" for v in vals)
-        return f"<tr><td>{label}</td>{cells}</tr>\n"
-
-    html += _row(f"{run_b} wins", wb)
-    if any(wa):
-        html += _row(f"{run_a} wins", wa)
-    html += _row("ties", tie_counts)
-    html += "</tbody></table>\n"
-
-    flipped = st.get("flipped_cases", [])
-    if flipped:
-        html += (f"<p><strong>{len(flipped)} case(s) flipped</strong> across runs "
-                 f"(verdict was not stable — treat as noise / genuinely close):</p>\n")
-        html += '<table class="scoring-table"><thead><tr><th>Case</th>'
-        html += "".join(f"<th>run {i+1}</th>" for i in range(runs))
-        html += "<th>majority</th></tr></thead><tbody>\n"
-        for fc in flipped:
-            vs = fc.get("verdicts", [])
-            badges = "".join(f"<td>{_pairwise_badge(v)}</td>" for v in vs)
-            html += (f"<tr><td>{_esc(fc.get('case_id',''))}</td>{badges}"
-                     f"<td>{_pairwise_badge(fc.get('majority','tie'))}</td></tr>\n")
-        html += "</tbody></table>\n"
-    else:
-        html += "<p>No cases flipped — every verdict was stable across all runs.</p>\n"
     return html
 
 
@@ -2306,7 +2266,6 @@ def generate_report(config, summary, run_result, run_dir,
     html += _wrap_section(_render_run_config(run_result, baseline_result))
     html += _render_analysis(run_dir, summary, run_result, baseline_summary)
     html += _wrap_section(_render_scoring_summary(summary, config, baseline_summary))
-    html += _wrap_section(_render_pairwise_stability(summary))
     html += _wrap_section(_render_regressions(summary, config))
     html += _wrap_section(_render_shared_outputs(run_dir, config))
     html += _render_per_case(summary, run_dir, config, baseline_dir, review)

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1858,13 +1858,18 @@ def _ascii_hist(items, lo_label, hi_label, mark_key):
     return f"{lo_label} " + "".join(cells) + f" {hi_label}"
 
 
-def _ascii_score_hist(med, values, smin=1, smax=5):
+def _ascii_score_hist(med, values, smin=None, smax=None):
     """`_ascii_hist` over the numeric score scale, marking the median level."""
     from collections import Counter
-    counts = Counter(values)
-    med = max(smin, min(smax, med))
-    items = [(s, counts.get(s, 0)) for s in range(smin, smax + 1)]
-    return _ascii_hist(items, str(smin), str(smax), med)
+    numeric = [int(v) for v in values if isinstance(v, (int, float))]
+    if not numeric:
+        return ""
+    lo = smin if smin is not None else min(numeric)
+    hi = smax if smax is not None else max(numeric)
+    counts = Counter(numeric)
+    med = max(lo, min(hi, int(med)))
+    items = [(s, counts.get(s, 0)) for s in range(lo, hi + 1)]
+    return _ascii_hist(items, str(lo), str(hi), med)
 
 
 def _colorise_hist(glyph):
@@ -2027,9 +2032,13 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
                 verds = pw_flipped.get(case_id) or [pw_winner] * pw_runs
                 from collections import Counter as _Counter
                 vc = _Counter(verds)
+                cats = [("A", vc.get("A", 0)), ("tie", vc.get("tie", 0)),
+                        ("B", vc.get("B", 0))]
+                errs = vc.get("error", 0)
+                if errs:
+                    cats.append(("error", errs))
                 glyph = _colorise_hist(_ascii_hist(
-                    [("A", vc.get("A", 0)), ("tie", vc.get("tie", 0)),
-                     ("B", vc.get("B", 0))], "A", "B", pw_winner))
+                    cats, "A", "E" if errs else "B", pw_winner))
                 verdict_html += (f'<br><span class="ascii-range" '
                                  f'title="verdicts: {_esc("/".join(verds))}">{glyph}</span>')
             html += (f'<tr><td>pairwise</td>'

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -2001,7 +2001,7 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
                     and "min" in jst):
                 vals = jst.get("values", [])
                 samples = ", ".join(str(v) for v in vals)
-                glyph = _colorise_hist(_ascii_score_hist(val, vals))
+                glyph = _colorise_hist(_ascii_score_hist(val, vals, 1, 5))
                 val_html += (f' <span class="ascii-range" '
                              f'title="samples: {_esc(samples)}">{glyph}</span>')
             elif (isinstance(jst, dict) and jst.get("samples", 1) > 1

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1215,7 +1215,7 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
             metric_name = "—"
             metric_val = "—"
 
-        # Sampling stability (from `score.py judges --repeat N`) — a proportion
+        # Sampling stability (from `score.py judges --samples N`) — a proportion
         # bar (stable vs varied across cases) appended to the metric.
         jst = agg.get("stability")
         if isinstance(jst, dict) and jst.get("samples", 1) > 1 and metric_val != "—":
@@ -1293,7 +1293,7 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
         pw_val = f"{wins_a}W / {wins_b}L / {ties}T"
         if errors:
             pw_val += f" / {errors}E"
-        # Verdict-stability (from `score.py pairwise --repeat N`) — same
+        # Verdict-stability (from `score.py pairwise --samples N`) — same
         # proportion bar the judge rows use.
         st = pw.get("stability") or {}
         n = st.get("runs", 1)
@@ -1987,7 +1987,7 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
 
             if err:
                 rat = f"ERROR: {err}"
-            # Per-case sampling distribution (from --repeat): an ASCII glyph
+            # Per-case sampling distribution (from --samples): an ASCII glyph
             # (monospace, aligns cleanly) showing the spread on the 1–5 scale.
             # Shown for every sampled judge — a stable judge is a single bar,
             # which reads at a glance as "all samples agree". Raw samples on hover.

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -586,8 +586,11 @@ details.case > summary:hover { color: var(--accent); }
 .pw-loss { background: var(--danger-soft); color: var(--danger); border-color: var(--danger-border); }
 .pw-tie { background: var(--warning-soft); color: var(--warning); border-color: var(--warning-border); }
 .pw-error { background: var(--neutral-soft); color: var(--text-muted); border-color: var(--neutral-border); }
-.pw-spread { font-size: 0.72em; color: var(--text-muted); font-family: ui-monospace, "SF Mono", Menlo, monospace; }
-.pw-stability { font-size: 0.85em; color: var(--text-muted); font-weight: 400; }
+.stab-wrap { display: inline-flex; align-items: center; gap: 5px; }
+.stab-bar { vertical-align: middle; }
+.stab-label { font-size: 0.8em; color: var(--text-muted); }
+.ascii-range { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 0.85em; letter-spacing: 1px; color: var(--text-muted); margin-left: 6px; white-space: pre; }
+.ascii-range .med { color: var(--accent); font-weight: 700; }
 .diff-table { width: 100%; border-collapse: collapse; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.82em; table-layout: fixed; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
 .diff-table td { padding: 1px 6px; vertical-align: top; white-space: pre-wrap; word-wrap: break-word; border: 1px solid var(--border); }
 .diff-table .ln { width: 35px; min-width: 35px; color: var(--text-muted); text-align: right; background: var(--surface-2); user-select: none; white-space: nowrap; }
@@ -1149,6 +1152,24 @@ def _render_model_usage(run_result, baseline_result=None):
     return html
 
 
+def _stability_proportion_bar(stable, total, samples):
+    """Small proportion bar (stable vs varied) summarizing a judge's cross-case
+    sampling consistency. Used in the Scoring Summary for LLM-judge rows and the
+    pairwise row so the whole table shares one visual language."""
+    if not total:
+        return ""
+    W, H = 46, 7
+    frac = stable / total
+    title = f"{stable}/{total} cases stable across {samples} samples"
+    return (
+        f'<span class="stab-wrap">'
+        f'<svg class="stab-bar" width="{W}" height="{H}" viewBox="0 0 {W} {H}" '
+        f'role="img" aria-label="{_esc(title)}"><title>{_esc(title)}</title>'
+        f'<rect x="0" y="0" width="{W}" height="{H}" rx="3.5" fill="var(--warning-soft)"/>'
+        f'<rect x="0" y="0" width="{W * frac:.1f}" height="{H}" rx="3.5" fill="var(--success)"/>'
+        f'</svg><span class="stab-label">{stable}/{total} · {samples}×</span></span>')
+
+
 def _render_scoring_summary(summary, config, baseline_summary=None):
     judges = summary.get("judges", {})
     thresholds = config.get("thresholds", {})
@@ -1194,18 +1215,13 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
             metric_name = "—"
             metric_val = "—"
 
-        # Sampling stability (from `score.py judges --repeat N`) — same
-        # treatment as the pairwise row: a confidence suffix on the value.
+        # Sampling stability (from `score.py judges --repeat N`) — a proportion
+        # bar (stable vs varied across cases) appended to the metric.
         jst = agg.get("stability")
         if isinstance(jst, dict) and jst.get("samples", 1) > 1 and metric_val != "—":
-            stable, tot = jst.get("stable_cases", 0), jst.get("total_cases", 0)
-            varied = tot - stable
-            if varied == 0:
-                metric_val += (f' <span class="pw-stability">· stable across '
-                               f'{jst["samples"]} samples</span>')
-            else:
-                metric_val += (f' <span class="pw-stability">· {stable}/{tot} stable '
-                               f'across {jst["samples"]} samples ({varied} varied)</span>')
+            metric_val += " " + _stability_proportion_bar(
+                jst.get("stable_cases", 0), jst.get("total_cases", 0),
+                jst.get("samples"))
 
         # Baseline
         bl_val = ""
@@ -1277,18 +1293,13 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
         pw_val = f"{wins_a}W / {wins_b}L / {ties}T"
         if errors:
             pw_val += f" / {errors}E"
-        # Fold verdict-stability (from `score.py pairwise --repeat N`) into the
-        # same cell — confidence on this tally — rather than a separate section.
+        # Verdict-stability (from `score.py pairwise --repeat N`) — same
+        # proportion bar the judge rows use.
         st = pw.get("stability") or {}
         n = st.get("runs", 1)
         if n and n > 1:
-            stable, tot = st.get("stable_cases", 0), st.get("total_cases", 0)
-            flipped = len(st.get("flipped_cases", []))
-            if flipped == 0:
-                pw_val += f' <span class="pw-stability">· stable across {n} samples</span>'
-            else:
-                pw_val += (f' <span class="pw-stability">· {stable}/{tot} stable across '
-                           f'{n} samples ({flipped} flipped)</span>')
+            pw_val += " " + _stability_proportion_bar(
+                st.get("stable_cases", 0), st.get("total_cases", 0), n)
         if wins_a > wins_b:
             pw_status_cls, pw_status = "pass", "WIN"
         elif wins_b > wins_a:
@@ -1826,6 +1837,43 @@ def _render_shared_outputs(run_dir, config):
     return html
 
 
+def _ascii_hist(items, lo_label, hi_label, mark_key):
+    """Monospace ASCII histogram of sampled judge values on a labelled axis.
+
+    `items` is an ordered list of (key, count); each renders as a block bar
+    (height = count, tallest = █), empty categories stay ░, and the bar for
+    `mark_key` is wrapped in markers (\\x01..\\x02) for colourising in HTML.
+    A stable judge — all samples in one bucket — is a single bar (e.g.
+    ``1 ░░░░█ 5``), so the column reads "agree" vs "wobble" at a glance.
+    Used for numeric judges (1 … 5), bool judges (F … P) and pairwise (A … B).
+    """
+    blocks = "▁▂▃▄▅▆▇█"
+    maxc = max((c for _, c in items), default=1) or 1
+    cells = []
+    for key, c in items:
+        ch = "░" if c == 0 else blocks[round(c / maxc * 7)]
+        if key == mark_key:
+            ch = "\x01" + ch + "\x02"   # marker (colourised in HTML)
+        cells.append(ch)
+    return f"{lo_label} " + "".join(cells) + f" {hi_label}"
+
+
+def _ascii_score_hist(med, values, smin=1, smax=5):
+    """`_ascii_hist` over the numeric score scale, marking the median level."""
+    from collections import Counter
+    counts = Counter(values)
+    med = max(smin, min(smax, med))
+    items = [(s, counts.get(s, 0)) for s in range(smin, smax + 1)]
+    return _ascii_hist(items, str(smin), str(smax), med)
+
+
+def _colorise_hist(glyph):
+    """HTML-escape an ASCII histogram and colourise its marked bar."""
+    return (_esc(glyph)
+            .replace("\x01", '<span class="med">')
+            .replace("\x02", "</span>"))
+
+
 def _render_per_case(summary, run_dir, config, baseline_dir, review):
     per_case = summary.get("per_case", {})
     if not per_case:
@@ -1847,6 +1895,7 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
     # Per-case verdict spread across repeated runs (stability), if available.
     pw_flipped = {fc.get("case_id"): fc.get("verdicts", [])
                   for fc in (pw.get("stability") or {}).get("flipped_cases", [])}
+    pw_runs = (pw.get("stability") or {}).get("runs", 1)
 
     html = '<h2 class="section-heading">Per-Case Details</h2>\n'
     if baseline_dir:
@@ -1938,19 +1987,27 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
 
             if err:
                 rat = f"ERROR: {err}"
-
-            # Sampling spread (from --repeat): annotate the value when the
-            # judge's samples for this case didn't all agree.
+            # Per-case sampling distribution (from --repeat): an ASCII glyph
+            # (monospace, aligns cleanly) showing the spread on the 1–5 scale.
+            # Shown for every sampled judge — a stable judge is a single bar,
+            # which reads at a glance as "all samples agree". Raw samples on hover.
             jst = jresult.get("stability")
-            if isinstance(jst, dict) and jst.get("samples", 1) > 1 and not jst.get("stable", True):
-                if "min" in jst and "max" in jst:
-                    spread = f"{jst['min']}–{jst['max']}"
-                else:
-                    spread = "/".join(str(v) for v in jst.get("values", []))
-                if spread:
-                    val_html += (f'<br><span class="pw-spread" '
-                                 f'title="per-sample values ({jst["samples"]} samples)">'
-                                 f'{_esc(spread)}</span>')
+            if (isinstance(jst, dict) and jst.get("samples", 1) > 1
+                    and "min" in jst):
+                vals = jst.get("values", [])
+                samples = ", ".join(str(v) for v in vals)
+                glyph = _colorise_hist(_ascii_score_hist(val, vals))
+                val_html += (f' <span class="ascii-range" '
+                             f'title="samples: {_esc(samples)}">{glyph}</span>')
+            elif (isinstance(jst, dict) and jst.get("samples", 1) > 1
+                  and "pass_count" in jst):
+                npass = jst["pass_count"]
+                nsamp = jst["samples"]
+                winner = "pass" if npass * 2 >= nsamp else "fail"
+                glyph = _colorise_hist(_ascii_hist(
+                    [("fail", nsamp - npass), ("pass", npass)], "F", "P", winner))
+                val_html += (f' <span class="ascii-range" '
+                             f'title="{npass}/{nsamp} pass">{glyph}</span>')
 
             rat_html = _md_to_html(_normalize_escapes(rat)) if rat else ""
             html += (f'<tr><td>{_esc(jname)}</td><td>{val_html}</td>'
@@ -1964,11 +2021,17 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
             pw_reasoning = str(pw_reasoning)
             pw_rat_html = _md_to_html(_normalize_escapes(pw_reasoning)) if pw_reasoning else ""
             # If this case flipped across repeated runs, show the verdict spread.
-            spread = pw_flipped.get(case_id)
             verdict_html = _pairwise_badge(pw_winner)
-            if spread:
-                verdict_html += (f'<br><span class="pw-spread" title="verdict per repeat run">'
-                                 f'{_esc("/".join(spread))}</span>')
+            if pw_runs and pw_runs > 1:
+                # stable cases didn't flip → all runs == winner (single bar)
+                verds = pw_flipped.get(case_id) or [pw_winner] * pw_runs
+                from collections import Counter as _Counter
+                vc = _Counter(verds)
+                glyph = _colorise_hist(_ascii_hist(
+                    [("A", vc.get("A", 0)), ("tie", vc.get("tie", 0)),
+                     ("B", vc.get("B", 0))], "A", "B", pw_winner))
+                verdict_html += (f'<br><span class="ascii-range" '
+                                 f'title="verdicts: {_esc("/".join(verds))}">{glyph}</span>')
             html += (f'<tr><td>pairwise</td>'
                      f'<td>{verdict_html}</td>'
                      f'<td class="rationale">{pw_rat_html}</td></tr>\n')

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -670,8 +670,64 @@ def _loads_json_object(text):
     return None
 
 
-def score_cases(judges, case_dirs, config, run_id=None):
-    """Score all cases with all judges in parallel."""
+def _normalize_result(result):
+    """Extract (value, rationale) from a scorer return (tuple/Feedback/primitive)."""
+    if isinstance(result, tuple) and len(result) == 2:
+        return result[0], result[1]
+    if hasattr(result, "value"):
+        return result.value, getattr(result, "rationale", "")
+    return result, ""
+
+
+def _aggregate_samples(runs, judge_type):
+    """Reduce N stochastic-judge samples to one value + rationale, recording spread.
+
+    `runs` is a list of {value, rationale?, error?}. Numeric (score) judges
+    reduce by median (noise reduction, returns an actually-observed score via
+    median_low); bool judges by majority vote. The kept rationale is one from a
+    sample matching the reduced value, so it stays consistent with the score.
+    `stability.stable` is True when every sample agreed.
+    """
+    import statistics
+    vals = [r["value"] for r in runs if r.get("value") is not None]
+    if not vals:
+        err = next((r.get("error") for r in runs if r.get("error")), "all samples failed")
+        return {"value": None, "error": err, "judge_type": judge_type,
+                "stability": {"samples": len(runs), "values": []}}
+    # bool must be checked before int (bool is a subclass of int)
+    if all(isinstance(v, bool) for v in vals):
+        passes = sum(1 for v in vals if v)
+        value = (passes * 2 >= len(vals))  # majority; ties resolve to pass
+        rationale = next((r.get("rationale", "") for r in runs
+                          if r.get("value") is value), "")
+        stability = {"samples": len(vals), "pass_count": passes,
+                     "values": vals, "stable": passes in (0, len(vals))}
+    elif all(isinstance(v, (int, float)) for v in vals):
+        value = statistics.median_low(vals)
+        lo, hi = min(vals), max(vals)
+        rationale = next((r.get("rationale", "") for r in runs
+                          if r.get("value") == value), runs[0].get("rationale", ""))
+        stability = {"samples": len(vals), "min": lo, "max": hi,
+                     "mean": round(statistics.fmean(vals), 2),
+                     "values": vals, "stable": lo == hi}
+    else:
+        value = vals[0]
+        rationale = next((r.get("rationale", "") for r in runs
+                          if r.get("value") == value), "")
+        stability = {"samples": len(vals), "values": vals,
+                     "stable": len({str(v) for v in vals}) <= 1}
+    return {"value": value, "rationale": rationale, "judge_type": judge_type,
+            "stability": stability}
+
+
+def score_cases(judges, case_dirs, config, run_id=None, samples=1):
+    """Score all cases with all judges in parallel.
+
+    When samples > 1, each stochastic (LLM) judge is run `samples` times per
+    case; the reduced value (median/majority) becomes the score and the spread
+    is recorded under per-case `stability`. Deterministic judges (check/code)
+    always run once.
+    """
     if not case_dirs:
         return {"per_case": {}, "aggregated": {n: {"values": [], "mean": None, "pass_rate": None} for n, *_ in judges}}
     per_case = {}
@@ -704,26 +760,22 @@ def score_cases(judges, case_dirs, config, run_id=None):
                         "judge_type": judge_type,
                     }
                     continue
+            # Only stochastic (LLM) judges are sampled repeatedly; deterministic
+            # check/code judges run once regardless of `samples`.
+            n = samples if (samples > 1 and judge_type == "llm") else 1
             try:
-                result = scorer(outputs=record)
-                # Normalize — accepts (bool, str) tuples, Feedback, primitives
-                if isinstance(result, tuple) and len(result) == 2:
-                    case_results[name] = {
-                        "value": result[0],
-                        "rationale": result[1],
-                        "judge_type": judge_type,
-                    }
-                elif hasattr(result, "value"):
-                    case_results[name] = {
-                        "value": result.value,
-                        "rationale": getattr(result, "rationale", ""),
-                        "judge_type": judge_type,
-                    }
-                elif isinstance(result, (bool, int, float, str)):
-                    case_results[name] = {"value": result, "rationale": "",
-                                          "judge_type": judge_type}
+                if n > 1:
+                    runs = []
+                    for _ in range(n):
+                        try:
+                            v, rat = _normalize_result(scorer(outputs=record))
+                            runs.append({"value": v, "rationale": rat})
+                        except Exception as e:
+                            runs.append({"value": None, "error": str(e)})
+                    case_results[name] = _aggregate_samples(runs, judge_type)
                 else:
-                    case_results[name] = {"value": result, "rationale": "",
+                    v, rat = _normalize_result(scorer(outputs=record))
+                    case_results[name] = {"value": v, "rationale": rat,
                                           "judge_type": judge_type}
             except Exception as e:
                 case_results[name] = {"value": None, "error": str(e),
@@ -767,6 +819,22 @@ def score_cases(judges, case_dirs, config, run_id=None):
         else:
             aggregated[name]["mean"] = None
             aggregated[name]["pass_rate"] = None
+
+    # Per-judge stability across cases (only meaningful when sampled > 1):
+    # how many cases gave a consistent score across all samples.
+    if samples > 1:
+        for name in aggregated:
+            scored = [per_case[c][name] for c in per_case
+                      if isinstance(per_case.get(c, {}).get(name), dict)
+                      and "stability" in per_case[c][name]
+                      and per_case[c][name].get("value") is not None]
+            if scored:
+                stable = sum(1 for r in scored if r["stability"].get("stable"))
+                aggregated[name]["stability"] = {
+                    "samples": samples,
+                    "stable_cases": stable,
+                    "total_cases": len(scored),
+                }
 
     return {"per_case": per_case, "aggregated": aggregated}
 
@@ -1363,19 +1431,29 @@ def cmd_judges(args):
     case_dirs = _get_case_dirs(args.run_id, runs_dir)
     project_root = Path.cwd()
 
+    samples = max(1, getattr(args, "repeat", 1) or 1)
     judges = load_judges(config, project_root)
-    print(f"Scoring {len(case_dirs)} cases with {len(judges)} judges: "
+    n_llm = sum(1 for _, _, _, jt in judges if jt == "llm")
+    suffix = (f" (LLM judges sampled {samples}×)"
+              if samples > 1 and n_llm else "")
+    print(f"Scoring {len(case_dirs)} cases with {len(judges)} judges{suffix}: "
           f"{[n for n, *_ in judges]}")
 
-    judge_results = score_cases(judges, case_dirs, config, run_id=args.run_id)
+    judge_results = score_cases(judges, case_dirs, config, run_id=args.run_id,
+                                samples=samples)
 
     for name, agg in judge_results.get("aggregated", {}).items():
         mean = agg.get("mean")
         rate = agg.get("pass_rate")
+        st = agg.get("stability")
+        st_note = ""
+        if isinstance(st, dict) and st.get("samples", 1) > 1:
+            stable, tot = st.get("stable_cases", 0), st.get("total_cases", 0)
+            st_note = f"  [{stable}/{tot} stable over {st['samples']} samples]"
         if rate is not None:
-            print(f"  {name}: pass_rate={rate:.1%}")
+            print(f"  {name}: pass_rate={rate:.1%}{st_note}")
         elif mean is not None:
-            print(f"  {name}: mean={mean:.2f}")
+            print(f"  {name}: mean={mean:.2f}{st_note}")
 
     _merge_summary(args.run_id, "judges", {
         name: {k: v for k, v in agg.items() if k != "values"}
@@ -1531,6 +1609,10 @@ def main():
     jdg_p = subparsers.add_parser("judges", help="Run all judges")
     jdg_p.add_argument("--run-id", required=True)
     jdg_p.add_argument("--config", required=True)
+    jdg_p.add_argument("--repeat", type=int, default=1,
+                       help="Sample each LLM judge N times per case; the median "
+                            "(score) / majority (bool) becomes the value and the "
+                            "spread is recorded for stability reporting")
 
     # pairwise
     pw_p = subparsers.add_parser("pairwise", help="Pairwise comparison")

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -485,7 +485,7 @@ _SCORE_SYSTEM_PROMPT = (
     "Return a JSON object with 'score' (integer 1-5) and 'rationale' (string).")
 
 
-def _call_judge_llm(prompt, model, system_prompt, images=None, max_tokens=1024):
+def _call_judge_llm(prompt, model, system_prompt, images=None, max_tokens=4096):
     """Call the Anthropic API with a judge prompt. Returns raw response text."""
     client = _get_anthropic_client()
     if images:
@@ -510,29 +510,55 @@ def _call_judge_llm(prompt, model, system_prompt, images=None, max_tokens=1024):
     return response.content[0].text.strip()
 
 
+def _rationale_field(text):
+    """Extract a JSON `rationale` string value, unescaped, or None.
+
+    Escaped-quote-aware so the value isn't cut at the first embedded quote.
+    """
+    m = re.search(r'"rationale"\s*:\s*"((?:[^"\\]|\\.)*)"', text)
+    if not m:
+        return None
+    try:
+        return json.loads(f'"{m.group(1)}"')
+    except json.JSONDecodeError:
+        return m.group(1)
+
+
 def _parse_bool_response(text):
-    """Parse {"passed": bool, "rationale": str} from LLM response."""
+    """Parse {"passed": bool, "rationale": str} from LLM response.
+
+    When no structured `rationale` field is present, fall back to the full
+    response text (it renders as markdown in the report) rather than a
+    200-char slice that truncates mid-word.
+    """
     match = re.search(r'"passed"\s*:\s*(true|false)', text, re.IGNORECASE)
     if match:
         passed = match.group(1).lower() == "true"
-        rat_match = re.search(r'"rationale"\s*:\s*"((?:[^"\\]|\\.)*)"', text)
-        rationale = rat_match.group(1) if rat_match else text[:200]
+        rationale = _rationale_field(text) or text.strip()
         return (passed, rationale)
-    return (False, f"Could not parse judge response: {text[:200]}")
+    return (False, text.strip() or "Could not parse judge response")
 
 
 def _parse_score_response(text):
-    """Parse {"score": int, "rationale": str} from LLM response with fallbacks."""
-    try:
-        match = re.search(r'"score"\s*:\s*(\d+)', text)
-        if match:
-            score_val = int(match.group(1))
-            rationale_match = re.search(r'"rationale"\s*:\s*"([^"]*)"', text)
-            rationale = (rationale_match.group(1) if rationale_match
-                         else text[:200])
-            return (score_val, rationale)
-    except (ValueError, AttributeError):
-        pass
+    """Parse {"score": int, "rationale": str} from an LLM response, with fallbacks.
+
+    Never truncates the rationale: when the judge returns prose instead of the
+    requested JSON (observed with opus-4-8), the full response text is used as
+    the rationale rather than a 200-char slice that cuts off mid-word.
+    """
+    # 1. Clean JSON object (handles escapes, newlines, embedded quotes).
+    obj = _loads_json_object(text)
+    if isinstance(obj, dict) and obj.get("score") is not None:
+        try:
+            rationale = str(obj.get("rationale") or "").strip() or text.strip()
+            return (int(obj["score"]), rationale)
+        except (ValueError, TypeError):
+            pass
+    # 2. Regex score + escaped-quote-aware rationale; full text if absent.
+    match = re.search(r'"score"\s*:\s*(\d+)', text)
+    if match:
+        return (int(match.group(1)), _rationale_field(text) or text.strip())
+    # 3. Prose fallbacks — keep the full text as the rationale.
     explicit = re.search(
         r'(?:overall|score|rating)\s*[=:]\s*(\d)\b'
         r'|(\d)\s*/\s*5'
@@ -540,11 +566,30 @@ def _parse_score_response(text):
         text, re.IGNORECASE)
     if explicit:
         score_val = int(next(g for g in explicit.groups() if g))
-        return (score_val, text[:200])
+        return (score_val, text.strip())
     nums = re.findall(r'\b([1-5])\b', text)
     if nums:
-        return (int(nums[-1]), text[:200])
-    return (3, f"Could not parse score from: {text[:200]}")
+        return (int(nums[-1]), text.strip())
+    return (3, text.strip() or "Could not parse score")
+
+
+def _loads_json_object(text):
+    """Best-effort parse of a single JSON object from a response (code fences
+    or surrounding prose tolerated). Returns a dict or None."""
+    t = text.strip()
+    fence = re.search(r'```(?:json)?\s*(\{.*?\})\s*```', t, re.DOTALL)
+    if fence:
+        t = fence.group(1)
+    for candidate in (t, t[t.find("{"):t.rfind("}") + 1] if "{" in t and "}" in t else ""):
+        if not candidate:
+            continue
+        try:
+            obj = json.loads(candidate, strict=False)
+            if isinstance(obj, dict):
+                return obj
+        except json.JSONDecodeError:
+            continue
+    return None
 
 
 def score_cases(judges, case_dirs, config, run_id=None):

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -373,7 +373,7 @@ def load_judges(config, project_root=None):
     - prompt/prompt_file: LLM judge
     - module/function: external code judge
 
-    Returns list of (name, scorer, condition, judge_type) 4-tuples.
+    Returns list of (name, scorer, condition, judge_type, samples) 5-tuples.
     """
     # Duplicate name validation
     seen_names = set()
@@ -421,7 +421,13 @@ def load_judges(config, project_root=None):
                   file=sys.stderr)
             continue
         if scorer:
-            judges.append((jc.name, scorer, jc.condition, judge_type))
+            n = max(1, jc.samples)
+            if n > 1 and judge_type != "llm":
+                print(f"  Warning: judge '{jc.name}' has samples={n} but is "
+                      f"a {judge_type} judge (deterministic); samples ignored",
+                      file=sys.stderr)
+                n = 1
+            judges.append((jc.name, scorer, jc.condition, judge_type, n))
     return judges
 
 
@@ -720,13 +726,12 @@ def _aggregate_samples(runs, judge_type):
             "stability": stability}
 
 
-def score_cases(judges, case_dirs, config, run_id=None, samples=1):
+def score_cases(judges, case_dirs, config, run_id=None, samples_override=None):
     """Score all cases with all judges in parallel.
 
-    When samples > 1, each stochastic (LLM) judge is run `samples` times per
-    case; the reduced value (median/majority) becomes the score and the spread
-    is recorded under per-case `stability`. Deterministic judges (check/code)
-    always run once.
+    Each judge's sample count comes from its config (`JudgeConfig.samples`);
+    `samples_override` (from CLI `--samples`) wins when set. Only stochastic
+    (LLM) judges are sampled; deterministic judges always run once.
     """
     if not case_dirs:
         return {"per_case": {}, "aggregated": {n: {"values": [], "mean": None, "pass_rate": None} for n, *_ in judges}}
@@ -740,7 +745,7 @@ def score_cases(judges, case_dirs, config, run_id=None, samples=1):
         case_id = case_dir.name
         record = load_case_record(case_dir, config, run_id=run_id)
         case_results = {}
-        for name, scorer, condition, judge_type in judges:
+        for name, scorer, condition, judge_type, judge_samples in judges:
             # Check condition — skip if it evaluates to False
             if condition:
                 try:
@@ -760,9 +765,10 @@ def score_cases(judges, case_dirs, config, run_id=None, samples=1):
                         "judge_type": judge_type,
                     }
                     continue
-            # Only stochastic (LLM) judges are sampled repeatedly; deterministic
-            # check/code judges run once regardless of `samples`.
-            n = samples if (samples > 1 and judge_type == "llm") else 1
+            # CLI --samples overrides per-judge config; deterministic judges
+            # always run once (warning already emitted by load_judges).
+            n = (samples_override if samples_override and samples_override > 1
+                 else judge_samples)
             try:
                 if n > 1:
                     runs = []
@@ -793,7 +799,7 @@ def score_cases(judges, case_dirs, config, run_id=None, samples=1):
                 case_id = case_dir.name
                 case_results = {name: {"value": None, "error": str(e),
                                        "judge_type": jt}
-                                for name, _, _, jt in judges}
+                                for name, _, _, jt, _ in judges}
                 print(f"  [{completed}/{len(case_dirs)}] {case_id} ERROR: {e}",
                       file=sys.stderr, flush=True)
             per_case[case_id] = case_results
@@ -822,16 +828,17 @@ def score_cases(judges, case_dirs, config, run_id=None, samples=1):
 
     # Per-judge stability across cases (only meaningful when sampled > 1):
     # how many cases gave a consistent score across all samples.
-    if samples > 1:
-        for name in aggregated:
-            scored = [per_case[c][name] for c in per_case
-                      if isinstance(per_case.get(c, {}).get(name), dict)
-                      and "stability" in per_case[c][name]
-                      and per_case[c][name].get("value") is not None]
-            if scored:
+    for name in aggregated:
+        scored = [per_case[c][name] for c in per_case
+                  if isinstance(per_case.get(c, {}).get(name), dict)
+                  and "stability" in per_case[c][name]
+                  and per_case[c][name].get("value") is not None]
+        if scored:
+            n_samples = scored[0]["stability"].get("samples", 1)
+            if n_samples > 1:
                 stable = sum(1 for r in scored if r["stability"].get("stable"))
                 aggregated[name]["stability"] = {
-                    "samples": samples,
+                    "samples": n_samples,
                     "stable_cases": stable,
                     "total_cases": len(scored),
                 }
@@ -1431,16 +1438,22 @@ def cmd_judges(args):
     case_dirs = _get_case_dirs(args.run_id, runs_dir)
     project_root = Path.cwd()
 
-    samples = max(1, getattr(args, "samples", 1) or 1)
+    samples_override = getattr(args, "samples", None) or None
+    if samples_override is not None:
+        samples_override = max(1, samples_override)
+        if samples_override == 1:
+            samples_override = None
     judges = load_judges(config, project_root)
-    n_llm = sum(1 for _, _, _, jt in judges if jt == "llm")
-    suffix = (f" (LLM judges sampled {samples}×)"
-              if samples > 1 and n_llm else "")
+    n_llm = sum(1 for _, _, _, jt, _ in judges if jt == "llm")
+    sampled = [n for n, _, _, jt, s in judges
+               if jt == "llm" and ((samples_override or s) > 1)]
+    suffix = (f" (sampling: {', '.join(f'{n}={samples_override or s}×' for n, _, _, _, s in judges if n in sampled)})"
+              if sampled else "")
     print(f"Scoring {len(case_dirs)} cases with {len(judges)} judges{suffix}: "
           f"{[n for n, *_ in judges]}")
 
     judge_results = score_cases(judges, case_dirs, config, run_id=args.run_id,
-                                samples=samples)
+                                samples_override=samples_override)
 
     for name, agg in judge_results.get("aggregated", {}).items():
         mean = agg.get("mean")
@@ -1528,7 +1541,13 @@ def cmd_pairwise(args):
         sys.exit(1)
     prompt_file = args.prompt_file or (pairwise_jc.prompt_file if pairwise_jc else "")
 
-    samples = max(1, getattr(args, "samples", 1) or 1)
+    cfg_samples = pairwise_jc.samples if pairwise_jc else 1
+    cli_samples = getattr(args, "samples", None) or None
+    if cli_samples is not None:
+        cli_samples = max(1, cli_samples)
+        if cli_samples == 1:
+            cli_samples = None
+    samples = cli_samples or cfg_samples
     suffix = f", samples={samples}" if samples > 1 else ""
     print(f"Pairwise comparison: {args.run_id} vs {args.baseline} "
           f"({len(case_ids)} cases, model={model}{suffix})")
@@ -1609,10 +1628,11 @@ def main():
     jdg_p = subparsers.add_parser("judges", help="Run all judges")
     jdg_p.add_argument("--run-id", required=True)
     jdg_p.add_argument("--config", required=True)
-    jdg_p.add_argument("--samples", type=int, default=1,
-                       help="Sample each LLM judge N times per case; the median "
-                            "(score) / majority (bool) becomes the value and the "
-                            "spread is recorded for stability reporting")
+    jdg_p.add_argument("--samples", type=int, default=None,
+                       help="Override per-judge samples config: sample each LLM "
+                            "judge N times per case; median (score) / majority "
+                            "(bool) becomes the value, spread recorded for "
+                            "stability reporting")
 
     # pairwise
     pw_p = subparsers.add_parser("pairwise", help="Pairwise comparison")
@@ -1625,9 +1645,9 @@ def main():
                       help="Override comparison prompt file")
     pw_p.add_argument("--model", default=None,
                       help="Override judge model")
-    pw_p.add_argument("--samples", type=int, default=1,
-                      help="Run the comparison N times and record verdict "
-                           "stability (tie/win variance + per-case agreement)")
+    pw_p.add_argument("--samples", type=int, default=None,
+                      help="Override per-judge samples config: run the comparison "
+                           "N times and record verdict stability")
 
     # regression
     reg_p = subparsers.add_parser("regression", help="Threshold checks")

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -962,31 +962,112 @@ def _get_anthropic_client():
     raise RuntimeError("Set ANTHROPIC_VERTEX_PROJECT_ID or ANTHROPIC_API_KEY")
 
 
+# Per-dimension verdict shape, reused for each comparison dimension.
+_PAIRWISE_DIM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "preferred": {"type": "string", "enum": ["A", "B", "tie", "n/a"]},
+        "reasoning": {"type": "string",
+                      "description": "Why this dimension favors A, B, or neither — cite specific content."},
+    },
+    "required": ["preferred", "reasoning"],
+}
+
+# Forced-output tool for the pairwise judge. Using tool_choice guarantees the
+# model returns exactly these fields instead of improvising key names
+# (observed: opus-4-8 emits `analysis`/`score_A`/`confidence` instead of the
+# documented `reasoning`/`dimensions`, which silently drops the per-dimension
+# breakdown). Structured output works uniformly across judge models.
+_PAIRWISE_DIM_NAMES = ("rfe_quality", "calibration", "feasibility", "revision")
+_PAIRWISE_TOOL = {
+    "name": "submit_comparison",
+    "description": ("Submit the blind pairwise comparison of outputs A and B. "
+                    "Provide the overall verdict, thorough overall reasoning, and "
+                    "a per-dimension breakdown."),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "preferred": {"type": "string", "enum": ["A", "B", "tie"],
+                          "description": "Which output is stronger overall."},
+            "reasoning": {"type": "string",
+                          "description": ("Thorough, self-contained overall reasoning — "
+                                          "several sentences citing specific content from "
+                                          "both outputs across RFE quality, assessment "
+                                          "calibration, feasibility depth, and revision "
+                                          "effectiveness. This is the primary field; make it "
+                                          "complete on its own.")},
+            "dimensions": {
+                "type": "object",
+                "description": "Per-dimension verdict and reasoning.",
+                "properties": {
+                    "rfe_quality": _PAIRWISE_DIM_SCHEMA,
+                    "calibration": _PAIRWISE_DIM_SCHEMA,
+                    "feasibility": _PAIRWISE_DIM_SCHEMA,
+                    "revision": _PAIRWISE_DIM_SCHEMA,
+                },
+            },
+        },
+        "required": ["preferred", "reasoning"],
+    },
+}
+
+
+def _normalize_pairwise_input(data):
+    """Recombine the flat per-dimension fields into a `dimensions` dict.
+
+    The tool schema is flat (top-level rfe_quality/calibration/feasibility/
+    revision), but a model may also nest them under `dimensions`. Collect
+    dimension-shaped objects ({preferred, reasoning}) from either location so
+    downstream always sees `data["dimensions"]` as a dict.
+    """
+    dims = {}
+    nested = data.get("dimensions")
+    if isinstance(nested, dict):
+        for k, v in nested.items():
+            if isinstance(v, dict):
+                dims[k] = v
+    for name in _PAIRWISE_DIM_NAMES:
+        v = data.pop(name, None)
+        if isinstance(v, dict):
+            dims[name] = v
+    if dims:
+        data["dimensions"] = dims
+    elif not isinstance(data.get("dimensions"), dict):
+        data.pop("dimensions", None)
+    return data
+
+
 def _call_judge(client, system_prompt, user_message, model, max_tokens=16384):
     try:
         response = client.messages.create(
             model=model, max_tokens=max_tokens,
-            system=("You are a judge comparing two outputs. "
-                    "Return ONLY a single JSON object — no prose, no code fences, "
-                    "no commentary before or after. The first character of your "
-                    "response must be '{' and the last must be '}'. Put ALL of "
-                    "your reasoning inside the JSON fields. The JSON must follow "
-                    "the schema specified in the user prompt and include a "
-                    "'preferred' field set to 'A', 'B', or 'tie'."),
+            system=("You are a blind judge comparing two outputs, A and B. "
+                    "Call the submit_comparison tool exactly once with your verdict "
+                    "and reasoning. Put ALL of your reasoning inside the tool input — "
+                    "do not write any text outside the tool call."),
+            tools=[_PAIRWISE_TOOL],
+            tool_choice={"type": "tool", "name": "submit_comparison"},
             messages=[
                 {"role": "user", "content": f"{system_prompt}\n\n{user_message}"},
             ],
         )
-        text = response.content[0].text
-        parsed = _extract_judge_json(text)
+        # Preferred path: read the forced tool_use block directly — no text
+        # parsing, no improvised keys.
+        for block in response.content:
+            if getattr(block, "type", None) == "tool_use" and block.name == "submit_comparison":
+                return _normalize_pairwise_input(dict(block.input)), None
+        # Fallback: model emitted text despite tool_choice (rare) — parse it.
+        text = "".join(getattr(b, "text", "") for b in response.content
+                       if getattr(b, "type", None) == "text")
+        parsed = _extract_judge_json(text) if text else None
         if parsed is not None:
             return parsed, None
         # Retry once with a larger budget if the response was truncated.
         if response.stop_reason == "max_tokens" and max_tokens < 32768:
             return _call_judge(client, system_prompt, user_message, model,
                                max_tokens=max_tokens * 2)
-        return None, (f"Could not parse JSON from response "
-                      f"(stop_reason={response.stop_reason}): {text[:200]}")
+        return None, (f"No submit_comparison tool_use in response "
+                      f"(stop_reason={response.stop_reason})")
     except Exception as e:
         return None, str(e)
 

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -895,6 +895,44 @@ def compare_runs(run_a_dir, run_b_dir, config, case_ids,
     }
 
 
+def _compute_pairwise_stability(runs):
+    """Summarize judge stochasticity across repeated pairwise runs.
+
+    `runs` is a list of compare_runs() result dicts. Returns per-run win/tie
+    counts plus per-case verdict agreement: which cases gave the same verdict
+    every run (stable) vs flipped, so readers can tell signal from noise.
+    """
+    from collections import Counter
+    n = len(runs)
+    # Per-case verdicts across runs, preserving case order from the first run.
+    case_order = [pc["case_id"] for pc in runs[0].get("per_case", [])]
+    verdicts = {cid: [] for cid in case_order}
+    for r in runs:
+        for pc in r.get("per_case", []):
+            verdicts.setdefault(pc["case_id"], []).append(pc.get("winner", "error"))
+
+    flipped = []
+    stable = 0
+    for cid in case_order:
+        vs = verdicts.get(cid, [])
+        if len(set(vs)) <= 1:
+            stable += 1
+        else:
+            majority = Counter(vs).most_common(1)[0][0]
+            flipped.append({"case_id": cid, "verdicts": vs, "majority": majority})
+    total = len(case_order)
+    return {
+        "runs": n,
+        "wins_a_counts": [r["wins_a"] for r in runs],
+        "wins_b_counts": [r["wins_b"] for r in runs],
+        "tie_counts": [r["ties"] for r in runs],
+        "total_cases": total,
+        "stable_cases": stable,
+        "agreement_rate": (stable / total) if total else 0.0,
+        "flipped_cases": flipped,
+    }
+
+
 def _format_outputs_for_pairwise(record):
     """Render the full set of skill-output files for a case as markdown.
 
@@ -1354,24 +1392,42 @@ def cmd_pairwise(args):
         sys.exit(1)
     prompt_file = args.prompt_file or (pairwise_jc.prompt_file if pairwise_jc else "")
 
+    repeat = max(1, getattr(args, "repeat", 1) or 1)
+    suffix = f", repeat={repeat}" if repeat > 1 else ""
     print(f"Pairwise comparison: {args.run_id} vs {args.baseline} "
-          f"({len(case_ids)} cases, model={model})")
+          f"({len(case_ids)} cases, model={model}{suffix})")
 
-    result = compare_runs(
-        run_dir, baseline_dir, config, case_ids,
-        prompt=pairwise_jc.prompt if pairwise_jc else None,
-        prompt_file=prompt_file,
-        model=model,
-    )
+    runs = []
+    for i in range(repeat):
+        if repeat > 1:
+            print(f"  --- repeat {i + 1}/{repeat} ---")
+        r = compare_runs(
+            run_dir, baseline_dir, config, case_ids,
+            prompt=pairwise_jc.prompt if pairwise_jc else None,
+            prompt_file=prompt_file,
+            model=model,
+        )
+        if "error" in r:
+            print(f"ERROR: {r['error']}", file=sys.stderr)
+            sys.exit(1)
+        print(f"  A wins: {r['wins_a']} | B wins: {r['wins_b']} | "
+              f"Ties: {r['ties']} | Errors: {r['errors']}")
+        runs.append(r)
 
-    if "error" in result:
-        print(f"ERROR: {result['error']}", file=sys.stderr)
-        sys.exit(1)
-
-    print(f"  A wins: {result['wins_a']}")
-    print(f"  B wins: {result['wins_b']}")
-    print(f"  Ties:   {result['ties']}")
-    print(f"  Errors: {result['errors']}")
+    # The first run is the primary (its per-case reasoning is rendered).
+    result = runs[0]
+    if repeat > 1:
+        result["stability"] = _compute_pairwise_stability(runs)
+        st = result["stability"]
+        print(f"  Stability over {repeat} runs: "
+              f"B wins {st['wins_b_counts']}, ties {st['tie_counts']}; "
+              f"{st['stable_cases']}/{st['total_cases']} cases gave the same "
+              f"verdict every run ({st['agreement_rate']:.0%} agreement)")
+        if st["flipped_cases"]:
+            print("  Flipped cases:")
+            for fc in st["flipped_cases"]:
+                print(f"    {fc['case_id']}: {'/'.join(fc['verdicts'])} "
+                      f"(majority {fc['majority']})")
 
     _merge_summary(args.run_id, "pairwise", result, runs_dir)
 
@@ -1429,6 +1485,9 @@ def main():
                       help="Override comparison prompt file")
     pw_p.add_argument("--model", default=None,
                       help="Override judge model")
+    pw_p.add_argument("--repeat", type=int, default=1,
+                      help="Run the comparison N times and record verdict "
+                           "stability (tie/win variance + per-case agreement)")
 
     # regression
     reg_p = subparsers.add_parser("regression", help="Threshold checks")

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -1431,7 +1431,7 @@ def cmd_judges(args):
     case_dirs = _get_case_dirs(args.run_id, runs_dir)
     project_root = Path.cwd()
 
-    samples = max(1, getattr(args, "repeat", 1) or 1)
+    samples = max(1, getattr(args, "samples", 1) or 1)
     judges = load_judges(config, project_root)
     n_llm = sum(1 for _, _, _, jt in judges if jt == "llm")
     suffix = (f" (LLM judges sampled {samples}×)"
@@ -1528,15 +1528,15 @@ def cmd_pairwise(args):
         sys.exit(1)
     prompt_file = args.prompt_file or (pairwise_jc.prompt_file if pairwise_jc else "")
 
-    repeat = max(1, getattr(args, "repeat", 1) or 1)
-    suffix = f", repeat={repeat}" if repeat > 1 else ""
+    samples = max(1, getattr(args, "samples", 1) or 1)
+    suffix = f", samples={samples}" if samples > 1 else ""
     print(f"Pairwise comparison: {args.run_id} vs {args.baseline} "
           f"({len(case_ids)} cases, model={model}{suffix})")
 
     runs = []
-    for i in range(repeat):
-        if repeat > 1:
-            print(f"  --- repeat {i + 1}/{repeat} ---")
+    for i in range(samples):
+        if samples > 1:
+            print(f"  --- sample {i + 1}/{samples} ---")
         r = compare_runs(
             run_dir, baseline_dir, config, case_ids,
             prompt=pairwise_jc.prompt if pairwise_jc else None,
@@ -1552,10 +1552,10 @@ def cmd_pairwise(args):
 
     # The first run is the primary (its per-case reasoning is rendered).
     result = runs[0]
-    if repeat > 1:
+    if samples > 1:
         result["stability"] = _compute_pairwise_stability(runs)
         st = result["stability"]
-        print(f"  Stability over {repeat} runs: "
+        print(f"  Stability over {samples} samples: "
               f"B wins {st['wins_b_counts']}, ties {st['tie_counts']}; "
               f"{st['stable_cases']}/{st['total_cases']} cases gave the same "
               f"verdict every run ({st['agreement_rate']:.0%} agreement)")
@@ -1609,7 +1609,7 @@ def main():
     jdg_p = subparsers.add_parser("judges", help="Run all judges")
     jdg_p.add_argument("--run-id", required=True)
     jdg_p.add_argument("--config", required=True)
-    jdg_p.add_argument("--repeat", type=int, default=1,
+    jdg_p.add_argument("--samples", type=int, default=1,
                        help="Sample each LLM judge N times per case; the median "
                             "(score) / majority (bool) becomes the value and the "
                             "spread is recorded for stability reporting")
@@ -1625,7 +1625,7 @@ def main():
                       help="Override comparison prompt file")
     pw_p.add_argument("--model", default=None,
                       help="Override judge model")
-    pw_p.add_argument("--repeat", type=int, default=1,
+    pw_p.add_argument("--samples", type=int, default=1,
                       help="Run the comparison N times and record verdict "
                            "stability (tie/win variance + per-case agreement)")
 

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -445,9 +445,8 @@ def _make_builtin_scorer(entry, jc, config):
             out = outputs or {}
             rendered = _render_jinja2_template(prompt_text, arguments, out)
             images = _extract_images(out)
-            raw = _call_judge_llm(rendered, judge_model,
-                                  _BOOL_SYSTEM_PROMPT, images=images)
-            return _parse_bool_response(raw)
+            return _call_structured_judge(rendered, judge_model, "bool",
+                                          images=images)
 
         return scorer
 
@@ -477,37 +476,116 @@ def _extract_images(outputs):
 
 
 _BOOL_SYSTEM_PROMPT = (
-    "You are a judge evaluating agent outputs. "
-    "Return a JSON object with 'passed' (boolean) and 'rationale' (string).")
+    "You are a judge evaluating agent outputs. Call the submit_evaluation "
+    "tool once with your pass/fail judgment and a thorough rationale.")
 
 _SCORE_SYSTEM_PROMPT = (
-    "You are a judge evaluating skill outputs. "
-    "Return a JSON object with 'score' (integer 1-5) and 'rationale' (string).")
+    "You are a judge evaluating skill outputs. Call the submit_score tool "
+    "once with an integer score 1-5 and a thorough rationale.")
+
+_SCORE_JUDGE_TOOL = {
+    "name": "submit_score",
+    "description": "Submit the evaluation score and rationale.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "score": {"type": "integer", "minimum": 1, "maximum": 5,
+                      "description": "Overall score, 1 (worst) to 5 (best)."},
+            "rationale": {"type": "string",
+                          "description": "Thorough justification citing specific "
+                                         "content from the outputs."},
+        },
+        "required": ["score", "rationale"],
+    },
+}
+
+_BOOL_JUDGE_TOOL = {
+    "name": "submit_evaluation",
+    "description": "Submit the pass/fail judgment and rationale.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "passed": {"type": "boolean",
+                       "description": "Whether the output passes the criterion."},
+            "rationale": {"type": "string",
+                          "description": "Thorough justification citing specific "
+                                         "content from the outputs."},
+        },
+        "required": ["passed", "rationale"],
+    },
+}
+
+
+def _judge_user_message(prompt, images=None):
+    """Build the user-message content for a judge call, inlining any images."""
+    if not images:
+        return prompt
+    parts = [{"type": "text", "text": prompt}]
+    for img in images:
+        parts.append({"type": "text", "text": f"\n**Image: {img['label']}**"})
+        parts.append({"type": "image", "source": {
+            "type": "base64",
+            "media_type": img["media_type"],
+            "data": img["data"],
+        }})
+    return parts
 
 
 def _call_judge_llm(prompt, model, system_prompt, images=None, max_tokens=4096):
-    """Call the Anthropic API with a judge prompt. Returns raw response text."""
+    """Call the Anthropic API with a judge prompt. Returns raw response text.
+
+    Retained as the text-parse fallback path; the primary path is
+    _call_structured_judge (forced tool output).
+    """
     client = _get_anthropic_client()
-    if images:
-        content_parts = [{"type": "text", "text": prompt}]
-        for img in images:
-            content_parts.append({"type": "text",
-                                  "text": f"\n**Image: {img['label']}**"})
-            content_parts.append({"type": "image", "source": {
-                "type": "base64",
-                "media_type": img["media_type"],
-                "data": img["data"],
-            }})
-        user_message = content_parts
-    else:
-        user_message = prompt
     response = client.messages.create(
         model=model,
         max_tokens=max_tokens,
         system=system_prompt,
-        messages=[{"role": "user", "content": user_message}],
+        messages=[{"role": "user", "content": _judge_user_message(prompt, images)}],
     )
     return response.content[0].text.strip()
+
+
+def _call_structured_judge(prompt, model, feedback_type, images=None,
+                           max_tokens=4096):
+    """Call an LLM judge with forced tool output. Returns (value, rationale).
+
+    feedback_type "bool" → (passed: bool, rationale); anything else →
+    (score: int, rationale). Forcing a tool guarantees the value and rationale
+    come back in known fields instead of free-form text the model may format
+    however it likes (opus-4-8 routinely ignores "return JSON" instructions).
+    Falls back to parsing any text in the response if no tool_use is returned.
+    """
+    is_bool = (feedback_type == "bool")
+    tool = _BOOL_JUDGE_TOOL if is_bool else _SCORE_JUDGE_TOOL
+    system_prompt = _BOOL_SYSTEM_PROMPT if is_bool else _SCORE_SYSTEM_PROMPT
+    parser = _parse_bool_response if is_bool else _parse_score_response
+    client = _get_anthropic_client()
+    response = client.messages.create(
+        model=model,
+        max_tokens=max_tokens,
+        system=system_prompt,
+        tools=[tool],
+        tool_choice={"type": "tool", "name": tool["name"]},
+        messages=[{"role": "user", "content": _judge_user_message(prompt, images)}],
+    )
+    for block in response.content:
+        if getattr(block, "type", None) == "tool_use" and block.name == tool["name"]:
+            data = dict(block.input)
+            rationale = str(data.get("rationale") or "").strip()
+            if is_bool:
+                if isinstance(data.get("passed"), bool):
+                    return (data["passed"], rationale or "(no rationale provided)")
+            else:
+                try:
+                    return (int(data["score"]), rationale or "(no rationale provided)")
+                except (KeyError, TypeError, ValueError):
+                    pass
+    # Fallback: model emitted text instead of a tool call (rare with tool_choice).
+    text = "".join(getattr(b, "text", "") for b in response.content
+                   if getattr(b, "type", None) == "text").strip()
+    return parser(text)
 
 
 def _rationale_field(text):
@@ -536,7 +614,7 @@ def _parse_bool_response(text):
         passed = match.group(1).lower() == "true"
         rationale = _rationale_field(text) or text.strip()
         return (passed, rationale)
-    return (False, text.strip() or "Could not parse judge response")
+    return (False, f"Could not parse judge response: {text.strip() or '(empty)'}")
 
 
 def _parse_score_response(text):
@@ -570,7 +648,7 @@ def _parse_score_response(text):
     nums = re.findall(r'\b([1-5])\b', text)
     if nums:
         return (int(nums[-1]), text.strip())
-    return (3, text.strip() or "Could not parse score")
+    return (3, f"Could not parse score from: {text.strip() or '(empty)'}")
 
 
 def _loads_json_object(text):
@@ -761,21 +839,15 @@ def _load_llm_judge(jc, config, project_root=None):
     if (os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID")
             or os.environ.get("ANTHROPIC_API_KEY")):
         judge_model = _resolve_judge_model(jc, config)
-        if jc.feedback_type == "bool":
-            system_prompt = _BOOL_SYSTEM_PROMPT
-            parser = _parse_bool_response
-        else:
-            system_prompt = _SCORE_SYSTEM_PROMPT
-            parser = _parse_score_response
+        feedback_type = "bool" if jc.feedback_type == "bool" else "score"
         arguments = jc.arguments
 
         def scorer(outputs=None, **kwargs):
             out = outputs or {}
             rendered = _render_jinja2_template(prompt, arguments, out)
             images = _extract_images(out)
-            raw = _call_judge_llm(rendered, judge_model, system_prompt,
-                                  images=images)
-            return parser(raw)
+            return _call_structured_judge(rendered, judge_model, feedback_type,
+                                          images=images)
 
         return scorer
 

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -692,36 +692,42 @@ def _aggregate_samples(runs, judge_type):
     reduce by median (noise reduction, returns an actually-observed score via
     median_low); bool judges by majority vote. The kept rationale is one from a
     sample matching the reduced value, so it stays consistent with the score.
-    `stability.stable` is True when every sample agreed.
+    `stability.stable` is True when every sample agreed and none errored.
     """
     import statistics
     vals = [r["value"] for r in runs if r.get("value") is not None]
+    error_count = sum(1 for r in runs if r.get("error"))
+    all_ok = error_count == 0
     if not vals:
         err = next((r.get("error") for r in runs if r.get("error")), "all samples failed")
         return {"value": None, "error": err, "judge_type": judge_type,
-                "stability": {"samples": len(runs), "values": []}}
+                "stability": {"samples": len(runs), "error_count": error_count,
+                               "values": []}}
     # bool must be checked before int (bool is a subclass of int)
     if all(isinstance(v, bool) for v in vals):
         passes = sum(1 for v in vals if v)
-        value = (passes * 2 >= len(vals))  # majority; ties resolve to pass
+        value = (passes * 2 > len(vals))  # strict majority; ties resolve to fail
         rationale = next((r.get("rationale", "") for r in runs
                           if r.get("value") is value), "")
-        stability = {"samples": len(vals), "pass_count": passes,
-                     "values": vals, "stable": passes in (0, len(vals))}
+        stability = {"samples": len(runs), "pass_count": passes,
+                     "error_count": error_count,
+                     "values": vals, "stable": all_ok and passes in (0, len(vals))}
     elif all(isinstance(v, (int, float)) for v in vals):
         value = statistics.median_low(vals)
         lo, hi = min(vals), max(vals)
         rationale = next((r.get("rationale", "") for r in runs
                           if r.get("value") == value), runs[0].get("rationale", ""))
-        stability = {"samples": len(vals), "min": lo, "max": hi,
+        stability = {"samples": len(runs), "min": lo, "max": hi,
+                     "error_count": error_count,
                      "mean": round(statistics.fmean(vals), 2),
-                     "values": vals, "stable": lo == hi}
+                     "values": vals, "stable": all_ok and lo == hi}
     else:
         value = vals[0]
         rationale = next((r.get("rationale", "") for r in runs
                           if r.get("value") == value), "")
-        stability = {"samples": len(vals), "values": vals,
-                     "stable": len({str(v) for v in vals}) <= 1}
+        stability = {"samples": len(runs), "error_count": error_count,
+                     "values": vals,
+                     "stable": all_ok and len({str(v) for v in vals}) <= 1}
     return {"value": value, "rationale": rationale, "judge_type": judge_type,
             "stability": stability}
 

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -908,25 +908,12 @@ class PairwiseResult:
     def reasoning(self) -> Optional[str]:
         """Overall reasoning from the canonical (A=run_a) judge call.
 
-        Judges don't reliably use the schema's `reasoning` key — observed
+        Judges don't always use the schema's `reasoning` key — observed
         variants include `analysis`, `rationale`, `explanation`, `scratchpad`,
         and `summary`. Search common key names and return the first non-empty
         string value so reasoning isn't silently dropped.
         """
         return _extract_reasoning_text(self.reasoning_ab)
-
-    @property
-    def dimensions(self) -> Optional[dict]:
-        """Per-dimension judgments from the canonical (A=run_a) judge call.
-
-        Tolerant of the `dimensions`/`scores` key-name variants judges use.
-        """
-        if isinstance(self.reasoning_ab, dict):
-            for key in ("dimensions", "scores"):
-                val = self.reasoning_ab.get(key)
-                if isinstance(val, dict) and val:
-                    return val
-        return None
 
 
 def compare_runs(run_a_dir, run_b_dir, config, case_ids,
@@ -1007,7 +994,7 @@ def compare_runs(run_a_dir, run_b_dir, config, case_ids,
         "wins_a": wins_a, "wins_b": wins_b,
         "ties": ties, "errors": errors,
         "per_case": [{"case_id": r.case_id, "winner": r.winner, "error": r.error,
-                      "reasoning": r.reasoning, "dimensions": r.dimensions}
+                      "reasoning": r.reasoning}
                      for r in results],
     }
 
@@ -1117,79 +1104,33 @@ def _get_anthropic_client():
     raise RuntimeError("Set ANTHROPIC_VERTEX_PROJECT_ID or ANTHROPIC_API_KEY")
 
 
-# Per-dimension verdict shape, reused for each comparison dimension.
-_PAIRWISE_DIM_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "preferred": {"type": "string", "enum": ["A", "B", "tie", "n/a"]},
-        "reasoning": {"type": "string",
-                      "description": "Why this dimension favors A, B, or neither — cite specific content."},
-    },
-    "required": ["preferred", "reasoning"],
-}
-
 # Forced-output tool for the pairwise judge. Using tool_choice guarantees the
-# model returns exactly these fields instead of improvising key names
-# (observed: opus-4-8 emits `analysis`/`score_A`/`confidence` instead of the
-# documented `reasoning`/`dimensions`, which silently drops the per-dimension
-# breakdown). Structured output works uniformly across judge models.
-_PAIRWISE_DIM_NAMES = ("rfe_quality", "calibration", "feasibility", "revision")
+# verdict and reasoning come back in known fields instead of free-form text
+# whose keys the model improvises (observed: opus-4-8 emits
+# `analysis`/`score_A`/`confidence` instead of the requested `reasoning`).
+# The schema is intentionally minimal — `preferred` is all the harness needs to
+# tally wins/losses/ties, and `reasoning` is what the report renders. Anything
+# the comparison prompt wants the judge to weigh (criteria, dimensions, ...) is
+# the prompt's concern and the judge folds it into `reasoning`; the harness
+# stays generic and prompt-agnostic.
 _PAIRWISE_TOOL = {
     "name": "submit_comparison",
-    "description": ("Submit the blind pairwise comparison of outputs A and B. "
-                    "Provide the overall verdict, thorough overall reasoning, and "
-                    "a per-dimension breakdown."),
+    "description": ("Submit the blind pairwise comparison of outputs A and B: "
+                    "the overall verdict and the reasoning behind it."),
     "input_schema": {
         "type": "object",
         "properties": {
             "preferred": {"type": "string", "enum": ["A", "B", "tie"],
                           "description": "Which output is stronger overall."},
             "reasoning": {"type": "string",
-                          "description": ("Thorough, self-contained overall reasoning — "
-                                          "several sentences citing specific content from "
-                                          "both outputs across RFE quality, assessment "
-                                          "calibration, feasibility depth, and revision "
-                                          "effectiveness. This is the primary field; make it "
-                                          "complete on its own.")},
-            "dimensions": {
-                "type": "object",
-                "description": "Per-dimension verdict and reasoning.",
-                "properties": {
-                    "rfe_quality": _PAIRWISE_DIM_SCHEMA,
-                    "calibration": _PAIRWISE_DIM_SCHEMA,
-                    "feasibility": _PAIRWISE_DIM_SCHEMA,
-                    "revision": _PAIRWISE_DIM_SCHEMA,
-                },
-            },
+                          "description": ("Thorough, self-contained reasoning citing "
+                                          "specific content from both outputs and "
+                                          "addressing every criterion the comparison "
+                                          "instructions specify.")},
         },
         "required": ["preferred", "reasoning"],
     },
 }
-
-
-def _normalize_pairwise_input(data):
-    """Recombine the flat per-dimension fields into a `dimensions` dict.
-
-    The tool schema is flat (top-level rfe_quality/calibration/feasibility/
-    revision), but a model may also nest them under `dimensions`. Collect
-    dimension-shaped objects ({preferred, reasoning}) from either location so
-    downstream always sees `data["dimensions"]` as a dict.
-    """
-    dims = {}
-    nested = data.get("dimensions")
-    if isinstance(nested, dict):
-        for k, v in nested.items():
-            if isinstance(v, dict):
-                dims[k] = v
-    for name in _PAIRWISE_DIM_NAMES:
-        v = data.pop(name, None)
-        if isinstance(v, dict):
-            dims[name] = v
-    if dims:
-        data["dimensions"] = dims
-    elif not isinstance(data.get("dimensions"), dict):
-        data.pop("dimensions", None)
-    return data
 
 
 def _call_judge(client, system_prompt, user_message, model, max_tokens=16384):
@@ -1210,7 +1151,7 @@ def _call_judge(client, system_prompt, user_message, model, max_tokens=16384):
         # parsing, no improvised keys.
         for block in response.content:
             if getattr(block, "type", None) == "tool_use" and block.name == "submit_comparison":
-                return _normalize_pairwise_input(dict(block.input)), None
+                return dict(block.input), None
         # Fallback: model emitted text despite tool_choice (rare) — parse it.
         text = "".join(getattr(b, "text", "") for b in response.content
                        if getattr(b, "type", None) == "text")

--- a/tests/test_score_builtin.py
+++ b/tests/test_score_builtin.py
@@ -245,6 +245,50 @@ class TestStructuredJudge:
         assert val == 3 and rat == "adequate"
 
 
+class TestSampleAggregation:
+
+    def test_score_reduces_to_median_and_records_spread(self):
+        import score
+        runs = [{"value": 4, "rationale": "r4a"},
+                {"value": 5, "rationale": "r5"},
+                {"value": 4, "rationale": "r4b"}]
+        out = score._aggregate_samples(runs, "llm")
+        assert out["value"] == 4                      # median_low of [4,5,4]
+        assert out["rationale"] in ("r4a", "r4b")     # a sample matching the value
+        st = out["stability"]
+        assert st["min"] == 4 and st["max"] == 5 and st["stable"] is False
+        assert st["samples"] == 3
+
+    def test_score_unanimous_is_stable(self):
+        import score
+        out = score._aggregate_samples(
+            [{"value": 5, "rationale": "a"}, {"value": 5, "rationale": "b"}], "llm")
+        assert out["value"] == 5
+        assert out["stability"]["stable"] is True
+
+    def test_bool_majority_vote(self):
+        import score
+        out = score._aggregate_samples(
+            [{"value": True, "rationale": "ok"},
+             {"value": False, "rationale": "no"},
+             {"value": True, "rationale": "ok2"}], "llm")
+        assert out["value"] is True                   # 2/3 pass
+        assert out["stability"]["pass_count"] == 2
+        assert out["stability"]["stable"] is False
+
+    def test_all_samples_failed(self):
+        import score
+        out = score._aggregate_samples(
+            [{"value": None, "error": "boom"}, {"value": None, "error": "boom2"}], "llm")
+        assert out["value"] is None
+        assert "boom" in out["error"]
+
+    def test_normalize_result_shapes(self):
+        import score
+        assert score._normalize_result((4, "why")) == (4, "why")
+        assert score._normalize_result(True) == (True, "")
+
+
 class TestOutputsProxy:
 
     def test_str_renders_files(self):

--- a/tests/test_score_builtin.py
+++ b/tests/test_score_builtin.py
@@ -23,7 +23,7 @@ class TestLoadJudgesBuiltin:
         ]
         judges = load_judges(config)
         assert len(judges) == 1
-        name, scorer, condition, judge_type = judges[0]
+        name, scorer, condition, judge_type, _samples = judges[0]
         assert name == "budget"
         assert judge_type == "builtin"
         assert condition == ""
@@ -42,7 +42,7 @@ class TestLoadJudgesBuiltin:
                         arguments={"max_cost_usd": 0.10}),
         ]
         judges = load_judges(config)
-        _, scorer, _, _ = judges[0]
+        _, scorer, _, _, _ = judges[0]
         result = scorer(outputs={"cost_usd": 0.50})
         assert result[0] is False
         assert "exceeds" in result[1]
@@ -109,7 +109,7 @@ class TestLoadJudgesBuiltin:
                         arguments={"max_cost_usd": 2.0}),
         ]
         judges = load_judges(config)
-        _, scorer, _, _ = judges[0]
+        _, scorer, _, _, _ = judges[0]
         result = scorer(outputs={"cost_usd": 1.50})
         assert result[0] is True
         assert "$2.00" in result[1]
@@ -124,7 +124,7 @@ class TestLoadJudgesBuiltin:
         ]
         judges = load_judges(config)
         assert len(judges) == 1
-        name, scorer, condition, judge_type = judges[0]
+        name, scorer, condition, judge_type, _samples = judges[0]
         assert name == "safety"
         assert judge_type == "builtin"
 
@@ -379,14 +379,14 @@ class TestLoadJudgesDuplicateValidation:
 
 class TestLoadJudgesTypes:
 
-    def test_check_judge_returns_4_tuple(self):
+    def test_check_judge_returns_5_tuple(self):
         config = EvalConfig(name="test", skill="test")
         config.judges = [
             JudgeConfig(name="test_check", check="return (True, 'ok')"),
         ]
         judges = load_judges(config)
         assert len(judges) == 1
-        name, scorer, condition, judge_type = judges[0]
+        name, scorer, condition, judge_type, _samples = judges[0]
         assert name == "test_check"
         assert judge_type == "check"
 
@@ -400,7 +400,7 @@ class TestLoadJudgesTypes:
             ),
         ]
         judges = load_judges(config)
-        _, scorer, _, _ = judges[0]
+        _, scorer, _, _, _ = judges[0]
         result = scorer(outputs={"content": "hi"})
         assert result[0] is True
 
@@ -435,7 +435,7 @@ class TestJudgeTypeMetadata:
             JudgeConfig(name="inline", check="return (True, 'ok')"),
         ]
         judges = load_judges(config)
-        types = {name: jtype for name, _, _, jtype in judges}
+        types = {name: jtype for name, _, _, jtype, _ in judges}
         assert types["budget"] == "builtin"
         assert types["inline"] == "check"
 
@@ -462,7 +462,7 @@ class TestVendoringPattern:
         ]
         judges = load_judges(config, project_root=tmp_path)
         assert len(judges) == 1
-        _, scorer, _, judge_type = judges[0]
+        _, scorer, _, judge_type, _ = judges[0]
         assert judge_type == "code"
         result = scorer(outputs={"cost_usd": 3.0})
         assert result[0] is True

--- a/tests/test_score_builtin.py
+++ b/tests/test_score_builtin.py
@@ -128,13 +128,15 @@ class TestLoadJudgesBuiltin:
         assert name == "safety"
         assert judge_type == "builtin"
 
-        with patch("score._call_judge_llm",
-                   return_value='{"passed": true, "rationale": "ok"}') as mock_call:
+        with patch("score._call_structured_judge",
+                   return_value=(True, "ok")) as mock_call:
             result = scorer(outputs={"conversation": "test", "files": {}})
             assert result == (True, "ok")
             rendered_prompt = mock_call.call_args[0][0]
             assert "malware" in rendered_prompt
             assert "test" in rendered_prompt
+            # builtin judges are pass/fail
+            assert mock_call.call_args[0][2] == "bool"
 
 
 class TestParsers:
@@ -175,6 +177,72 @@ class TestParsers:
         score, rationale = _parse_score_response("no numbers here at all")
         assert score == 3
         assert "Could not parse" in rationale
+
+    def test_parse_score_prose_keeps_full_rationale(self):
+        # Judge returned markdown prose instead of JSON: the score is still
+        # extracted and the FULL text is kept as the rationale (not truncated
+        # to 200 chars mid-word).
+        from score import _parse_score_response
+        prose = ("## Assessment\n\n**WHAT:** clear. " + ("detail " * 80)
+                 + "\n\n**Total: 4/5**")
+        score, rationale = _parse_score_response(prose)
+        assert score == 4
+        assert len(rationale) > 200
+        assert rationale.endswith("**Total: 4/5**")
+
+    def test_parse_score_rationale_with_embedded_quotes(self):
+        from score import _parse_score_response
+        raw = ('{"score": 5, "rationale": "Names \\"Acme Corp\\" and quantifies '
+               'impact across all criteria."}')
+        score, rationale = _parse_score_response(raw)
+        assert score == 5
+        assert '"Acme Corp"' in rationale
+
+    def test_parse_bool_prose_keeps_full_rationale(self):
+        from score import _parse_bool_response
+        prose = '{"passed": true} because ' + ("reason " * 80)
+        passed, rationale = _parse_bool_response(prose)
+        assert passed is True
+        assert len(rationale) > 200
+
+
+class TestStructuredJudge:
+
+    def _resp(self, *blocks):
+        return type("R", (), {"content": list(blocks)})()
+
+    def _tool_use(self, name, data):
+        return type("B", (), {"type": "tool_use", "name": name, "input": data})()
+
+    def _text(self, txt):
+        return type("B", (), {"type": "text", "text": txt})()
+
+    def test_structured_score_from_tool_use(self):
+        import score
+        resp = self._resp(self._tool_use(
+            "submit_score", {"score": 4, "rationale": "solid across criteria"}))
+        with patch("score._get_anthropic_client") as mock_client:
+            mock_client.return_value.messages.create.return_value = resp
+            val, rat = score._call_structured_judge("p", "m", "score")
+        assert val == 4 and rat == "solid across criteria"
+
+    def test_structured_bool_from_tool_use(self):
+        import score
+        resp = self._resp(self._tool_use(
+            "submit_evaluation", {"passed": False, "rationale": "missing field"}))
+        with patch("score._get_anthropic_client") as mock_client:
+            mock_client.return_value.messages.create.return_value = resp
+            val, rat = score._call_structured_judge("p", "m", "bool")
+        assert val is False and rat == "missing field"
+
+    def test_structured_falls_back_to_text(self):
+        # No tool_use block (model emitted text despite tool_choice) → parse text.
+        import score
+        resp = self._resp(self._text('{"score": 3, "rationale": "adequate"}'))
+        with patch("score._get_anthropic_client") as mock_client:
+            mock_client.return_value.messages.create.return_value = resp
+            val, rat = score._call_structured_judge("p", "m", "score")
+        assert val == 3 and rat == "adequate"
 
 
 class TestOutputsProxy:


### PR DESCRIPTION
Makes LLM-judge output trustworthy and adds sampling-stability measurement across the harness. Builds on #113 (which fixed the pairwise judge to see the full artifact set).

## 1. Force structured output for all LLM judges

Root cause: **opus-4-8 ignores "return JSON" text instructions** and improvises its output format, which silently degraded both the pairwise and the regular score/bool judges.

- **Pairwise judge**: opus-4-8 returned `analysis`/`score_A`/`confidence` instead of `reasoning`/`dimensions` → per-dimension breakdown captured ~2/20, reasoning inconsistently short. Fix: `_call_judge` uses forced tool use (`submit_comparison`); tolerant field extraction handles model-improvised key names. Result: reasoning 20/20 (avg ~3.8k chars), dimensions 20/20.
- **Score/bool judges**: opus-4-8 returned markdown prose, so the parser fell back to a **200-char rationale slice truncated mid-word** (~4/20 cases). Fix: both call sites route through `_call_structured_judge` (forced `submit_score`/`submit_evaluation` tools). The text-parse fallback was also hardened to keep the full text (no truncation), and judge `max_tokens` raised 1024→4096. After re-scoring, 0/20 rationales truncated.

## 2. Generic pairwise judge (drop hardcoded dimensions)

The pairwise tool schema and prompt were rfe-creator-specific (hardcoded dimension names like `completeness`, `evidence_quality`, etc.). Reworked to be fully generic:

- Tool schema is just `{preferred, reasoning}` — no dimensions concept
- Default `comparison-judge.md` prompt lists dimensions as guidance but the contract is open-ended
- The eval config's pairwise prompt can define whatever criteria fit the skill being evaluated

## 3. Per-judge `samples` config for stability measurement

LLM judge scores are stochastic. Each judge can now declare `samples: N` in `eval.yaml` to be sampled N times per case:

```yaml
judges:
  - name: rfe_quality
    prompt: "..."
    samples: 5
  - name: pairwise
    prompt_file: comparison-judge.md
    samples: 3
  - name: check_files
    check: "..."
    # samples on non-LLM judges emits a warning and is ignored
```

- **Per-judge config**: `judges[].samples` (default 1) — each LLM judge controls its own sample count
- **CLI override**: `--samples N` on `judges`/`pairwise` subcommands overrides per-judge config for all judges
- **Warning**: `samples > 1` on a non-LLM judge (check, builtin, code) emits a warning and is ignored — deterministic judges always run once
- **Reduction**: numeric judges use median_low, bool judges use majority vote
- **Stability tracking**: per-case `stability` dict (`min`/`max`/`values`/`stable`), aggregate `stable_cases`/`total_cases` per judge in `summary.yaml`

## 4. Report visualization

- **Scoring summary**: judge and pairwise rows get a proportion bar (cases stable vs varied)
- **Per-case**: every sampled judge renders an inline monospace ASCII histogram on a labelled axis — numeric `1 ░░░▃█ 5`, bool `F ▅█ P`, pairwise `A ░░█ B`. Bars scale by sample count; the median/majority bar is accent-colored. Stable judges show a single full bar, so the column scans "agree vs wobble" at a glance. Histogram is always shown when samples > 1, not only when variance is present.

## Test plan

- [x] `tests/test_score_builtin.py`: 43 pass (updated for 5-tuple judge format, added prose-rationale, embedded-quote, and structured-judge tests)
- [x] Full unit suite: 303 pass
- [x] End-to-end: re-scored both runs (0 truncated rationales) and `--samples 3` pairwise stability (100% agreement); `--samples 5` judges on Nemotron run (18/20 rfe_quality stable, 15/20 revision, 16/20 feasibility — only 1 case spread ≥2)
- [x] Per-judge `samples` config: verified parsing from eval.yaml, CLI override, warning on non-LLM judges
- [x] Reports regenerated with all glyph variants verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)