### PR TITLE
Warn on stale inline frontmatter fields

### DIFF
--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -1252,47 +1252,24 @@ def _parse_inline_check_source(source):
 # Names an inline check conventionally binds the parsed frontmatter to. The
 # analysis is name-based, so anything else is simply not analysed — silence,
 # never a wrong warning.
-_FRONTMATTER_NAMES = {"fm", "frontmatter", "meta"}
+_FRONTMATTER_NAMES = {"fm", "frontmatter"}
 
 
 def _extract_frontmatter_field_refs(source):
-    """Fields an inline check REQUIRES from the frontmatter.
+    """Frontmatter field names an inline check mentions.
 
-    Three idioms count as a requirement — `fm.get("x")`, `fm["x"]`, and
-    `"x" in fm` / `"x" not in fm`, the last being the one the README, the
-    cookbook and the eval.yaml template all use.
-
-    Two do not, and skipping them is what keeps this quiet on healthy configs:
-    `fm.get("x", default)` states outright that the field is optional, and a
-    reference whose only use is a truth test (`if fm.get("x"): ...`) is an
-    absence assertion — it warns precisely when the skill is behaving.
+    Every literal reference counts — `fm.get("x")`, `fm.get("x", default)`,
+    `fm["x"]`, `"x" in fm`. Deliberately no attempt to infer whether the field
+    is *required*: intent is not in the syntax. `if fm.get("x"): return True`
+    and `if fm.get("x"): return False` are the same expression and opposite
+    requirements, and the project's own template tells authors to pass a
+    default to every lookup, so a default says nothing either. Precision comes
+    from only reporting judges that actually failed (see `score_cases`), not
+    from guessing here.
     """
     tree = _parse_inline_check_source(source)
     if tree is None:
         return []
-
-    # Polarity decides intent. `if fm.get("x")` asserts the field should be
-    # ABSENT — warning there fires when the skill is behaving. `if not
-    # fm.get("x")` is the opposite: it requires the field, and is the exact
-    # shape issue #33 is about. So collect POSITIVE truth tests only, and step
-    # over a `not` rather than through it.
-    optional = set()
-
-    def _mark_positive_tests(node):
-        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
-            return                      # negated: a requirement, keep it
-        if isinstance(node, ast.BoolOp):
-            for value in node.values:
-                _mark_positive_tests(value)
-            return
-        optional.add(id(node))
-
-    for node in ast.walk(tree):
-        for attr in ("test",):
-            test = getattr(node, attr, None)
-            if test is not None:
-                _mark_positive_tests(test)
-
     refs = set()
     for node in ast.walk(tree):
         name = None
@@ -1301,17 +1278,13 @@ def _extract_frontmatter_field_refs(source):
                 and node.func.attr == "get"
                 and _is_frontmatter_name(node.func.value)
                 and node.args):
-            if len(node.args) > 1:      # an explicit default = optional
-                continue
-            if id(node) in optional:    # `if fm.get("x")` = expects absence
-                continue
             name = _literal_string(node.args[0])
         elif (isinstance(node, ast.Subscript)
-              and _is_frontmatter_name(node.value)):
+              and _is_frontmatter_name(node.value)
+              and isinstance(node.ctx, ast.Load)):   # not a write or a del
             name = _literal_string(node.slice)
         elif isinstance(node, ast.Compare) and len(node.ops) == 1:
-            op = node.ops[0]
-            if (isinstance(op, (ast.In, ast.NotIn))
+            if (isinstance(node.ops[0], (ast.In, ast.NotIn))
                     and _is_frontmatter_name(node.comparators[0])):
                 name = _literal_string(node.left)
         if name:
@@ -1446,35 +1419,59 @@ def _collect_frontmatter_keys(record, content_keys):
             found[key] = keys
     return found
 
-def _warn_stale_inline_field_refs(judges, case_dirs, config, run_id=None):
-    """Warn when inline checks reference absent YAML frontmatter fields.
+# How many cases the probe reads. One is too few — the first case is often the
+# one that produced nothing — and reading every case duplicates the scoring
+# loop's IO for no extra signal.
+_STALE_FIELD_PROBE_CASES = 3
 
-    Advisory only. Every failure mode is swallowed: this runs before any judge
-    and after the agent has already been paid for, so a diagnostic that can
-    raise would destroy the run it exists to explain.
+
+def _warn_stale_inline_field_refs(judges, case_dirs, config, aggregated,
+                                  run_id=None):
+    """Explain a check judge that failed everywhere, if its fields moved.
+
+    Runs AFTER scoring and only for a judge whose every case returned False.
+    That is what makes it quiet: a passing judge is never reported, so no
+    amount of guessing about which references are "required" is needed — the
+    judge's own verdict is the evidence. Issue #33's symptom was exactly this
+    shape, a 0% pass rate that looked like a skill regression.
+
+    Advisory only, and swallows everything: this is a diagnostic printed after
+    the run has already been paid for.
     """
     try:
-        _stale_inline_field_refs(judges, case_dirs, config, run_id)
+        _stale_inline_field_refs(judges, case_dirs, config, aggregated, run_id)
     except Exception as exc:                      # pragma: no cover - guard
         print(f"  Warning: stale-field check skipped: {exc}", file=sys.stderr)
 
 
-# How many cases the probe reads before giving up. One is too few — the first
-# case is often the one that failed to produce artifacts — and reading all of
-# them duplicates the scoring loop's own IO for no extra signal.
-_STALE_FIELD_PROBE_CASES = 3
+def _judge_failed_every_case(agg):
+    """True when a judge never once succeeded — every case False, or errored.
+
+    Both are evidence. A judge whose field was renamed usually returns False,
+    but one that indexes into the frontmatter it can no longer find raises
+    instead, which is just as conclusive and is what the artifact-without-
+    frontmatter case does.
+    """
+    agg = agg or {}
+    values = [v for v in agg.get("values", []) if isinstance(v, bool)]
+    if values:
+        return not any(values)
+    return not agg.get("values") and bool(agg.get("errored_cases"))
 
 
-def _stale_inline_field_refs(judges, case_dirs, config, run_id=None):
+def _stale_inline_field_refs(judges, case_dirs, config, aggregated,
+                             run_id=None):
     refs_by_judge = {}
-    for name, scorer, condition, judge_type, _samples in judges:
+    for name, scorer, _condition, judge_type, _samples in judges:
         if judge_type != "check":
+            continue
+        if not _judge_failed_every_case(aggregated.get(name)):
             continue
         source = getattr(scorer, "_inline_check_source", "")
         refs = _extract_frontmatter_field_refs(source)
         content_keys = _extract_frontmatter_content_keys(source)
         if refs and content_keys:
-            refs_by_judge[name] = (refs, content_keys, condition)
+            refs_by_judge[name] = (refs, content_keys)
     if not refs_by_judge or not case_dirs:
         return
 
@@ -1488,52 +1485,27 @@ def _stale_inline_field_refs(judges, case_dirs, config, run_id=None):
         _emit_stale_field_warnings(refs_by_judge, records)
 
 
-def _judge_runs_on(condition, record):
-    """Whether an `if:`-gated judge would run on this case.
-
-    Errs towards running: an unevaluatable condition should not silence a
-    diagnostic, and a judge skipped on every probed case must not be reported
-    against artifacts it never looks at.
-    """
-    if not condition:
-        return True
-    try:
-        return bool(eval(condition, {"__builtins__": {}},
-                         {"annotations": record.get("annotations", {}),
-                          "outputs": record}))
-    except Exception:
-        return True
-
-
 def _emit_stale_field_warnings(refs_by_judge, records):
-    """Report a field only when EVERY probed case that runs the judge lacks it.
+    """Report a field only when every probed case lacks it.
 
-    One case is weak evidence — a heterogeneous dataset, or a case that simply
-    produced nothing, would otherwise generate a warning about a field the rest
-    of the run has. A field absent everywhere is drift.
+    Absent everywhere is drift; absent in one case is a case that failed.
     """
-    for name, (refs, content_keys, condition) in refs_by_judge.items():
-        seen = {}          # artifact -> keys observed across the probed cases
-        looked = False
+    for name, (refs, content_keys) in refs_by_judge.items():
+        seen = {}
         for record in records:
-            if not _judge_runs_on(condition, record):
-                continue
             for source, available in _collect_frontmatter_keys(
                     record, content_keys).items():
-                looked = True
                 seen.setdefault(source, set()).update(available)
-        if not looked:
-            continue
         for source, available in seen.items():
             missing = [ref for ref in refs if ref not in available]
             if not missing:
                 continue
             print(
-                f"  Warning: inline judge '{name}' requires frontmatter "
-                f"field(s) absent from {source} in every case checked: "
+                f"  Warning: judge '{name}' failed on every case and reads "
+                f"frontmatter field(s) absent from {source}: "
                 f"{', '.join(missing)}. "
                 f"Present: {', '.join(sorted(available)) or '(none)'}. "
-                "If the skill renamed them, update the judge.",
+                "If the skill renamed them, the judge is stale.",
                 file=sys.stderr,
             )
 
@@ -1547,7 +1519,6 @@ def score_cases(judges, case_dirs, config, run_id=None, samples_override=None):
     """
     if not case_dirs:
         return {"per_case": {}, "aggregated": {n: {"values": [], "mean": None, "pass_rate": None} for n, *_ in judges}}
-    _warn_stale_inline_field_refs(judges, case_dirs, config, run_id=run_id)
     per_case = {}
     aggregated = {name: {"values": [], "errored_cases": 0}
                   for name, *_ in judges}
@@ -1678,6 +1649,9 @@ def score_cases(judges, case_dirs, config, run_id=None, samples_override=None):
         else:
             aggregated[name]["mean"] = None
             aggregated[name]["pass_rate"] = None
+
+    _warn_stale_inline_field_refs(judges, case_dirs, config, aggregated,
+                                  run_id=run_id)
 
     # Per-judge stability across cases (only meaningful when sampled > 1):
     # how many cases gave a consistent score across all samples.

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -1357,44 +1357,76 @@ def _literal_string(node):
 
 
 def _extract_yaml_frontmatter_keys(text):
-    """Extract top-level keys from markdown YAML frontmatter."""
-    if not isinstance(text, str) or not text.startswith("---"):
-        return set()
-    parts = text.split("---", 2)
+    """Extract top-level keys from markdown YAML frontmatter.
+
+    Three outcomes, and the difference matters:
+      * a set     — frontmatter parsed, these are its keys;
+      * empty set — the document genuinely has no frontmatter, so every
+                    referenced field really is absent (worth warning about);
+      * None      — frontmatter is there but unreadable, so we know nothing
+                    and must stay quiet rather than report it all missing.
+    """
+    if not isinstance(text, str):
+        return None
+    stripped = text.lstrip("\ufeff \t\r\n")
+    if not stripped.startswith("---"):
+        return set()          # no frontmatter block at all
+    parts = stripped.split("---", 2)
     if len(parts) < 3:
-        return set()
+        return None           # opened but never closed — malformed, unknown
     try:
         frontmatter = yaml.safe_load(parts[1]) or {}
-    except yaml.YAMLError:
-        return set()
+    except Exception:
+        # Not just YAMLError: safe_load raises a bare ValueError for an
+        # out-of-range date (`due: 2026-02-30`) or an over-long integer.
+        return None
     if not isinstance(frontmatter, dict):
-        return set()
+        return None
     return {str(k) for k in frontmatter}
 
 
 def _collect_frontmatter_keys(record, content_keys=None):
     """Collect YAML frontmatter keys from loaded text artifacts."""
     if content_keys:
-        return {
-            key: _extract_yaml_frontmatter_keys(record.get(key))
-            for key in content_keys
-            if key in record
-        }
+        found = {}
+        for key in content_keys:
+            if key not in record:
+                continue
+            keys = _extract_yaml_frontmatter_keys(record.get(key))
+            if keys is not None:      # None = unreadable, so we know nothing
+                found[key] = keys
+        return found
 
     keys = set()
     found_artifact = False
     for content in record.get("files", {}).values():
-        found_artifact = True
-        keys.update(_extract_yaml_frontmatter_keys(content))
+        parsed = _extract_yaml_frontmatter_keys(content)
+        if parsed is not None:
+            found_artifact = True
+            keys.update(parsed)
     for name, content in record.items():
         if name.endswith("_content"):
-            found_artifact = True
-            keys.update(_extract_yaml_frontmatter_keys(content))
+            parsed = _extract_yaml_frontmatter_keys(content)
+            if parsed is not None:
+                found_artifact = True
+                keys.update(parsed)
     return {"collected artifacts": keys} if found_artifact else {}
 
 
 def _warn_stale_inline_field_refs(judges, case_dirs, config, run_id=None):
-    """Warn when inline checks reference absent YAML frontmatter fields."""
+    """Warn when inline checks reference absent YAML frontmatter fields.
+
+    Advisory only. Every failure mode is swallowed: this runs before any judge
+    and after the agent has already been paid for, so a diagnostic that can
+    raise would destroy the run it exists to explain.
+    """
+    try:
+        _stale_inline_field_refs(judges, case_dirs, config, run_id)
+    except Exception as exc:                      # pragma: no cover - guard
+        print(f"  Warning: stale-field check skipped: {exc}", file=sys.stderr)
+
+
+def _stale_inline_field_refs(judges, case_dirs, config, run_id=None):
     refs_by_judge = {}
     for name, scorer, _condition, judge_type, _samples in judges:
         if judge_type != "check":
@@ -1413,6 +1445,10 @@ def _warn_stale_inline_field_refs(judges, case_dirs, config, run_id=None):
     except Exception:
         return
 
+    _emit_stale_field_warnings(refs_by_judge, record)
+
+
+def _emit_stale_field_warnings(refs_by_judge, record):
     for name, (refs, content_keys) in refs_by_judge.items():
         available_by_source = _collect_frontmatter_keys(record, content_keys)
         for source, available in available_by_source.items():

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -1388,11 +1388,15 @@ def _extract_yaml_frontmatter_keys(text):
     stripped = text.lstrip("\ufeff \t\r\n")
     if not stripped.startswith("---"):
         return set()          # no frontmatter block at all
-    parts = stripped.split("---", 2)
-    if len(parts) < 3:
+    # Line-anchored. A plain `split("---", 2)` also matches a `---` inside a
+    # scalar, so `title: foo --- bar` truncates the block and everything below
+    # it reads as absent — a warning about a field that is right there.
+    match = re.match(r"-{3,}[ \t]*\r?\n(.*?)\r?\n-{3,}[ \t]*(?:\r?\n|\Z)",
+                     stripped, re.DOTALL)
+    if match is None:
         return None           # opened but never closed — malformed, unknown
     try:
-        frontmatter = yaml.safe_load(parts[1]) or {}
+        frontmatter = yaml.safe_load(match.group(1)) or {}
     except Exception:
         # Not just YAMLError: safe_load raises a bare ValueError for an
         # out-of-range date (`due: 2026-02-30`) or an over-long integer.

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -1249,24 +1249,79 @@ def _parse_inline_check_source(source):
         return None
 
 
+# Names an inline check conventionally binds the parsed frontmatter to. The
+# analysis is name-based, so anything else is simply not analysed — silence,
+# never a wrong warning.
+_FRONTMATTER_NAMES = {"fm", "frontmatter", "meta"}
+
+
 def _extract_frontmatter_field_refs(source):
-    """Return fm.get("field") references from an inline check snippet."""
+    """Fields an inline check REQUIRES from the frontmatter.
+
+    Three idioms count as a requirement — `fm.get("x")`, `fm["x"]`, and
+    `"x" in fm` / `"x" not in fm`, the last being the one the README, the
+    cookbook and the eval.yaml template all use.
+
+    Two do not, and skipping them is what keeps this quiet on healthy configs:
+    `fm.get("x", default)` states outright that the field is optional, and a
+    reference whose only use is a truth test (`if fm.get("x"): ...`) is an
+    absence assertion — it warns precisely when the skill is behaving.
+    """
     tree = _parse_inline_check_source(source)
     if tree is None:
         return []
+
+    # Polarity decides intent. `if fm.get("x")` asserts the field should be
+    # ABSENT — warning there fires when the skill is behaving. `if not
+    # fm.get("x")` is the opposite: it requires the field, and is the exact
+    # shape issue #33 is about. So collect POSITIVE truth tests only, and step
+    # over a `not` rather than through it.
+    optional = set()
+
+    def _mark_positive_tests(node):
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+            return                      # negated: a requirement, keep it
+        if isinstance(node, ast.BoolOp):
+            for value in node.values:
+                _mark_positive_tests(value)
+            return
+        optional.add(id(node))
+
+    for node in ast.walk(tree):
+        for attr in ("test",):
+            test = getattr(node, attr, None)
+            if test is not None:
+                _mark_positive_tests(test)
+
     refs = set()
     for node in ast.walk(tree):
-        if not (isinstance(node, ast.Call)
+        name = None
+        if (isinstance(node, ast.Call)
                 and isinstance(node.func, ast.Attribute)
                 and node.func.attr == "get"
-                and isinstance(node.func.value, ast.Name)
-                and node.func.value.id == "fm"):
-            continue
-        if (node.args
-                and isinstance(node.args[0], ast.Constant)
-                and isinstance(node.args[0].value, str)):
-            refs.add(node.args[0].value)
-    return sorted(set(refs))
+                and _is_frontmatter_name(node.func.value)
+                and node.args):
+            if len(node.args) > 1:      # an explicit default = optional
+                continue
+            if id(node) in optional:    # `if fm.get("x")` = expects absence
+                continue
+            name = _literal_string(node.args[0])
+        elif (isinstance(node, ast.Subscript)
+              and _is_frontmatter_name(node.value)):
+            name = _literal_string(node.slice)
+        elif isinstance(node, ast.Compare) and len(node.ops) == 1:
+            op = node.ops[0]
+            if (isinstance(op, (ast.In, ast.NotIn))
+                    and _is_frontmatter_name(node.comparators[0])):
+                name = _literal_string(node.left)
+        if name:
+            refs.add(name)
+    return sorted(refs)
+
+
+def _is_frontmatter_name(node):
+    """The parsed-frontmatter variable, by the conventional names."""
+    return isinstance(node, ast.Name) and node.id in _FRONTMATTER_NAMES
 
 
 def _extract_frontmatter_content_keys(source):
@@ -1298,7 +1353,7 @@ def _extract_frontmatter_content_keys(source):
     def _record_assignment(target, sources):
         if not isinstance(target, ast.Name):
             return
-        if target.id == "fm":
+        if target.id in _FRONTMATTER_NAMES:
             fm_sources.update(sources)
         elif sources:
             var_sources[target.id] = sources
@@ -1326,24 +1381,13 @@ def _extract_frontmatter_content_keys(source):
 
     function = tree.body[0]
     _visit_statements(function.body)
-    if fm_sources:
-        return sorted(fm_sources)
-
-    keys = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Subscript) and _is_outputs_name(node.value):
-            key = _literal_string(node.slice)
-            if key and key.endswith("_content"):
-                keys.add(key)
-        elif (isinstance(node, ast.Call)
-              and isinstance(node.func, ast.Attribute)
-              and node.func.attr == "get"
-              and _is_outputs_name(node.func.value)
-              and node.args):
-            key = _literal_string(node.args[0])
-            if key and key.endswith("_content"):
-                keys.add(key)
-    return sorted(keys)
+    # No fallback on purpose. If the assignment could not be traced we do not
+    # know which artifact holds the frontmatter, and guessing from every
+    # `*_content` read in the snippet blames artifacts the judge never parsed —
+    # reporting THEIR keys as "available". Silence is the correct output, and
+    # it makes every gap in the walk above (nested defs, tuple targets, loop
+    # variables) degrade to a no-op rather than a wrong accusation.
+    return sorted(fm_sources)
 
 
 def _is_outputs_name(node):
@@ -1385,33 +1429,22 @@ def _extract_yaml_frontmatter_keys(text):
     return {str(k) for k in frontmatter}
 
 
-def _collect_frontmatter_keys(record, content_keys=None):
-    """Collect YAML frontmatter keys from loaded text artifacts."""
-    if content_keys:
-        found = {}
-        for key in content_keys:
-            if key not in record:
-                continue
-            keys = _extract_yaml_frontmatter_keys(record.get(key))
-            if keys is not None:      # None = unreadable, so we know nothing
-                found[key] = keys
-        return found
+def _collect_frontmatter_keys(record, content_keys):
+    """Frontmatter keys per artifact the judge actually parses.
 
-    keys = set()
-    found_artifact = False
-    for content in record.get("files", {}).values():
-        parsed = _extract_yaml_frontmatter_keys(content)
-        if parsed is not None:
-            found_artifact = True
-            keys.update(parsed)
-    for name, content in record.items():
-        if name.endswith("_content"):
-            parsed = _extract_yaml_frontmatter_keys(content)
-            if parsed is not None:
-                found_artifact = True
-                keys.update(parsed)
-    return {"collected artifacts": keys} if found_artifact else {}
-
+    Only the artifacts `content_keys` names. The union-everything path this
+    replaced swept in the dataset answer key (`annotations_*_content`) and the
+    staged input copies — the files most likely to still carry the OLD field
+    name after a rename, so the union hid exactly the drift being looked for.
+    """
+    found = {}
+    for key in content_keys or ():
+        if key not in record:
+            continue
+        keys = _extract_yaml_frontmatter_keys(record.get(key))
+        if keys is not None:      # None = unreadable, so we know nothing
+            found[key] = keys
+    return found
 
 def _warn_stale_inline_field_refs(judges, case_dirs, config, run_id=None):
     """Warn when inline checks reference absent YAML frontmatter fields.

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -14,6 +14,7 @@ Usage:
 import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
 import argparse
+import ast
 import importlib
 import json
 import logging
@@ -1239,6 +1240,195 @@ def _aggregate_samples(runs, judge_type):
     return result
 
 
+def _parse_inline_check_source(source):
+    """Parse an inline check snippet as the function body used at runtime."""
+    wrapped = f"def _check(outputs, arguments):\n{textwrap.indent(source or '', '    ')}"
+    try:
+        return ast.parse(wrapped)
+    except SyntaxError:
+        return None
+
+
+def _extract_frontmatter_field_refs(source):
+    """Return fm.get("field") references from an inline check snippet."""
+    tree = _parse_inline_check_source(source)
+    if tree is None:
+        return []
+    refs = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "fm"):
+            continue
+        if (node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)):
+            refs.add(node.args[0].value)
+    return sorted(set(refs))
+
+
+def _extract_frontmatter_content_keys(source):
+    """Return outputs['name_content'] keys that flow into an fm assignment."""
+    tree = _parse_inline_check_source(source)
+    if tree is None:
+        return []
+    var_sources = {}
+    fm_sources = set()
+
+    def _content_keys_in_expr(node):
+        if isinstance(node, ast.Subscript) and _is_outputs_name(node.value):
+            key = _literal_string(node.slice)
+            return {key} if key and key.endswith("_content") else set()
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and _is_outputs_name(node.func.value)
+                and node.args):
+            key = _literal_string(node.args[0])
+            return {key} if key and key.endswith("_content") else set()
+        if isinstance(node, ast.Name):
+            return var_sources.get(node.id, set())
+        keys = set()
+        for child in ast.iter_child_nodes(node):
+            keys.update(_content_keys_in_expr(child))
+        return keys
+
+    def _record_assignment(target, sources):
+        if not isinstance(target, ast.Name):
+            return
+        if target.id == "fm":
+            fm_sources.update(sources)
+        elif sources:
+            var_sources[target.id] = sources
+        else:
+            var_sources.pop(target.id, None)
+
+    def _visit_statements(statements):
+        for statement in statements:
+            if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if isinstance(statement, ast.Assign):
+                sources = _content_keys_in_expr(statement.value)
+                for target in statement.targets:
+                    _record_assignment(target, sources)
+            elif isinstance(statement, ast.AnnAssign):
+                sources = (_content_keys_in_expr(statement.value)
+                           if statement.value else set())
+                _record_assignment(statement.target, sources)
+            for attr in ("body", "orelse", "finalbody"):
+                nested = getattr(statement, attr, None)
+                if isinstance(nested, list):
+                    _visit_statements(nested)
+            for handler in getattr(statement, "handlers", []):
+                _visit_statements(handler.body)
+
+    function = tree.body[0]
+    _visit_statements(function.body)
+    if fm_sources:
+        return sorted(fm_sources)
+
+    keys = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Subscript) and _is_outputs_name(node.value):
+            key = _literal_string(node.slice)
+            if key and key.endswith("_content"):
+                keys.add(key)
+        elif (isinstance(node, ast.Call)
+              and isinstance(node.func, ast.Attribute)
+              and node.func.attr == "get"
+              and _is_outputs_name(node.func.value)
+              and node.args):
+            key = _literal_string(node.args[0])
+            if key and key.endswith("_content"):
+                keys.add(key)
+    return sorted(keys)
+
+
+def _is_outputs_name(node):
+    return isinstance(node, ast.Name) and node.id == "outputs"
+
+
+def _literal_string(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _extract_yaml_frontmatter_keys(text):
+    """Extract top-level keys from markdown YAML frontmatter."""
+    if not isinstance(text, str) or not text.startswith("---"):
+        return set()
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return set()
+    try:
+        frontmatter = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError:
+        return set()
+    if not isinstance(frontmatter, dict):
+        return set()
+    return {str(k) for k in frontmatter}
+
+
+def _collect_frontmatter_keys(record, content_keys=None):
+    """Collect YAML frontmatter keys from loaded text artifacts."""
+    if content_keys:
+        return {
+            key: _extract_yaml_frontmatter_keys(record.get(key))
+            for key in content_keys
+            if key in record
+        }
+
+    keys = set()
+    found_artifact = False
+    for content in record.get("files", {}).values():
+        found_artifact = True
+        keys.update(_extract_yaml_frontmatter_keys(content))
+    for name, content in record.items():
+        if name.endswith("_content"):
+            found_artifact = True
+            keys.update(_extract_yaml_frontmatter_keys(content))
+    return {"collected artifacts": keys} if found_artifact else {}
+
+
+def _warn_stale_inline_field_refs(judges, case_dirs, config, run_id=None):
+    """Warn when inline checks reference absent YAML frontmatter fields."""
+    refs_by_judge = {}
+    for name, scorer, _condition, judge_type, _samples in judges:
+        if judge_type != "check":
+            continue
+        source = getattr(scorer, "_inline_check_source", "")
+        refs = _extract_frontmatter_field_refs(source)
+        if refs:
+            refs_by_judge[name] = (
+                refs, _extract_frontmatter_content_keys(source)
+            )
+    if not refs_by_judge or not case_dirs:
+        return
+
+    try:
+        record = load_case_record(case_dirs[0], config, run_id=run_id)
+    except Exception:
+        return
+
+    for name, (refs, content_keys) in refs_by_judge.items():
+        available_by_source = _collect_frontmatter_keys(record, content_keys)
+        for source, available in available_by_source.items():
+            missing = [ref for ref in refs if ref not in available]
+            if not missing:
+                continue
+            available_text = ", ".join(sorted(available)) or "(none)"
+            missing_text = ", ".join(missing)
+            print(
+                f"  Warning: inline judge '{name}' references "
+                f"frontmatter field(s) not found in {source}: {missing_text}. "
+                f"Available fields: {available_text}",
+                file=sys.stderr,
+            )
+
+
 def score_cases(judges, case_dirs, config, run_id=None, samples_override=None):
     """Score all cases with all judges in parallel.
 
@@ -1248,6 +1438,7 @@ def score_cases(judges, case_dirs, config, run_id=None, samples_override=None):
     """
     if not case_dirs:
         return {"per_case": {}, "aggregated": {n: {"values": [], "mean": None, "pass_rate": None} for n, *_ in judges}}
+    _warn_stale_inline_field_refs(judges, case_dirs, config, run_id=run_id)
     per_case = {}
     aggregated = {name: {"values": [], "errored_cases": 0}
                   for name, *_ in judges}
@@ -1412,6 +1603,7 @@ def _make_inline_check(jc):
     def scorer(outputs=None, **kwargs):
         return check_fn(outputs or {}, arguments or {})
 
+    scorer._inline_check_source = source
     return scorer
 
 

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -1459,41 +1459,81 @@ def _warn_stale_inline_field_refs(judges, case_dirs, config, run_id=None):
         print(f"  Warning: stale-field check skipped: {exc}", file=sys.stderr)
 
 
+# How many cases the probe reads before giving up. One is too few — the first
+# case is often the one that failed to produce artifacts — and reading all of
+# them duplicates the scoring loop's own IO for no extra signal.
+_STALE_FIELD_PROBE_CASES = 3
+
+
 def _stale_inline_field_refs(judges, case_dirs, config, run_id=None):
     refs_by_judge = {}
-    for name, scorer, _condition, judge_type, _samples in judges:
+    for name, scorer, condition, judge_type, _samples in judges:
         if judge_type != "check":
             continue
         source = getattr(scorer, "_inline_check_source", "")
         refs = _extract_frontmatter_field_refs(source)
-        if refs:
-            refs_by_judge[name] = (
-                refs, _extract_frontmatter_content_keys(source)
-            )
+        content_keys = _extract_frontmatter_content_keys(source)
+        if refs and content_keys:
+            refs_by_judge[name] = (refs, content_keys, condition)
     if not refs_by_judge or not case_dirs:
         return
 
+    records = []
+    for case_dir in case_dirs[:_STALE_FIELD_PROBE_CASES]:
+        try:
+            records.append(load_case_record(case_dir, config, run_id=run_id))
+        except Exception:
+            continue
+    if records:
+        _emit_stale_field_warnings(refs_by_judge, records)
+
+
+def _judge_runs_on(condition, record):
+    """Whether an `if:`-gated judge would run on this case.
+
+    Errs towards running: an unevaluatable condition should not silence a
+    diagnostic, and a judge skipped on every probed case must not be reported
+    against artifacts it never looks at.
+    """
+    if not condition:
+        return True
     try:
-        record = load_case_record(case_dirs[0], config, run_id=run_id)
+        return bool(eval(condition, {"__builtins__": {}},
+                         {"annotations": record.get("annotations", {}),
+                          "outputs": record}))
     except Exception:
-        return
-
-    _emit_stale_field_warnings(refs_by_judge, record)
+        return True
 
 
-def _emit_stale_field_warnings(refs_by_judge, record):
-    for name, (refs, content_keys) in refs_by_judge.items():
-        available_by_source = _collect_frontmatter_keys(record, content_keys)
-        for source, available in available_by_source.items():
+def _emit_stale_field_warnings(refs_by_judge, records):
+    """Report a field only when EVERY probed case that runs the judge lacks it.
+
+    One case is weak evidence — a heterogeneous dataset, or a case that simply
+    produced nothing, would otherwise generate a warning about a field the rest
+    of the run has. A field absent everywhere is drift.
+    """
+    for name, (refs, content_keys, condition) in refs_by_judge.items():
+        seen = {}          # artifact -> keys observed across the probed cases
+        looked = False
+        for record in records:
+            if not _judge_runs_on(condition, record):
+                continue
+            for source, available in _collect_frontmatter_keys(
+                    record, content_keys).items():
+                looked = True
+                seen.setdefault(source, set()).update(available)
+        if not looked:
+            continue
+        for source, available in seen.items():
             missing = [ref for ref in refs if ref not in available]
             if not missing:
                 continue
-            available_text = ", ".join(sorted(available)) or "(none)"
-            missing_text = ", ".join(missing)
             print(
-                f"  Warning: inline judge '{name}' references "
-                f"frontmatter field(s) not found in {source}: {missing_text}. "
-                f"Available fields: {available_text}",
+                f"  Warning: inline judge '{name}' requires frontmatter "
+                f"field(s) absent from {source} in every case checked: "
+                f"{', '.join(missing)}. "
+                f"Present: {', '.join(sorted(available)) or '(none)'}. "
+                "If the skill renamed them, update the judge.",
                 file=sys.stderr,
             )
 

--- a/tests/test_score_builtin.py
+++ b/tests/test_score_builtin.py
@@ -487,6 +487,62 @@ class TestInlineJudgeFieldValidation:
                       f"return bool({name}.get('title')), 'x'")
             assert refs(source) == ["title"], name
 
+    def _stale_field_config(self, condition=None):
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [OutputConfig(path="artifacts")]
+        config.judges = [
+            JudgeConfig(
+                name="frontmatter_valid",
+                condition=condition,
+                check=(
+                    "import yaml\n"
+                    "fm = yaml.safe_load("
+                    "outputs['artifacts_content'].split('---', 2)[1]) or {}\n"
+                    "if not fm.get('strat_key'):\n"
+                    "    return False, 'bad'\n"
+                    "return True, 'ok'"
+                ),
+            ),
+        ]
+        return config
+
+    def _run_cases(self, tmp_path, cases, condition=None):
+        dirs = []
+        for name, front in cases:
+            art = tmp_path / name / "artifacts"
+            art.mkdir(parents=True)
+            if front is not None:
+                (art / "r.md").write_text(f"---\n{front}\n---\nbody\n")
+            dirs.append(tmp_path / name)
+        config = self._stale_field_config(condition)
+        score_cases(load_judges(config), sorted(dirs), config)
+
+    def test_drift_across_every_case_warns(self, tmp_path, capsys):
+        self._run_cases(tmp_path, [("case-001", "source_key: a"),
+                                   ("case-002", "source_key: b")])
+        assert "strat_key" in capsys.readouterr().err
+
+    def test_one_empty_case_does_not_warn_for_the_whole_run(self, tmp_path,
+                                                            capsys):
+        """Probing only case-001 meant a case that produced nothing spoke for
+        every other case — and a partly-failed run is exactly when someone is
+        trying to tell a skill regression from a judge bug."""
+        self._run_cases(tmp_path, [("case-001", None),
+                                   ("case-002", "strat_key: b")])
+        assert "strat_key" not in capsys.readouterr().err
+
+    def test_a_healthy_run_is_silent(self, tmp_path, capsys):
+        self._run_cases(tmp_path, [("case-001", "strat_key: a"),
+                                   ("case-002", "strat_key: b")])
+        assert capsys.readouterr().err.count("requires frontmatter") == 0
+
+    def test_a_judge_skipped_everywhere_is_not_reported(self, tmp_path, capsys):
+        """An `if:`-gated judge that never runs cannot be stale against
+        artifacts it never reads."""
+        self._run_cases(tmp_path, [("case-001", "source_key: a")],
+                        condition="annotations.get('kind') == 'never'")
+        assert "strat_key" not in capsys.readouterr().err
+
     def test_unparseable_frontmatter_does_not_abort_the_run(self, tmp_path):
         """`yaml.safe_load` raises a bare ValueError — not YAMLError — for an
         out-of-range date, and the probe runs before any judge. Uncaught, it

--- a/tests/test_score_builtin.py
+++ b/tests/test_score_builtin.py
@@ -632,6 +632,19 @@ class TestInlineJudgeFieldValidation:
         assert result["per_case"]["case-002"]["frontmatter_valid"]["value"] is True
         assert result["per_case"]["case-001"]["frontmatter_valid"]["value"] is None
 
+    def test_an_inline_delimiter_does_not_truncate_the_frontmatter(self):
+        """`split("---", 2)` also matches a `---` inside a scalar, so
+        everything below the first one read as absent — a warning naming a
+        field that is right there in the file. Agent-written markdown controls
+        this text, so it is reachable on a normal run."""
+        from score import _extract_yaml_frontmatter_keys as keys
+        assert keys("---\ntitle: foo --- bar\nstatus: ok\n---\nbody\n") == {
+            "title", "status"}
+        # Delimiters stay line-anchored across the other shapes.
+        assert keys("---\r\ntitle: a\r\n---\r\nb") == {"title"}   # CRLF
+        assert keys("---\ntitle: a\n---") == {"title"}          # ends at EOF
+        assert keys("----\ntitle: a\n----\nb") == {"title"}     # longer fence
+
     def test_unreadable_frontmatter_is_unknown_but_absent_is_empty(self):
         """Two different things. No frontmatter block means the fields really
         are absent, which is worth saying. Frontmatter that will not parse

--- a/tests/test_score_builtin.py
+++ b/tests/test_score_builtin.py
@@ -446,23 +446,34 @@ class TestInlineJudgeFieldValidation:
         assert "source_key" in captured.err
 
     @pytest.mark.parametrize("label,snippet,expected", [
-        # Required — the shape issue #33 is about, in its three spellings.
-        ("negated get", "if not fm.get('strat_key'): return False, 'b'",
-         ["strat_key"]),
-        ("bool get", "return bool(fm.get('strat_key')), 'x'", ["strat_key"]),
-        ("subscript", "return bool(fm['title']), 'x'", ["title"]),
-        # `"x" not in fm` is what README.md, the skill-batch cookbook and the
-        # eval.yaml template all use — the template seeds generated evals.
-        ("not in", "if 'score' not in fm: return False, 'm'", ["score"]),
-        ("in", "if 'score' in fm: return True, 'ok'", ["score"]),
-        # Not required, and warning here fires on a healthy run.
-        ("explicit default", "return True, fm.get('priority', 'normal')", []),
-        ("expects absence", "if fm.get('deprecated'): return False, 'd'", []),
+        # Every literal reference counts. Intent is deliberately NOT inferred:
+        # `if fm.get("x"): return True` and `... return False` are the same
+        # expression with opposite meanings, and the eval.yaml template tells
+        # authors to pass a default to every lookup, so a default says nothing
+        # either. Precision comes from only reporting judges that failed.
+        ("get", "return bool(fm.get('k')), 'x'", ["k"]),
+        ("get with default", "return True, fm.get('k', '')", ["k"]),
+        ("negated get", "if not fm.get('k'): return False, 'b'", ["k"]),
+        ("assert", "assert fm.get('k')", ["k"]),
+        ("subscript read", "return bool(fm['k']), 'x'", ["k"]),
+        ("not in", "if 'k' not in fm: return False, 'm'", ["k"]),
+        # Writes and deletes are not reads of a field the artifact must have.
+        ("subscript write", "fm['k'] = 1", []),
+        ("subscript del", "del fm['k']", []),
     ])
-    def test_which_references_count_as_required(self, label, snippet, expected):
+    def test_which_references_are_collected(self, label, snippet, expected):
         from score import _extract_frontmatter_field_refs
         source = f"fm = outputs['a_content']\n{snippet}\nreturn True, 'ok'"
         assert _extract_frontmatter_field_refs(source) == expected, label
+
+    def test_meta_is_not_treated_as_frontmatter(self):
+        """`meta` is the conventional name for parsed JSON too, and a JSON
+        judge has no YAML frontmatter to be missing from."""
+        from score import _extract_frontmatter_field_refs as refs
+        assert refs("meta = outputs['m_content']\n"
+                    "return bool(meta.get('run_id')), 'x'") == []
+        assert refs("frontmatter = outputs['a_content']\n"
+                    "return bool(frontmatter.get('k')), 'x'") == ["k"]
 
     def test_an_untraceable_frontmatter_source_stays_silent(self):
         """`fm` built by iterating outputs['files'] — the shape strat-creator
@@ -479,13 +490,6 @@ class TestInlineJudgeFieldValidation:
             "return bool(fm.get('title')), notes"
         )
         assert _extract_frontmatter_content_keys(source) == []
-
-    def test_the_conventional_aliases_are_recognised(self):
-        from score import _extract_frontmatter_field_refs as refs
-        for name in ("fm", "frontmatter", "meta"):
-            source = (f"{name} = outputs['a_content']\n"
-                      f"return bool({name}.get('title')), 'x'")
-            assert refs(source) == ["title"], name
 
     def _stale_field_config(self, condition=None):
         config = EvalConfig(name="test", skill="test")
@@ -517,18 +521,72 @@ class TestInlineJudgeFieldValidation:
         config = self._stale_field_config(condition)
         score_cases(load_judges(config), sorted(dirs), config)
 
+    def test_a_passing_judge_is_never_reported(self, tmp_path, capsys):
+        """The evidence gate, and the reason no intent inference is needed.
+
+        This judge asserts a field is GONE, so it passes precisely when the
+        field is absent — the condition that would otherwise look like drift.
+        """
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [OutputConfig(path="artifacts")]
+        config.judges = [JudgeConfig(name="j", check=(
+            "import yaml\n"
+            "fm = yaml.safe_load("
+            "outputs['artifacts_content'].split('---', 2)[1]) or {}\n"
+            "if 'legacy_key' in fm:\n"
+            "    return False, 'still there'\n"
+            "return True, 'clean'"))]
+        for name in ("case-001", "case-002"):
+            art = tmp_path / name / "artifacts"
+            art.mkdir(parents=True)
+            (art / "r.md").write_text("---\nnew_key: a\n---\nbody\n")
+        result = score_cases(load_judges(config),
+                             sorted(tmp_path.iterdir()), config)
+        assert result["aggregated"]["j"]["pass_rate"] == 1.0
+        assert "legacy_key" not in capsys.readouterr().err
+
+    def test_the_documented_get_with_default_style_still_warns(
+            self, tmp_path, capsys):
+        """`eval-yaml-template.md` tells authors to pass a default to every
+        lookup, so treating a default as "optional" would silence the feature
+        on the style the project recommends."""
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [OutputConfig(path="artifacts")]
+        config.judges = [JudgeConfig(name="j", check=(
+            "import yaml\n"
+            "fm = yaml.safe_load("
+            "outputs['artifacts_content'].split('---', 2)[1]) or {}\n"
+            "if not fm.get('strat_key', ''):\n"
+            "    return False, 'bad'\n"
+            "return True, 'ok'"))]
+        for name in ("case-001", "case-002"):
+            art = tmp_path / name / "artifacts"
+            art.mkdir(parents=True)
+            (art / "r.md").write_text("---\nsource_key: a\n---\nbody\n")
+        score_cases(load_judges(config), sorted(tmp_path.iterdir()), config)
+        assert "strat_key" in capsys.readouterr().err
+
     def test_drift_across_every_case_warns(self, tmp_path, capsys):
         self._run_cases(tmp_path, [("case-001", "source_key: a"),
                                    ("case-002", "source_key: b")])
         assert "strat_key" in capsys.readouterr().err
 
-    def test_one_empty_case_does_not_warn_for_the_whole_run(self, tmp_path,
-                                                            capsys):
-        """Probing only case-001 meant a case that produced nothing spoke for
-        every other case — and a partly-failed run is exactly when someone is
-        trying to tell a skill regression from a judge bug."""
+    def test_a_barren_first_case_does_not_hide_the_drift(self, tmp_path,
+                                                         capsys):
+        """Probing only case-001 loses the diagnostic whenever that case
+        produced nothing — and a partly-failed run is exactly when someone is
+        trying to tell a skill regression from a stale judge."""
         self._run_cases(tmp_path, [("case-001", None),
-                                   ("case-002", "strat_key: b")])
+                                   ("case-002", "source_key: b"),
+                                   ("case-003", "source_key: c")])
+        assert "strat_key" in capsys.readouterr().err
+
+    def test_unreadable_frontmatter_does_not_accuse_every_field(
+            self, tmp_path, capsys):
+        """One bad date must not turn into "every field you reference is
+        missing". Unreadable is unknown, and unknown stays quiet."""
+        self._run_cases(tmp_path, [("case-001", "due: 2026-02-30"),
+                                   ("case-002", "due: 2026-02-30")])
         assert "strat_key" not in capsys.readouterr().err
 
     def test_a_healthy_run_is_silent(self, tmp_path, capsys):

--- a/tests/test_score_builtin.py
+++ b/tests/test_score_builtin.py
@@ -445,6 +445,69 @@ class TestInlineJudgeFieldValidation:
         assert "strat_key" in captured.err
         assert "source_key" in captured.err
 
+    def test_unparseable_frontmatter_does_not_abort_the_run(self, tmp_path):
+        """`yaml.safe_load` raises a bare ValueError — not YAMLError — for an
+        out-of-range date, and the probe runs before any judge. Uncaught, it
+        destroyed a run that main completes with a per-case error."""
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [OutputConfig(path="artifacts")]
+        config.judges = [
+            JudgeConfig(
+                name="frontmatter_valid",
+                check=(
+                    "import yaml\n"
+                    "fm = yaml.safe_load("
+                    "outputs['artifacts_content'].split('---', 2)[1]) or {}\n"
+                    "return bool(fm.get('title')), 'checked'"
+                ),
+            ),
+        ]
+        cases = []
+        for name, front in (("case-001", "due: 2026-02-30\ntitle: a"),
+                            ("case-002", "title: b")):
+            art = tmp_path / name / "artifacts"
+            art.mkdir(parents=True)
+            (art / "r.md").write_text(f"---\n{front}\n---\nbody\n")
+            cases.append(tmp_path / name)
+
+        result = score_cases(load_judges(config), cases, config)
+
+        # The good case still scores; the bad one errors, as it does on main.
+        assert result["per_case"]["case-002"]["frontmatter_valid"]["value"] is True
+        assert result["per_case"]["case-001"]["frontmatter_valid"]["value"] is None
+
+    def test_unreadable_frontmatter_is_unknown_but_absent_is_empty(self):
+        """Two different things. No frontmatter block means the fields really
+        are absent, which is worth saying. Frontmatter that will not parse
+        means we know nothing — reporting every field missing there is a wall
+        of warnings caused by one bad date."""
+        from score import _extract_yaml_frontmatter_keys as keys
+        assert keys("body, no frontmatter") == set()          # absent
+        assert keys("---\ndue: 2026-02-30\n---\nb") is None    # unreadable
+        assert keys("---\ntitle: a\nbody") is None             # unclosed
+        assert keys("---\ntitle: a\n---\nb") == {"title"}
+
+    def test_a_bad_artifact_does_not_silence_the_warning_for_others(
+            self, tmp_path, capsys):
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [OutputConfig(path="artifacts")]
+        config.judges = [
+            JudgeConfig(
+                name="frontmatter_valid",
+                check=(
+                    "import yaml\n"
+                    "fm = yaml.safe_load("
+                    "outputs['artifacts_content'].split('---', 2)[1]) or {}\n"
+                    "return bool(fm.get('strat_key')), 'x'"
+                ),
+            ),
+        ]
+        art = tmp_path / "case-001" / "artifacts"
+        art.mkdir(parents=True)
+        (art / "r.md").write_text("---\nsource_key: a\n---\nbody\n")
+        score_cases(load_judges(config), [tmp_path / "case-001"], config)
+        assert "strat_key" in capsys.readouterr().err
+
     def test_warning_probe_does_not_abort_scoring_on_loader_error(
             self, tmp_path):
         config = EvalConfig(name="test", skill="test")

--- a/tests/test_score_builtin.py
+++ b/tests/test_score_builtin.py
@@ -9,8 +9,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from agent_eval.config import EvalConfig, JudgeConfig, ModelsConfig
-from score import load_judges
+from agent_eval.config import EvalConfig, JudgeConfig, ModelsConfig, OutputConfig
+from score import load_judges, score_cases
 
 
 class TestLoadJudgesBuiltin:
@@ -409,6 +409,204 @@ class TestLoadJudgesTypes:
 
         result = scorer(outputs={"content": "this is too long"})
         assert result[0] is False
+
+
+class TestInlineJudgeFieldValidation:
+
+    def test_warns_before_scoring_when_frontmatter_field_is_stale(
+            self, tmp_path, capsys):
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [OutputConfig(path="artifacts")]
+        config.judges = [
+            JudgeConfig(
+                name="frontmatter_valid",
+                check=(
+                    "import yaml\n"
+                    "task = outputs['artifacts_content']\n"
+                    "fm = yaml.safe_load(task.split('---', 2)[1])\n"
+                    "if not fm.get('strat_key'):\n"
+                    "    return False, 'bad strat_key'\n"
+                    "return True, 'ok'"
+                ),
+            ),
+        ]
+        case_dir = tmp_path / "case-001"
+        artifact_dir = case_dir / "artifacts"
+        artifact_dir.mkdir(parents=True)
+        (artifact_dir / "result.md").write_text(
+            "---\nsource_key: alpha\n---\nbody\n"
+        )
+
+        judges = load_judges(config)
+        score_cases(judges, [case_dir], config)
+
+        captured = capsys.readouterr()
+        assert "frontmatter_valid" in captured.err
+        assert "strat_key" in captured.err
+        assert "source_key" in captured.err
+
+    def test_warning_probe_does_not_abort_scoring_on_loader_error(
+            self, tmp_path):
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [OutputConfig(path="..")]
+        config.judges = [
+            JudgeConfig(
+                name="frontmatter_valid",
+                check=(
+                    "fm = {}\n"
+                    "if not fm.get('strat_key'):\n"
+                    "    return False, 'bad strat_key'\n"
+                    "return True, 'ok'"
+                ),
+            ),
+        ]
+        case_dir = tmp_path / "case-001"
+        case_dir.mkdir()
+
+        judges = load_judges(config)
+        results = score_cases(judges, [case_dir], config)
+
+        assert "Path escapes root directory" in (
+            results["per_case"]["case-001"]["frontmatter_valid"]["error"]
+        )
+
+    def test_referenced_artifact_field_is_checked_independently(
+            self, tmp_path, capsys):
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [
+            OutputConfig(path="artifacts"),
+            OutputConfig(path="other"),
+        ]
+        config.judges = [
+            JudgeConfig(
+                name="frontmatter_valid",
+                check=(
+                    "import yaml\n"
+                    "task = outputs['artifacts_content']\n"
+                    "fm = yaml.safe_load(task.split('---', 2)[1])\n"
+                    "if not fm.get('strat_key'):\n"
+                    "    return False, 'bad strat_key'\n"
+                    "return True, 'ok'"
+                ),
+            ),
+        ]
+        case_dir = tmp_path / "case-001"
+        artifact_dir = case_dir / "artifacts"
+        other_dir = case_dir / "other"
+        artifact_dir.mkdir(parents=True)
+        other_dir.mkdir(parents=True)
+        (artifact_dir / "result.md").write_text(
+            "---\nsource_key: alpha\n---\nbody\n"
+        )
+        (other_dir / "result.md").write_text(
+            "---\nstrat_key: legacy\n---\nbody\n"
+        )
+
+        judges = load_judges(config)
+        score_cases(judges, [case_dir], config)
+
+        captured = capsys.readouterr()
+        assert "frontmatter_valid" in captured.err
+        assert "strat_key" in captured.err
+        assert "source_key" in captured.err
+
+    def test_commented_field_reference_does_not_warn(self, tmp_path, capsys):
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [OutputConfig(path="artifacts")]
+        config.judges = [
+            JudgeConfig(
+                name="frontmatter_valid",
+                check=(
+                    "import yaml\n"
+                    "task = outputs['artifacts_content']\n"
+                    "fm = yaml.safe_load(task.split('---', 2)[1])\n"
+                    "# fm.get('strat_key') used to be checked here\n"
+                    "if not fm.get('source_key'):\n"
+                    "    return False, 'bad source_key'\n"
+                    "return True, 'ok'"
+                ),
+            ),
+        ]
+        case_dir = tmp_path / "case-001"
+        artifact_dir = case_dir / "artifacts"
+        artifact_dir.mkdir(parents=True)
+        (artifact_dir / "result.md").write_text(
+            "---\nsource_key: alpha\n---\nbody\n"
+        )
+
+        judges = load_judges(config)
+        score_cases(judges, [case_dir], config)
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_referenced_artifact_without_frontmatter_warns(
+            self, tmp_path, capsys):
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [OutputConfig(path="artifacts")]
+        config.judges = [
+            JudgeConfig(
+                name="frontmatter_valid",
+                check=(
+                    "import yaml\n"
+                    "task = outputs['artifacts_content']\n"
+                    "fm = yaml.safe_load(task.split('---', 2)[1]) or {}\n"
+                    "if not fm.get('strat_key'):\n"
+                    "    return False, 'bad strat_key'\n"
+                    "return True, 'ok'"
+                ),
+            ),
+        ]
+        case_dir = tmp_path / "case-001"
+        artifact_dir = case_dir / "artifacts"
+        artifact_dir.mkdir(parents=True)
+        (artifact_dir / "result.md").write_text("body without frontmatter\n")
+
+        judges = load_judges(config)
+        score_cases(judges, [case_dir], config)
+
+        captured = capsys.readouterr()
+        assert "frontmatter_valid" in captured.err
+        assert "strat_key" in captured.err
+
+    def test_extra_content_read_does_not_imply_frontmatter_source(
+            self, tmp_path, capsys):
+        config = EvalConfig(name="test", skill="test")
+        config.outputs = [
+            OutputConfig(path="artifacts"),
+            OutputConfig(path="other"),
+        ]
+        config.judges = [
+            JudgeConfig(
+                name="frontmatter_valid",
+                check=(
+                    "import yaml\n"
+                    "task = outputs['artifacts_content']\n"
+                    "comparison = outputs['other_content']\n"
+                    "fm = yaml.safe_load(task.split('---', 2)[1])\n"
+                    "if comparison and not fm.get('strat_key'):\n"
+                    "    return False, 'bad strat_key'\n"
+                    "return True, 'ok'"
+                ),
+            ),
+        ]
+        case_dir = tmp_path / "case-001"
+        artifact_dir = case_dir / "artifacts"
+        other_dir = case_dir / "other"
+        artifact_dir.mkdir(parents=True)
+        other_dir.mkdir(parents=True)
+        (artifact_dir / "result.md").write_text(
+            "---\nstrat_key: alpha\n---\nbody\n"
+        )
+        (other_dir / "result.md").write_text(
+            "---\nsource_key: beta\n---\nbody\n"
+        )
+
+        judges = load_judges(config)
+        score_cases(judges, [case_dir], config)
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
 
 
 class TestJudgeTypeMetadata:

--- a/tests/test_score_builtin.py
+++ b/tests/test_score_builtin.py
@@ -445,6 +445,48 @@ class TestInlineJudgeFieldValidation:
         assert "strat_key" in captured.err
         assert "source_key" in captured.err
 
+    @pytest.mark.parametrize("label,snippet,expected", [
+        # Required — the shape issue #33 is about, in its three spellings.
+        ("negated get", "if not fm.get('strat_key'): return False, 'b'",
+         ["strat_key"]),
+        ("bool get", "return bool(fm.get('strat_key')), 'x'", ["strat_key"]),
+        ("subscript", "return bool(fm['title']), 'x'", ["title"]),
+        # `"x" not in fm` is what README.md, the skill-batch cookbook and the
+        # eval.yaml template all use — the template seeds generated evals.
+        ("not in", "if 'score' not in fm: return False, 'm'", ["score"]),
+        ("in", "if 'score' in fm: return True, 'ok'", ["score"]),
+        # Not required, and warning here fires on a healthy run.
+        ("explicit default", "return True, fm.get('priority', 'normal')", []),
+        ("expects absence", "if fm.get('deprecated'): return False, 'd'", []),
+    ])
+    def test_which_references_count_as_required(self, label, snippet, expected):
+        from score import _extract_frontmatter_field_refs
+        source = f"fm = outputs['a_content']\n{snippet}\nreturn True, 'ok'"
+        assert _extract_frontmatter_field_refs(source) == expected, label
+
+    def test_an_untraceable_frontmatter_source_stays_silent(self):
+        """`fm` built by iterating outputs['files'] — the shape strat-creator
+        and the docs use. The artifact cannot be identified, so the old
+        fallback blamed an unrelated `*_content` read and printed ITS keys as
+        available. Silence is the only honest output."""
+        from score import _extract_frontmatter_content_keys
+        source = (
+            "files = outputs.get('files', {})\n"
+            "rev = next((c for p, c in files.items() "
+            "if p.endswith('-review.md')), None)\n"
+            "notes = outputs['notes_content']\n"
+            "fm = yaml.safe_load(rev.split('---', 2)[1])\n"
+            "return bool(fm.get('title')), notes"
+        )
+        assert _extract_frontmatter_content_keys(source) == []
+
+    def test_the_conventional_aliases_are_recognised(self):
+        from score import _extract_frontmatter_field_refs as refs
+        for name in ("fm", "frontmatter", "meta"):
+            source = (f"{name} = outputs['a_content']\n"
+                      f"return bool({name}.get('title')), 'x'")
+            assert refs(source) == ["title"], name
+
     def test_unparseable_frontmatter_does_not_abort_the_run(self, tmp_path):
         """`yaml.safe_load` raises a bare ValueError — not YAMLError — for an
         out-of-range date, and the probe runs before any judge. Uncaught, it


### PR DESCRIPTION
## Summary

- add a warning-only preflight for inline check judges that reference YAML frontmatter fields via `fm.get(...)`
- infer the output artifact that feeds the `fm` assignment so unrelated `_content` reads do not create noisy warnings
- add regression tests for stale fields, empty frontmatter, loader-error tolerance, comments, and multi-artifact cases

Closes #33.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests/test_score_builtin.py::TestInlineJudgeFieldValidation -q`
- `.\.venv\Scripts\python.exe -m pytest tests/test_score_builtin.py -q`
- `git diff --cached --check`
- `UV_CACHE_DIR=C:\tmp\uv-cache uvx skillsaw`

Full `.\.venv\Scripts\python.exe -m pytest tests/ -v` previously failed in my Windows environment with existing shell/symlink/path-related failures: 46 failed, 323 passed, 2 deselected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline judge checks now detect references to missing or outdated frontmatter fields and issue warnings, helping identify configuration problems earlier.
  * Validation distinguishes between absent, empty, and unreadable frontmatter and continues scoring available cases when individual checks encounter errors.

* **Tests**
  * Added comprehensive coverage for field validation, commented references, output-specific behavior, skipped and passing judges, loading failures, and scoring resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->