### PR TITLE
feat: isolate solver workspace from eval infrastructure

### DIFF
--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -341,7 +341,6 @@ class ClaudeCodeRunner(EvalRunner):
         "GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT",
         "CLOUDSDK_CONFIG", "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
         "MLFLOW_TRACKING_URI", "MLFLOW_EXPERIMENT_NAME",
-        "AGENT_EVAL_RUNS_DIR",
     }
 
     def _build_env(self, extra_env=None):

--- a/docs/opaque-cli-runner-contract.md
+++ b/docs/opaque-cli-runner-contract.md
@@ -87,9 +87,8 @@ Before the command runs, the workspace contains:
 | `output/` | Pre-created output directory (`{output_dir}`) | Yes — write artifacts here |
 | Output dirs from `outputs[*].path` | Pre-created directories matching eval.yaml | Yes — alternative artifact locations |
 | `.claude/settings.json` | Permissions, hooks, env vars | No — Claude Code specific |
-| `.claude/hooks/tools.py` | Tool interception script | No — Claude Code specific |
 | `subagents/` | Subagent transcript capture dir | No — Claude Code specific |
-| Symlinks to `scripts/`, `skills/`, `CLAUDE.md`, `.context/` | Project resources | Maybe — depends on the external command |
+| Symlinks to `scripts/`, `.context/`; copy of `CLAUDE.md` | Project resources | Maybe — depends on the external command |
 
 ## What the harness reads after execution
 

--- a/skills/eval-optimize/SKILL.md
+++ b/skills/eval-optimize/SKILL.md
@@ -135,7 +135,7 @@ Apply targeted fixes to the SKILL.md. For each edit:
 
 Show each edit before applying. If the change is risky (could affect passing cases), note it.
 
-**Execution mode context**: check `execution.mode` in eval.yaml. In `case` mode, each case runs in its own isolated workspace with all case files copied in — the skill receives case-specific arguments resolved from input.yaml. In `batch` mode, all cases are in one workspace via batch.yaml. Your edits must work for the configured mode.
+**Execution mode context**: check `execution.mode` in eval.yaml. In `case` mode, each case runs in its own isolated workspace with the input file and any `dataset.workspace.files` entries copied in — the skill receives case-specific arguments resolved from input.yaml. Eval-only files (`answers.yaml`, `annotations.yaml`) stay in the dataset directory and are not visible to the solver. In `batch` mode, all cases are in one workspace via batch.yaml. Your edits must work for the configured mode.
 
 ## Step 5: Re-Run and Verify
 

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -113,21 +113,21 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/workspace.py \
   [--cases <id> [<id> ...]]
 ```
 
-The script prints `WORKSPACE: <path>`, `CASES: <count>`, `BATCH: <path>`. Report these to the user. If `inputs.tools` is configured, it also prints `HOOKS: N tool interceptors configured`.
+The script prints `WORKSPACE: <path>`, `HARNESS: <path>`, `CASES: <count>`, `BATCH: <path>`. Report these to the user. If `inputs.tools` is configured, it also prints `HOOKS: N tool interceptors configured`. The harness directory (`<harness>`) is a sibling of the workspace that stores hook scripts and `tool_handlers.yaml` outside the solver's reach.
 
 If the case count is 0, stop — the filter matched nothing.
 
 ## Step 3b: Resolve Tool Interception (if `inputs.tools` configured)
 
-If eval.yaml has `inputs.tools` entries, this step is **mandatory**. `workspace.py` emits a skeleton in `tool_handlers.yaml`; you must resolve each handler's `prompt` into concrete runtime checks (`input_filters`, `env_checks`, `case_overrides`). Do not skip this even when the eval.yaml is unchanged — the workspace is created fresh each time.
+If eval.yaml has `inputs.tools` entries, this step is **mandatory**. `workspace.py` emits a skeleton in the harness directory's `tool_handlers.yaml`; you must resolve each handler's `prompt` into concrete runtime checks (`input_filters`, `env_checks`, `case_overrides`). Do not skip this even when the eval.yaml is unchanged — the workspace is created fresh each time.
 
-Read `${CLAUDE_SKILL_DIR}/references/tool-interception.md` for the full format, field reference, and resolution examples. Then read `<workspace>/tool_handlers.yaml` and for each handler:
+Read `${CLAUDE_SKILL_DIR}/references/tool-interception.md` for the full format, field reference, and resolution examples. Then read `<harness>/tool_handlers.yaml` (the `HARNESS:` path from Step 3) and for each handler:
 
 1. **Identify type**: AskUserQuestion, Bash, or MCP tool
 2. **Add required fields**: `input_filters` for Bash, `env_checks` for services, `case_overrides` for deterministic answers
 3. **Verify**: every Bash handler has `input_filters` — without them the handler is non-functional
 
-Write the resolved handlers back to `tool_handlers.yaml`.
+Write the resolved handlers back to `<harness>/tool_handlers.yaml`. In `case` mode, each case has its own file at `<harness>/<case-id>/tool_handlers.yaml` — resolve all of them (content starts identical but `case_overrides` may differ per case).
 
 ## Step 4: Execute Skill
 

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -11,27 +11,28 @@ How data flows from dataset cases through execution, collection, and scoring.
 - Builds `batch.yaml` — a list of one entry per case, each entry being the full parsed content of the input file. No field extraction — the entire input file content is included.
 - Builds `case_order.yaml` — maps position to case ID (`[{case_id: "case-001-name"}, ...]`)
 - Creates output directories from `outputs[].path` in eval.yaml
-- Symlinks project resources (`.claude/`, `CLAUDE.md`, `scripts/`, `skills/`, `.context/`)
-- If `inputs.tools` configured, generates `tool_handlers.yaml` and `.claude/settings.json` with hooks
+- Symlinks project directories (`scripts/`, `.context/`) and copies files (`CLAUDE.md`) into workspace. `.claude/` subdirectories (e.g., `skills/`) are symlinked for skill discovery; `settings.json` is always generated.
+- Creates a sibling harness directory (`{run-id}._harness/`) outside the solver workspace for hook scripts and `tool_handlers.yaml`
+- If `inputs.tools` configured, generates `tool_handlers.yaml` and `hooks/tools.py` in the harness dir, and `.claude/settings.json` in the workspace with hook commands pointing to the harness
 
-**Workspace structure**:
+**Workspace structure (batch mode)**:
 ```
 /tmp/agent-eval/{run-id}/
   batch.yaml              # Full input data per case
   case_order.yaml         # Position → case ID mapping
   {output_dirs}/          # Empty dirs for skill outputs
-  .claude/settings.json   # Generated hook config (if inputs.tools)
-  hooks/tools.py          # Hook script (if inputs.tools)
-  tool_handlers.yaml      # Handler config (if inputs.tools)
+  .claude/settings.json   # Generated (hooks + permissions)
   scripts/ → symlink
-  .claude/ → symlink (or generated)
-  CLAUDE.md → symlink
-  skills/ → symlink
+  .claude/skills/ → symlink
+  CLAUDE.md               # Copied from project root
+/tmp/agent-eval/{run-id}._harness/
+  tool_handlers.yaml      # Handler config (if inputs.tools)
+  hooks/tools.py          # Hook script (if inputs.tools)
 ```
 
 ### Case Mode (execution.mode: case)
 
-When `execution.mode` is `case` (default), workspace.py creates a separate workspace per case:
+When `execution.mode` is `case` (default), workspace.py creates a separate workspace per case, with a sibling harness directory for hook isolation:
 
 ```
 /tmp/agent-eval/{run-id}/
@@ -39,19 +40,29 @@ When `execution.mode` is `case` (default), workspace.py creates a separate works
   cases/
     case-001-name/
       input.yaml          # Copied from dataset
-      strategy.md         # Copied from dataset (companion files)
-      answers.yaml        # Copied from dataset (if present)
       {output_dirs}/      # Empty dirs for skill outputs
       .claude/settings.json  # Generated (hooks + permissions)
       subagents/           # SubagentStop hook target
       scripts/ → symlink
-      CLAUDE.md → symlink
-      skills/ → symlink
+      .claude/skills/ → symlink
+      CLAUDE.md            # Copied from project root
     case-002-name/
       ...
+/tmp/agent-eval/{run-id}._harness/
+  case-001-name/
+    tool_handlers.yaml    # Per-case handler config
+    hooks/tools.py        # Per-case hook script
+  case-002-name/
+    ...
 ```
 
-Each case gets ALL files from the dataset case directory (not just input.yaml), plus symlinked project resources and hooks. The skill runs in the case workspace as its working directory.
+Each case gets:
+- The input file from the dataset case directory
+- Files listed in `dataset.workspace.files` (e.g., source code for the agent to work on). Eval-only files (`answers.yaml`, `annotations.yaml`, etc.) are automatically excluded.
+- Symlinked project directories and copied project files
+- Tool interception hooks in the sibling harness dir (inaccessible to the solver via Claude Code file tools)
+
+The skill runs in the case workspace as its working directory.
 
 ## 2. Workspace → Execution
 
@@ -71,9 +82,9 @@ Each case gets ALL files from the dataset case directory (not just input.yaml), 
 
 **What the skill sees (case mode)**:
 - Working directory: the case workspace (`workspace/cases/{case_id}/`)
-- Input: case-specific arguments resolved from `execution.arguments` template + all case files on disk
+- Input: case-specific arguments resolved from `execution.arguments` template + input file + workspace files on disk
 - Output directories: created and ready
-- Hooks: per-case hooks with SubagentStop for transcript capture
+- Hooks: per-case hooks with SubagentStop for transcript capture. Hook scripts live in the sibling harness dir — the solver can see hook commands in `settings.json` but cannot access the harness files via Claude Code file tools.
 
 **Case mode execution**:
 - execute.py iterates `case_order.yaml`, invoking the skill once per case

--- a/skills/eval-run/references/tool-interception.md
+++ b/skills/eval-run/references/tool-interception.md
@@ -5,9 +5,9 @@ This documents how `inputs.tools` handlers are resolved and executed during head
 ## Flow
 
 1. **eval.yaml** defines handlers with `match` (what to intercept) and `prompt` (how to handle)
-2. **workspace.py** extracts basic tool name patterns from `match` text, writes `tool_handlers.yaml`, and includes `hook_model` from `models.hook`
-3. **eval-run agent (Step 3b)** reads `tool_handlers.yaml`, interprets the `prompt` field, and adds concrete runtime checks
-4. **tools.py** (PreToolUse hook) executes the checks at runtime. AskUserQuestion uses a 3-tier resolution: exact `case_overrides` match → LLM call (using `hook_model`) → first-option fallback. All other tool checks are deterministic.
+2. **workspace.py** extracts basic tool name patterns from `match` text, writes `tool_handlers.yaml` and `hooks/tools.py` to the harness directory (a sibling of the workspace at `<run-id>._harness/`), and includes `hook_model` from `models.hook`. In case mode, each case gets its own harness subdirectory (`<harness>/<case-id>/`).
+3. **eval-run agent (Step 3b)** reads `<harness>/tool_handlers.yaml`, interprets the `prompt` field, and adds concrete runtime checks
+4. **tools.py** (PreToolUse hook, invoked with `--config <harness>/tool_handlers.yaml`) executes the checks at runtime. AskUserQuestion uses a 3-tier resolution: exact `case_overrides` match → LLM call (using `hook_model`, reading `answers.yaml` from `--case-dir`) → first-option fallback. All other tool checks are deterministic.
 
 ## tool_handlers.yaml Format
 
@@ -56,7 +56,7 @@ case_overrides:
 
 1. Match by pattern: `patterns: ["AskUserQuestion"]`
 2. **Tier 1 — exact match**: look up the question text in `case_overrides`
-3. **Tier 2 — LLM call**: if no exact match and options are available, call the `hook_model` with the question, options, handler `prompt`, and case context (`input.yaml` + `answers.yaml` from CWD). The LLM picks the best option based on context. **Note**: case files are sent to the LLM API — do not put secrets, credentials, or PII in `input.yaml` or `answers.yaml`.
+3. **Tier 2 — LLM call**: if no exact match and options are available, call the `hook_model` with the question, options, handler `prompt`, and case context (`input.yaml` from CWD + `answers.yaml` from `--case-dir` or CWD). The LLM picks the best option based on context. **Note**: case files are sent to the LLM API — do not put secrets, credentials, or PII in `input.yaml` or `answers.yaml`.
 4. **Tier 3 — fallback**: pick the first option, or "yes"
 5. Return `permissionDecision: "allow"` with `updatedInput` containing answers
 

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -30,11 +30,14 @@ from agent_eval.events import (
     DEFAULT_RESULT_CAP, parse_stream_events, merge_subagent_transcripts,
 )
 
-# Files/dirs created by the harness infrastructure, not by the skill
+# Files/dirs created by the harness infrastructure, not by the skill.
+# CLAUDE.md is copied into the workspace by workspace.py
+# and should not appear as a solver-modified file.
 _HARNESS_PATHS = {
     ".claude", ".git", ".work", "subagents", "hooks",
     "stdout.log", "stderr.log",
     "run_result.json", "batch.yaml", "case_order.yaml",
+    "CLAUDE.md",
 }
 
 

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -35,14 +35,14 @@ from agent_eval.hooks import (
 )
 
 _HARNESS_SYSTEM_PROMPT = (
-    "You are running inside an evaluation harness. Tool interception hooks "
-    "and permission controls are in place for safety. You MUST NOT: "
+    "This workspace has tool permission controls and hooks configured in "
+    ".claude/settings.json. You MUST NOT: "
     "rename, copy, or move scripts to bypass tool filters; "
-    "modify .claude/settings.json or hook scripts; "
-    "disable or work around any harness controls; "
+    "modify .claude/settings.json or any hook scripts; "
+    "disable or work around any configured controls; "
     "use alternative paths or commands to avoid blocked operations. "
     "If a tool call is blocked, report it and continue with the remaining "
-    "pipeline steps. Do not attempt workarounds."
+    "steps. Do not attempt workarounds."
 )
 
 

--- a/skills/eval-run/scripts/tools.py
+++ b/skills/eval-run/scripts/tools.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """PreToolUse hook script for intercepting tools during headless eval.
 
-Reads tool_handlers.yaml from the workspace. Handlers contain resolved
-patterns and runtime checks (from natural language `match` and `prompt`
-in eval.yaml, resolved by eval-run at workspace setup time).
+Reads tool_handlers.yaml from ``--config`` path (or CWD as fallback).
+Handlers contain resolved patterns and runtime checks (from natural
+language ``match`` and ``prompt`` in eval.yaml, resolved by eval-run
+at workspace setup time).
 
 Supports:
 - Auto-answering AskUserQuestion via per-case overrides
@@ -13,6 +14,7 @@ Supports:
 
 import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
+import argparse
 import json
 import os
 import re
@@ -23,14 +25,29 @@ import yaml
 
 
 def main():
+    parser = argparse.ArgumentParser(description="PreToolUse hook interceptor")
+    parser.add_argument("--config", default=None,
+                        help="Path to tool_handlers.yaml (default: CWD)")
+    parser.add_argument("--case-dir", default=None,
+                        help="Dataset case directory containing answers.yaml")
+    args = parser.parse_args()
+
     input_data = json.load(sys.stdin)
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
 
-    # Load handler config from workspace
-    config_path = Path("tool_handlers.yaml")
-    if not config_path.exists():
-        sys.exit(0)
+    # Load handler config — from --config if provided, else CWD.
+    # When --config is explicit, missing file is fail-closed (D5):
+    # deny the tool call rather than silently passing through.
+    if args.config:
+        config_path = Path(args.config)
+        if not config_path.exists():
+            _deny(f"Hook config not found: {config_path}")
+            return
+    else:
+        config_path = Path("tool_handlers.yaml")
+        if not config_path.exists():
+            sys.exit(0)
 
     with open(config_path) as f:
         config = yaml.safe_load(f) or {}
@@ -42,7 +59,7 @@ def main():
 
     # --- AskUserQuestion: auto-answer ---
     if tool_name == "AskUserQuestion":
-        _handle_ask_user(tool_input, config, handler)
+        _handle_ask_user(tool_input, config, handler, case_dir=args.case_dir)
         return
 
     # --- Env checks: block if environment doesn't match ---
@@ -58,7 +75,7 @@ def main():
         sys.exit(0)
 
     # --- Default for matched tools without specific handling: block ---
-    _deny(f"Blocked by eval harness: {handler.get('match', 'matched handler')}")
+    _deny(f"Blocked by policy: {handler.get('match', 'matched handler')}")
 
 
 def _find_handler(tool_name, tool_input, handlers):
@@ -100,7 +117,7 @@ def _find_handler(tool_name, tool_input, handlers):
     return None
 
 
-def _handle_ask_user(tool_input, config, handler):
+def _handle_ask_user(tool_input, config, handler, case_dir=None):
     """Auto-answer AskUserQuestion using case overrides, LLM, or first option.
 
     Resolution order for each question:
@@ -126,7 +143,8 @@ def _handle_ask_user(tool_input, config, handler):
 
         # 2. LLM-based answer
         if answer is None and options:
-            answer = _llm_answer(text, options, prompt, model=hook_model)
+            answer = _llm_answer(text, options, prompt, model=hook_model,
+                                 case_dir=case_dir)
 
         # 3. Fallback
         if answer is None:
@@ -147,21 +165,27 @@ def _handle_ask_user(tool_input, config, handler):
     json.dump(output, sys.stdout)
 
 
-def _llm_answer(question, options, handler_prompt, model=None):
+def _llm_answer(question, options, handler_prompt, model=None, case_dir=None):
     """Use an LLM to pick the best answer for a question.
 
-    Reads input.yaml and answers.yaml from CWD for case-specific context.
+    Reads input.yaml from CWD and answers.yaml from ``case_dir`` (or CWD
+    as fallback) for case-specific context.
     Returns the selected option label, or None if the API call fails.
     """
-    # Load case context
+    # Load case context — input.yaml from CWD, answers.yaml from --case-dir
     case_context = ""
-    for fname in ("input.yaml", "answers.yaml"):
-        p = Path(fname)
-        if p.exists():
-            try:
-                case_context += f"\n--- {fname} ---\n{p.read_text()}\n"
-            except OSError:
-                pass
+    input_path = Path("input.yaml")
+    if input_path.exists():
+        try:
+            case_context += f"\n--- input.yaml ---\n{input_path.read_text()}\n"
+        except OSError:
+            pass
+    answers_path = Path(case_dir) / "answers.yaml" if case_dir else Path("answers.yaml")
+    if answers_path.exists():
+        try:
+            case_context += f"\n--- answers.yaml ---\n{answers_path.read_text()}\n"
+        except OSError:
+            pass
 
     option_labels = [o["label"] for o in options]
     option_list = "\n".join(

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -18,6 +18,7 @@ import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 import argparse
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -41,7 +42,7 @@ def main():
         "--symlinks",
         default=None,
         help="Comma-separated dirs/files to symlink into workspace "
-        "(default: scripts,.claude,CLAUDE.md,.context,skills)",
+        "(default: scripts,.claude,CLAUDE.md,.context)",
     )
     args = parser.parse_args()
 
@@ -67,15 +68,21 @@ def main():
         print("ERROR: run-id must match [A-Za-z0-9._-]+", file=sys.stderr)
         sys.exit(1)
 
-    # Create workspace in secure temp directory
+    # Create workspace and sibling harness directory in secure temp directory.
+    # The harness directory stores hook scripts and tool_handlers.yaml
+    # outside the solver workspace so the evaluated agent cannot access them.
     base_dir = (Path(tempfile.gettempdir()) / "agent-eval").resolve()
     workspace = (base_dir / args.run_id).resolve()
+    harness_dir = (base_dir / f"{args.run_id}._harness").resolve()
     if base_dir not in workspace.parents and workspace != base_dir:
         print("ERROR: invalid run-id path", file=sys.stderr)
         sys.exit(1)
     if workspace.exists():
         shutil.rmtree(workspace)
+    if harness_dir.exists():
+        shutil.rmtree(harness_dir)
     workspace.mkdir(parents=True, mode=0o700)
+    harness_dir.mkdir(parents=True, mode=0o700)
 
     # Initialize a bare git repo so Claude Code subagents can discover
     # the project root and load .claude/settings.json with the expanded
@@ -84,7 +91,7 @@ def main():
 
     # Branch on execution mode
     if config.execution.mode == "case":
-        _create_per_case_workspace(workspace, case_dirs, config, args)
+        _create_per_case_workspace(workspace, case_dirs, config, args, harness_dir)
         return
 
     # ── Batch mode (below) ───────────────────────────────────────
@@ -138,20 +145,19 @@ def main():
     with open(workspace / "case_order.yaml", "w") as f:
         yaml.dump(case_order, f, default_flow_style=False)
 
-    # Symlink project resources into workspace
-    # Skip .claude when tool hooks are configured — _setup_tool_hooks
-    # creates its own .claude/settings.json and symlinking would write
-    # into the project's .claude/ directory instead
+    # Symlink project resources into workspace.
+    # .claude is always skipped — we create our own settings.json.
+    # skills is excluded by default (D4) — it exposes judge prompts,
+    # scoring scripts, and tool-interception docs to the solver.
     project_root = Path.cwd()
-    default_symlinks = ["scripts", ".claude", "CLAUDE.md", ".context", "skills"]
-    # Always skip .claude symlink — we create our own settings.json
-    # (for SubagentStop hook at minimum, plus tool interception if configured)
+    default_symlinks = ["scripts", ".claude", "CLAUDE.md", ".context"]
     skip_symlinks = {".claude"}
     symlink_names = (
         [s.strip() for s in args.symlinks.split(",") if s.strip()]
         if args.symlinks
         else default_symlinks
     )
+    symlink_dirs = []
     for name in symlink_names:
         if name in skip_symlinks:
             continue
@@ -160,50 +166,80 @@ def main():
             print(f"WARNING: skipping invalid symlink entry: {name}", file=sys.stderr)
             continue
         target = project_root / name
+        if not target.exists():
+            continue
+        # Copy files instead of symlinking (D3) — additionalDirectories
+        # only accepts directories, so file symlinks would need the
+        # project root in the allowlist
+        if target.is_file():
+            shutil.copy2(target, workspace / name)
+            continue
+        # Symlink directories and track targets for additionalDirectories
         link = workspace / name
-        if target.exists():
-            link.symlink_to(target.resolve())
+        link.symlink_to(target.resolve())
+        symlink_dirs.append(str(target.resolve()))
 
-    # When .claude is skipped for hooks, symlink subdirectories (e.g. skills/)
-    if ".claude" in skip_symlinks:
-        claude_dir = project_root / ".claude"
-        if claude_dir.is_dir():
-            for sub in claude_dir.iterdir():
-                if sub.is_dir() and sub.name != "settings.json":
-                    link = workspace / ".claude" / sub.name
-                    if not link.exists():
-                        link.parent.mkdir(parents=True, exist_ok=True)
-                        link.symlink_to(sub.resolve())
+    # Symlink .claude subdirectories (skills/, etc.) for skill discovery
+    claude_dir = project_root / ".claude"
+    if claude_dir.is_dir():
+        for sub in claude_dir.iterdir():
+            if sub.is_dir() and sub.name != "settings.json":
+                link = workspace / ".claude" / sub.name
+                if not link.exists():
+                    link.parent.mkdir(parents=True, exist_ok=True)
+                    link.symlink_to(sub.resolve())
+                    symlink_dirs.append(str(sub.resolve()))
 
     # Generate tool interception hooks if inputs.tools configured
     if config.inputs.tools:
-        _setup_tool_hooks(workspace, config)
+        _setup_tool_hooks(workspace, config, harness_dir,
+                          symlink_dirs=symlink_dirs)
     else:
         # Even without tool interception, set up SubagentStop hook
         # to capture background agent transcripts for tracing.
-        _setup_subagent_only_hook(workspace, config)
+        _setup_subagent_only_hook(workspace, config, symlink_dirs=symlink_dirs)
 
     print(f"WORKSPACE: {workspace}")
+    print(f"HARNESS: {harness_dir}")
     print(f"CASES: {len(case_dirs)}")
     print(f"BATCH: {workspace / 'batch.yaml'}")
 
 
-def _create_per_case_workspace(workspace, case_dirs, config, args):
+def _create_per_case_workspace(workspace, case_dirs, config, args, harness_dir):
     """Create a separate workspace per case for per-case execution.
 
     Each case gets its own workspace subdirectory with:
-    - All files from the dataset case directory (input.yaml, strategy.md, etc.)
-    - Symlinked project resources (scripts, skills, .context, CLAUDE.md)
-    - Tool interception hooks and SubagentStop hook
+    - Input file from the dataset case directory
+    - Symlinked project resources (scripts, .context, CLAUDE.md)
+    - Tool interception hooks (in sibling harness dir, not workspace)
+    - SubagentStop hook for transcript capture
     - Output directories from eval.yaml
     """
     project_root = Path.cwd()
-    default_symlinks = ["scripts", ".claude", "CLAUDE.md", ".context", "skills"]
+    default_symlinks = ["scripts", ".claude", "CLAUDE.md", ".context"]
     symlink_names = (
         [s.strip() for s in args.symlinks.split(",") if s.strip()]
         if args.symlinks
         else default_symlinks
     )
+
+    # Pre-compute directory symlink targets for scoped additionalDirectories.
+    # Same for all cases since they share the same project resources.
+    symlink_dirs = []
+    for name in symlink_names:
+        if name == ".claude":
+            continue
+        p = Path(name)
+        if p.is_absolute() or ".." in p.parts:
+            continue
+        target = project_root / name
+        if target.is_dir():
+            symlink_dirs.append(str(target.resolve()))
+    claude_dir = project_root / ".claude"
+    if claude_dir.is_dir():
+        for sub in claude_dir.iterdir():
+            if sub.is_dir() and sub.name != "settings.json":
+                symlink_dirs.append(str(sub.resolve()))
 
     case_order = []
 
@@ -213,7 +249,13 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
         case_ws.mkdir(parents=True, exist_ok=True)
         subprocess.run(["git", "init", "-q", str(case_ws)], check=True)
 
-        # Copy only the input file and answers.yaml into the workspace.
+        # Create per-case harness subdirectory for hook isolation (D2).
+        case_harness = harness_dir / case_id
+        case_harness.mkdir(parents=True, exist_ok=True)
+
+        # Copy only the input file into the workspace.
+        # answers.yaml stays in the dataset dir — the hook reads it
+        # from --case-dir so the solver cannot access the answer key.
         # Companion files (e.g., source code for autofix skills) should
         # use dataset.input_files_dir (see #70) to explicitly declare
         # which files the skill needs. Everything else (gold standards,
@@ -221,9 +263,6 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
         input_src = _find_input_file(case_dir)
         if input_src:
             shutil.copy2(input_src, case_ws / input_src.name)
-        answers_src = case_dir / "answers.yaml"
-        if answers_src.is_file():
-            shutil.copy2(answers_src, case_ws / "answers.yaml")
 
         # Copy input files directory if present (e.g., source code for the
         # agent to work on). Contents are placed at the workspace root,
@@ -274,8 +313,17 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
             if p.is_absolute() or ".." in p.parts:
                 continue
             target = project_root / name
+            if not target.exists():
+                continue
+            # Copy files instead of symlinking (D3)
+            if target.is_file():
+                dest = case_ws / name
+                if not dest.exists():
+                    shutil.copy2(target, dest)
+                continue
+            # Symlink directories
             link = case_ws / name
-            if target.exists() and not link.exists():
+            if not link.exists():
                 link.symlink_to(target.resolve())
 
         # Symlink .claude subdirectories (skills/, etc.)
@@ -290,9 +338,12 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
 
         # Set up hooks (tool interception + SubagentStop)
         if config.inputs.tools:
-            _setup_tool_hooks(case_ws, config)
+            _setup_tool_hooks(case_ws, config, case_harness,
+                              dataset_case_dir=case_dir,
+                              symlink_dirs=symlink_dirs)
         else:
-            _setup_subagent_only_hook(case_ws, config)
+            _setup_subagent_only_hook(case_ws, config,
+                                     symlink_dirs=symlink_dirs)
 
         case_order.append({"case_id": case_id})
 
@@ -301,6 +352,7 @@ def _create_per_case_workspace(workspace, case_dirs, config, args):
         yaml.dump(case_order, f, default_flow_style=False)
 
     print(f"WORKSPACE: {workspace}")
+    print(f"HARNESS: {harness_dir}")
     print(f"MODE: case")
     print(f"CASES: {len(case_dirs)}")
     for entry in case_order:
@@ -329,6 +381,7 @@ def _read_input(case_dir, config=None):
         ws = getattr(getattr(config, "dataset", None), "workspace", None)
         _SKIP_NAMES = _SKIP_NAMES | {
             Path(f).parts[0] for f in (getattr(ws, "files", None) or [])
+            if Path(f).parts
         }
 
     # First pass: look for a file named 'input.*'
@@ -412,7 +465,12 @@ def _inject_env(settings, config):
 
 
 def _carry_over_permissions(settings):
-    """Copy project permissions (allow, deny, additionalDirectories) into settings."""
+    """Copy project permissions (allow, deny) into workspace settings.
+
+    additionalDirectories are intentionally NOT carried over — the workspace
+    uses scoped directory access based on actual symlink targets.  Copying
+    project additionalDirectories would re-expose the full project root.
+    """
     import json as _json
 
     project_settings = Path.cwd() / ".claude" / "settings.json"
@@ -430,15 +488,13 @@ def _carry_over_permissions(settings):
         settings.setdefault("permissions", {})["allow"] = allow_list
     if proj_perms.get("deny"):
         settings.setdefault("permissions", {})["deny"] = list(proj_perms["deny"])
-    if proj_perms.get("additionalDirectories"):
-        dirs = list(proj_perms["additionalDirectories"])
-        for d in list(dirs):
-            resolved = str(Path(d).resolve())
-            if resolved != d and resolved not in dirs:
-                dirs.append(resolved)
-        settings.setdefault("permissions", {}).setdefault(
-            "additionalDirectories", []
-        ).extend(dirs)
+    # Intentionally skip additionalDirectories — the workspace scopes
+    # access to resolved symlink targets only
+    dropped = proj_perms.get("additionalDirectories", [])
+    if dropped:
+        print(f"WARNING: dropping {len(dropped)} additionalDirectories from "
+              f"project settings (workspace uses scoped access): "
+              f"{', '.join(str(d) for d in dropped)}", file=sys.stderr)
 
 
 def _merge_harness_permissions(settings, config):
@@ -476,13 +532,20 @@ def _apply_runner_settings(settings, config):
     Lets users add Claude Code settings (model defaults, env, MCP servers,
     etc.) to a runner without forking the harness. Merged after harness
     defaults so user overrides win for scalar keys; lists are extended.
+
+    **Isolation note**: this runs after scoped `additionalDirectories`
+    are set.  If `runner.settings` contains
+    `permissions.additionalDirectories`, those entries are appended —
+    intentionally, as an escape hatch for skills that need broader access
+    (e.g., reading project source outside symlinked dirs).  Users who set
+    this accept the isolation trade-off.
     """
     user_settings = getattr(config.runner, "settings", None) or {}
     if user_settings:
         _deep_merge(settings, user_settings)
 
 
-def _setup_subagent_only_hook(workspace, config):
+def _setup_subagent_only_hook(workspace, config, symlink_dirs=None):
     """Set up SubagentStop hook without tool interception.
 
     When there are no inputs.tools, we still need the SubagentStop hook
@@ -497,15 +560,18 @@ def _setup_subagent_only_hook(workspace, config):
 
     settings = {}
 
-    # Carry over project permissions (allow, deny, additionalDirectories)
+    # Carry over project permissions (allow, deny)
     _carry_over_permissions(settings)
     _merge_harness_permissions(settings, config)
 
-    # Grant project root access
-    project_root = str(Path.cwd().resolve())
-    settings.setdefault("permissions", {}).setdefault(
-        "additionalDirectories", []
-    ).append(project_root)
+    # Grant access to resolved symlink directory targets — not the entire
+    # project root, which would expose eval.yaml, judge prompts, etc.
+    if symlink_dirs:
+        additional = settings.setdefault("permissions", {}).setdefault(
+            "additionalDirectories", [])
+        for d in symlink_dirs:
+            if d not in additional:
+                additional.append(d)
 
     # Add SubagentStop hook
     from agent_eval.agent.stream_capture import setup_subagent_hook
@@ -559,8 +625,24 @@ def _extract_tool_patterns(match_text):
     return patterns or ["*"]
 
 
-def _setup_tool_hooks(workspace, config):
-    """Generate settings.json and tool_handlers.yaml for tool interception."""
+def _setup_tool_hooks(workspace, config, harness_dir, dataset_case_dir=None,
+                      symlink_dirs=None):
+    """Generate settings.json and tool_handlers.yaml for tool interception.
+
+    Hook scripts and config are written to ``harness_dir`` (a sibling of the
+    solver workspace) so the evaluated agent cannot read, modify, or delete
+    them.  ``settings.json`` stays in the workspace since Claude Code reads
+    it from CWD.
+
+    Args:
+        workspace: Solver workspace path (receives .claude/settings.json).
+        config: EvalConfig instance.
+        harness_dir: Sibling harness directory for hook files.
+        dataset_case_dir: Dataset case directory containing answers.yaml
+            (case mode only). Passed as ``--case-dir`` to the hook script.
+        symlink_dirs: Resolved directory paths of workspace symlinks.
+            Added to additionalDirectories instead of the project root.
+    """
     import json as _json
 
     # Build handler config with resolved patterns
@@ -581,50 +663,54 @@ def _setup_tool_hooks(workspace, config):
         handlers.append(handler)
         hook_matchers.update(patterns)
 
-    # Write tool_handlers.yaml
+    # Write tool_handlers.yaml to harness dir (outside solver workspace)
     handler_data = {"handlers": handlers}
     if config.models.hook:
         handler_data["hook_model"] = config.models.hook
-    with open(workspace / "tool_handlers.yaml", "w") as f:
+    with open(harness_dir / "tool_handlers.yaml", "w") as f:
         yaml.dump(handler_data, f, default_flow_style=False)
 
-    # Copy interceptor script
-    hooks_dir = workspace / "hooks"
+    # Copy interceptor script to harness dir
+    hooks_dir = harness_dir / "hooks"
     hooks_dir.mkdir(exist_ok=True)
     interceptor_src = Path(__file__).parent / "tools.py"
     if interceptor_src.exists():
         shutil.copy2(interceptor_src, hooks_dir / "tools.py")
 
+    # Build hook command with explicit paths and shell quoting (D6)
+    tools_path = shlex.quote(str((hooks_dir / "tools.py").resolve()))
+    config_path = shlex.quote(str((harness_dir / "tool_handlers.yaml").resolve()))
+    cmd = f"python3 {tools_path} --config {config_path}"
+    if dataset_case_dir:
+        cmd += f" --case-dir {shlex.quote(str(dataset_case_dir.resolve()))}"
+
     # Generate .claude/settings.json with PreToolUse hooks
-    # Don't overwrite if symlinked from project — create alongside
     settings_dir = workspace / ".claude"
     settings_dir.mkdir(parents=True, exist_ok=True)
 
     settings = {"hooks": {"PreToolUse": []}}
     for matcher in sorted(hook_matchers):
-        settings["hooks"]["PreToolUse"].append(
-            {
-                "matcher": matcher,
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": f"python3 {workspace}/hooks/tools.py",
-                    }
-                ],
-            }
-        )
+        settings["hooks"]["PreToolUse"].append({
+            "matcher": matcher,
+            "hooks": [{
+                "type": "command",
+                "command": cmd,
+            }],
+        })
 
-    # Carry over permissions (allow, deny, additionalDirectories)
+    # Carry over permissions (allow, deny)
     _carry_over_permissions(settings)
 
     _merge_harness_permissions(settings, config)
 
-    # Grant access to the project root so symlinked resources (skills,
-    # scripts, context) can be read by the sandbox.
-    project_root = str(Path.cwd().resolve())
-    settings.setdefault("permissions", {}).setdefault(
-        "additionalDirectories", []
-    ).append(project_root)
+    # Grant access to resolved symlink directory targets — not the entire
+    # project root, which would expose eval.yaml, judge prompts, etc.
+    if symlink_dirs:
+        additional = settings.setdefault("permissions", {}).setdefault(
+            "additionalDirectories", [])
+        for d in symlink_dirs:
+            if d not in additional:
+                additional.append(d)
 
     # Add SubagentStop hook to capture background agent transcripts.
     # The hook copies each subagent's .jsonl file to workspace/subagents/.

--- a/skills/eval-run/scripts/workspace_files.py
+++ b/skills/eval-run/scripts/workspace_files.py
@@ -5,6 +5,13 @@ side effects from workspace.py.
 """
 
 import shutil
+import sys
+from pathlib import Path
+
+# Files that contain evaluation material (answer keys, gold standards,
+# annotations for judges).  These must never be copied into the solver
+# workspace — the solver would have direct access to the answers.
+_EVAL_ONLY_NAMES = {"answers", "annotations", "reference", "expected", "gold"}
 
 
 def _copy_input_files(case_dir, workspace, config):
@@ -13,7 +20,8 @@ def _copy_input_files(case_dir, workspace, config):
     Iterates ``config.dataset.workspace.files`` and copies each listed
     path from *case_dir* into *workspace*, preserving relative structure.
     Directory entries are copied recursively.  Symlinks are skipped to
-    prevent escaping the case directory.
+    prevent escaping the case directory.  Evaluation-only files (answer
+    keys, annotations, gold standards) are silently skipped.
     """
     ds = getattr(config, "dataset", None)
     if ds is None:
@@ -27,11 +35,22 @@ def _copy_input_files(case_dir, workspace, config):
 
     case_root = case_dir.resolve()
     for entry in files:
+        # Reject "." — it copies the entire case dir including eval material
+        if entry == "." or not Path(entry).parts:
+            print(f"WARNING: skipping workspace.files entry '{entry}' "
+                  f"(copies entire case dir including eval material)",
+                  file=sys.stderr)
+            continue
         src = case_dir / entry
         if src.is_symlink():
             continue
+        # Skip eval-only files at any level
+        if _is_eval_only(src):
+            continue
         if src.is_dir():
-            _copy_tree(src, case_dir, workspace, case_root)
+            if not src.resolve().is_relative_to(case_root):
+                continue
+            _copy_tree(src, case_dir, workspace)
         elif src.is_file():
             if not src.resolve().is_relative_to(case_root):
                 continue
@@ -41,8 +60,13 @@ def _copy_input_files(case_dir, workspace, config):
             shutil.copy2(src, dst)
 
 
-def _copy_tree(src_dir, case_dir, workspace, case_root):
-    """Recursively copy a directory, skipping symlinks."""
+def _is_eval_only(path):
+    """Check if a path matches an evaluation-only filename pattern."""
+    return path.stem.lower() in _EVAL_ONLY_NAMES
+
+
+def _copy_tree(src_dir, case_dir, workspace):
+    """Recursively copy a directory, skipping symlinks and eval-only files."""
     resolved_root = src_dir.resolve()
     for item in src_dir.rglob("*"):
         if item.is_symlink():
@@ -50,6 +74,8 @@ def _copy_tree(src_dir, case_dir, workspace, case_root):
         if not item.is_file():
             continue
         if not item.resolve().is_relative_to(resolved_root):
+            continue
+        if _is_eval_only(item):
             continue
         rel = item.relative_to(case_dir)
         dst = workspace / rel

--- a/tests/test_input_files.py
+++ b/tests/test_input_files.py
@@ -246,3 +246,125 @@ def test_copy_workspace_files_skips_symlinked_entry(tmp_path):
 
     assert not os.path.lexists(workspace / "evil")
     assert list(workspace.iterdir()) == []
+
+
+# ── Isolation: eval-only file exclusion ────────────────────────────
+
+
+def test_copy_workspace_files_skips_answers_yaml(tmp_path):
+    """answers.yaml must never be copied into the workspace."""
+    case_dir = tmp_path / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    (case_dir / "answers.yaml").write_text("secret: answer")
+    (case_dir / "input.yaml").write_text("prompt: hello")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(
+            workspace=WorkspaceConfig(files=["answers.yaml", "input.yaml"]),
+        ),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert not (workspace / "answers.yaml").exists(), \
+        "answers.yaml must not be copied into solver workspace"
+    assert (workspace / "input.yaml").read_text() == "prompt: hello"
+
+
+def test_copy_workspace_files_skips_annotations_yaml(tmp_path):
+    """annotations.yaml must never be copied into the workspace."""
+    case_dir = tmp_path / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    (case_dir / "annotations.yaml").write_text("expected: pass")
+    (case_dir / "code.py").write_text("x = 1")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(
+            workspace=WorkspaceConfig(files=["annotations.yaml", "code.py"]),
+        ),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert not (workspace / "annotations.yaml").exists()
+    assert (workspace / "code.py").read_text() == "x = 1"
+
+
+def test_copy_workspace_files_skips_eval_only_in_directory(tmp_path):
+    """Eval-only files inside a directory entry are excluded."""
+    case_dir = tmp_path / "cases" / "case-001"
+    (case_dir / "data").mkdir(parents=True)
+    (case_dir / "data" / "config.yaml").write_text("key: val")
+    (case_dir / "data" / "answers.yaml").write_text("secret: answer")
+    (case_dir / "data" / "gold.json").write_text('{"score": 1}')
+    (case_dir / "data" / "reference.md").write_text("expected output")
+    (case_dir / "data" / "expected.txt").write_text("gold standard")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(workspace=WorkspaceConfig(files=["data"])),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert (workspace / "data" / "config.yaml").read_text() == "key: val"
+    for name in ("answers.yaml", "gold.json", "reference.md", "expected.txt"):
+        assert not (workspace / "data" / name).exists(), \
+            f"eval-only file '{name}' must not be copied"
+
+
+def test_copy_workspace_files_rejects_dot_entry(tmp_path):
+    """Entry '.' must be skipped with a warning (copies entire case dir)."""
+    case_dir = tmp_path / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    (case_dir / "answers.yaml").write_text("secret")
+    (case_dir / "input.yaml").write_text("prompt: hello")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(workspace=WorkspaceConfig(files=["."])),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    # Nothing should be copied — "." is rejected
+    assert list(workspace.iterdir()) == []
+
+
+def test_copy_workspace_files_dir_traversal_blocked(tmp_path):
+    """Directory entries outside case_root are blocked."""
+    case_dir = tmp_path / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("secret")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    # Even if validation is bypassed (e.g. direct EvalConfig construction),
+    # the runtime check rejects directories outside case_root
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(workspace=WorkspaceConfig(files=["../../outside"])),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert not (workspace / "outside").exists()
+    assert not (workspace / "secret.txt").exists()

--- a/tests/test_workspace_isolation.py
+++ b/tests/test_workspace_isolation.py
@@ -1,0 +1,161 @@
+"""Unit tests for workspace isolation (spec 006).
+
+Verifies that the solver workspace does not expose answer keys,
+evaluation infrastructure, or awareness that it's being benchmarked.
+
+Source-analysis tests read file contents directly to avoid importing
+modules that require Python 3.10+ (Path | str type syntax).
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "eval-run" / "scripts"))
+
+TOOLS_PY = str(Path(__file__).parent.parent / "skills" / "eval-run" / "scripts" / "tools.py")
+WORKSPACE_PY = Path(__file__).parent.parent / "skills" / "eval-run" / "scripts" / "workspace.py"
+PROJECT_ROOT = str(Path(__file__).parent.parent)
+
+
+@pytest.fixture(scope="module")
+def workspace_src():
+    """Read workspace.py source once for all source-analysis tests."""
+    return WORKSPACE_PY.read_text()
+
+
+# ── P1: Core isolation ──────────────────────────────────────────
+
+
+def test_answers_not_in_workspace(workspace_src):
+    """answers.yaml must not be copied into the per-case workspace."""
+    assert 'shutil.copy2(answers_src, case_ws / "answers.yaml")' not in workspace_src
+    assert 'answers_src = case_dir / "answers.yaml"' not in workspace_src
+
+
+def test_hooks_in_harness_dir(workspace_src):
+    """tool_handlers.yaml and tools.py are written to harness dir, not workspace."""
+    assert 'harness_dir / "tool_handlers.yaml"' in workspace_src
+    assert 'hooks_dir = harness_dir / "hooks"' in workspace_src
+    # Old workspace references should be gone
+    assert 'hooks_dir = workspace / "hooks"' not in workspace_src
+    assert 'workspace / "tool_handlers.yaml"' not in workspace_src
+
+
+def test_hook_command_points_to_harness(workspace_src):
+    """settings.json hook command must reference the harness path, not workspace."""
+    assert 'tools_path = shlex.quote(str((hooks_dir / "tools.py").resolve()))' in workspace_src
+    assert 'config_path = shlex.quote(str((harness_dir / "tool_handlers.yaml").resolve()))' in workspace_src
+    assert 'cmd = f"python3 {tools_path} --config {config_path}"' in workspace_src
+    # Old: bare workspace path in command
+    assert 'f"python3 {workspace}/hooks/tools.py"' not in workspace_src
+
+
+# ── P2: Access scoping ──────────────────────────────────────────
+
+
+def test_additional_dirs_scoped(workspace_src):
+    """additionalDirectories must not contain the project root —
+    only resolved directory symlink targets."""
+    assert '"additionalDirectories", []).append(project_root)' not in workspace_src
+    assert "if symlink_dirs:" in workspace_src
+    assert "if d not in additional:" in workspace_src
+
+
+def test_carry_over_skips_additional_dirs(workspace_src):
+    """_carry_over_permissions must not copy additionalDirectories
+    from the project's settings.json."""
+    # The old extend pattern should be gone from _carry_over_permissions
+    func_src = workspace_src.split("def _carry_over_permissions")[1].split("\ndef ")[0]
+    assert ".extend(" not in func_src
+    # Must warn about dropped entries
+    assert "dropping" in func_src
+    assert "additionalDirectories" in func_src
+
+
+def test_claude_md_copied_not_symlinked(workspace_src):
+    """CLAUDE.md (and any file) must be copied, not symlinked, into the workspace."""
+    assert "if target.is_file():" in workspace_src
+    assert "shutil.copy2(target, workspace / name)" in workspace_src  # batch mode
+    assert "shutil.copy2(target, dest)" in workspace_src  # case mode
+
+
+def test_skills_not_in_default_symlinks(workspace_src):
+    """'skills' must not appear in either default_symlinks list."""
+    for m in re.finditer(r'default_symlinks\s*=\s*\[([^\]]+)\]', workspace_src):
+        items = m.group(1)
+        assert '"skills"' not in items and "'skills'" not in items, \
+            f"'skills' found in default_symlinks: [{items}]"
+
+
+# ── P3: Decontamination ─────────────────────────────────────────
+
+
+def test_harness_prompt_neutral():
+    """_HARNESS_SYSTEM_PROMPT must not contain evaluation-revealing language."""
+    execute_src = (Path(__file__).parent.parent
+                   / "skills" / "eval-run" / "scripts" / "execute.py").read_text()
+    m = re.search(r'_HARNESS_SYSTEM_PROMPT\s*=\s*\((.*?)\)', execute_src, re.DOTALL)
+    assert m, "_HARNESS_SYSTEM_PROMPT not found in execute.py"
+    prompt = m.group(1).lower()
+    for word in ("evaluation", "harness", "benchmark", "eval "):
+        assert word not in prompt, \
+            f"System prompt contains '{word}'"
+
+
+def test_safe_env_no_eval_runs_dir():
+    """AGENT_EVAL_RUNS_DIR must not be in _SAFE_ENV_KEYS."""
+    claude_code_src = (Path(__file__).parent.parent
+                       / "agent_eval" / "agent" / "claude_code.py").read_text()
+    # Find the _SAFE_ENV_KEYS block
+    m = re.search(r'_SAFE_ENV_KEYS\s*=\s*\{(.*?)\}', claude_code_src, re.DOTALL)
+    assert m, "_SAFE_ENV_KEYS not found"
+    assert "AGENT_EVAL_RUNS_DIR" not in m.group(1)
+
+
+# ── Review fixes: workspace.files and collect.py ────────────────
+
+
+def test_workspace_files_skips_eval_only():
+    """workspace_files.py must filter eval-only files (answers, annotations, etc.)."""
+    ws_files_src = (Path(__file__).parent.parent
+                    / "skills" / "eval-run" / "scripts" / "workspace_files.py").read_text()
+    assert "_EVAL_ONLY_NAMES" in ws_files_src
+    assert '"answers"' in ws_files_src
+    assert '"annotations"' in ws_files_src
+    assert "_is_eval_only" in ws_files_src
+    # The "." entry must be rejected
+    assert 'entry == "."' in ws_files_src
+
+
+def test_collect_excludes_claude_md():
+    """collect.py _HARNESS_PATHS must include CLAUDE.md to prevent false _modified."""
+    collect_src = (Path(__file__).parent.parent
+                   / "skills" / "eval-run" / "scripts" / "collect.py").read_text()
+    m = re.search(r'_HARNESS_PATHS\s*=\s*\{([^}]+)\}', collect_src, re.DOTALL)
+    assert m, "_HARNESS_PATHS not found in collect.py"
+    assert '"CLAUDE.md"' in m.group(1), \
+        "CLAUDE.md must be in _HARNESS_PATHS to prevent false _modified collection"
+
+
+# ── P1: Fail-closed hook ────────────────────────────────────────
+
+
+def test_tools_fail_closed():
+    """tools.py with --config pointing to a missing file must return JSON deny."""
+    result = subprocess.run(
+        [sys.executable, TOOLS_PY,
+         "--config", "/nonexistent/tool_handlers.yaml"],
+        input=json.dumps({"tool_name": "Bash", "tool_input": {"command": "ls"}}),
+        capture_output=True, text=True, timeout=10,
+        env={**os.environ, "PYTHONPATH": PROJECT_ROOT},
+    )
+    output = json.loads(result.stdout)
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "not found" in output["hookSpecificOutput"]["reason"].lower()


### PR DESCRIPTION
The evaluated agent currently has full visibility into the eval harness: answer keys, judge prompts, scoring scripts, and a system prompt that says "you are running inside an evaluation harness."

This PR eliminates those leakage vectors so results reflect actual skill capability. Scoped to the non-containerized architecture; Bash remains unsandboxed (Docker/Inspect tracked separately).

**Harness directory** — Hook scripts and `tool_handlers.yaml` move to a sibling directory (`<run-id>._harness/`) outside the solver workspace. Sibling rather than child because batch mode's `.git/` makes any child readable. `tools.py` takes `--config`/`--case-dir` flags pointing to the harness; missing config is fail-closed.

**Access scoping** — `additionalDirectories` grants only resolved symlink targets, not the project root. `CLAUDE.md` is copied (not symlinked) since `additionalDirectories` only accepts directories, and excluded from artifact collection in `collect.py` to avoid false `_modified` results. `skills/` removed from default symlinks — it exposes judge prompts and scoring scripts. Project `additionalDirectories` are no longer carried over; `runner.settings` remains as an explicit escape hatch.

**Decontamination** — Neutral system prompt and deny messages (no "eval harness" language). `AGENT_EVAL_RUNS_DIR` dropped from env allowlist. `answers.yaml` stays in the dataset dir, read by the hook via `--case-dir`. Eval-only files (`answers.yaml`, `annotations.yaml`, `reference.*`, `expected.*`, `gold.*`) filtered at copy time; `"."` entry rejected.

**Tests** — 12 source-analysis tests (3.9+) + 5 functional tests (3.10+), all passing.