### PR TITLE
fix: add missing output_dir param to OpenCodeRunner.run_skill()

### DIFF
--- a/agent_eval/agent/opencode.py
+++ b/agent_eval/agent/opencode.py
@@ -83,6 +83,7 @@ class OpenCodeRunner(EvalRunner):
         system_prompt: Optional[str] = None,
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
+        output_dir: Optional[Path] = None,
     ) -> RunResult:
         receiver = None
         otel_port = None


### PR DESCRIPTION
## Summary
- `OpenCodeRunner.run_skill()` was missing the `output_dir` parameter defined by the base class `EvalRunner.run_skill()` 
- `execute.py` passes `output_dir=case_output` to all runners, causing a `TypeError` at runtime for OpenCode

## Test plan
- [x] Ran `ci:payload-analysis` eval case-009 against OpenCode with `claude-opus-4-6` — all 7 judges pass (5/5 on both LLM judges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)