### PR TITLE
fix: validate run_id and baseline as single path segments (CWE-22)

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -64,6 +64,42 @@ def _validate_relative_path(
     return value
 
 
+def _validate_path_segment(value: str, name: str) -> str:
+    """Validate that a value is a single path segment (no directory traversal).
+
+    Ensures the value contains no path separators (/ or \\), is not a
+    relative directory reference (. or ..), and contains no control characters.
+    Used to prevent path traversal attacks (CWE-22) when constructing
+    filesystem paths from user-controlled input.
+
+    Args:
+        value: The path segment to validate (e.g., run_id, skill name)
+        name: Parameter name for error messages
+
+    Returns:
+        The validated value
+
+    Raises:
+        ValueError: If value is not a valid single path segment
+    """
+    if not _is_valid_eval_name(value):
+        # Provide detailed error message based on what failed
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{name} must be a non-empty string, got: {value!r}")
+        if "/" in value or "\\" in value:
+            raise ValueError(
+                f"{name} must be a single path segment, "
+                f"cannot contain path separators: {value!r}"
+            )
+        if value in (".", ".."):
+            raise ValueError(
+                f"{name} cannot be a relative directory reference: {value!r}"
+            )
+        # Control characters or other invalid chars
+        raise ValueError(f"{name} contains invalid characters: {value!r}")
+    return value
+
+
 @dataclass
 class DiscoveryResult:
     """A discovered eval config file."""
@@ -580,9 +616,11 @@ class EvalConfig:
                     stacklevel=2,
                 )
 
-        if config.skill and not _is_valid_eval_name(config.skill):
-            raise ValueError(
-                f"Invalid skill name in {path}: {config.skill!r}")
+        if config.skill:
+            try:
+                _validate_path_segment(config.skill, f"skill name in {path}")
+            except ValueError as e:
+                raise ValueError(str(e)) from e
 
         return config
 

--- a/skills/eval-mlflow/scripts/attach_feedback.py
+++ b/skills/eval-mlflow/scripts/attach_feedback.py
@@ -41,7 +41,7 @@ except ImportError:
           file=sys.stderr)
     sys.exit(0)
 
-from agent_eval.config import EvalConfig
+from agent_eval.config import EvalConfig, _validate_path_segment
 from agent_eval.mlflow.experiment import log_feedback, resolve_tracking_uri
 from agent_eval.mlflow.traces import find_run_traces
 
@@ -57,6 +57,9 @@ def main():
     parser.add_argument("--trace-id", default=None,
                         help="Direct trace ID (skip search)")
     args = parser.parse_args()
+
+    # Validate run_id to prevent path traversal (CWE-22)
+    args.run_id = _validate_path_segment(args.run_id, "--run-id")
 
     config = EvalConfig.from_yaml(args.config)
     mlflow.set_tracking_uri(resolve_tracking_uri(config))

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -30,7 +30,7 @@ except ImportError:
           file=sys.stderr)
     sys.exit(0)
 
-from agent_eval.config import EvalConfig
+from agent_eval.config import EvalConfig, _validate_path_segment
 from agent_eval.mlflow.experiment import resolve_tracking_uri
 
 
@@ -47,6 +47,9 @@ def main():
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--config", required=True)
     args = parser.parse_args()
+
+    # Validate run_id to prevent path traversal (CWE-22)
+    args.run_id = _validate_path_segment(args.run_id, "--run-id")
 
     config = EvalConfig.from_yaml(args.config)
     mlflow.set_tracking_uri(resolve_tracking_uri(config))

--- a/skills/eval-run/scripts/preflight.py
+++ b/skills/eval-run/scripts/preflight.py
@@ -30,7 +30,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from agent_eval.config import EvalConfig
+from agent_eval.config import EvalConfig, _validate_path_segment
 
 
 # State directories that skills write to between runs
@@ -71,6 +71,12 @@ def main():
     parser.add_argument("--baseline", default=None,
                         help="Verify the given baseline run-id exists before continuing")
     args = parser.parse_args()
+
+    # Validate run_id / baseline to prevent path traversal (CWE-22)
+    if args.run_id:
+        _validate_path_segment(args.run_id, "--run-id")
+    if args.baseline:
+        _validate_path_segment(args.baseline, "--baseline")
 
     config = EvalConfig.from_yaml(args.config)
     project_root = Path.cwd()

--- a/skills/eval-run/scripts/preflight.py
+++ b/skills/eval-run/scripts/preflight.py
@@ -73,9 +73,9 @@ def main():
     args = parser.parse_args()
 
     # Validate run_id / baseline to prevent path traversal (CWE-22)
-    if args.run_id:
+    if args.run_id is not None:
         _validate_path_segment(args.run_id, "--run-id")
-    if args.baseline:
+    if args.baseline is not None:
         _validate_path_segment(args.baseline, "--baseline")
 
     config = EvalConfig.from_yaml(args.config)

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -2478,10 +2478,12 @@ def main():
     # Validate run_id / baseline to prevent path traversal (CWE-22)
     for _arg_name, _arg_val in [("--run-id", args.run_id),
                                 ("--baseline", args.baseline)]:
-        if _arg_val and (not isinstance(_arg_val, str)
-                         or "/" in _arg_val or "\\" in _arg_val
-                         or _arg_val in (".", "..")
-                         or any(ord(c) < 32 for c in _arg_val)):
+        if _arg_val is None:
+            continue
+        if (not isinstance(_arg_val, str) or not _arg_val
+                or "/" in _arg_val or "\\" in _arg_val
+                or _arg_val in (".", "..")
+                or any(ord(c) < 32 for c in _arg_val)):
             print(f"ERROR: {_arg_name} must be a single path segment: {_arg_val!r}",
                   file=sys.stderr)
             sys.exit(1)

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -2475,6 +2475,17 @@ def main():
                       or any(ord(c) < 32 for c in eval_name)):
         print(f"ERROR: invalid skill name: {eval_name!r}", file=sys.stderr)
         sys.exit(1)
+    # Validate run_id / baseline to prevent path traversal (CWE-22)
+    for _arg_name, _arg_val in [("--run-id", args.run_id),
+                                ("--baseline", args.baseline)]:
+        if _arg_val and (not isinstance(_arg_val, str)
+                         or "/" in _arg_val or "\\" in _arg_val
+                         or _arg_val in (".", "..")
+                         or any(ord(c) < 32 for c in _arg_val)):
+            print(f"ERROR: {_arg_name} must be a single path segment: {_arg_val!r}",
+                  file=sys.stderr)
+            sys.exit(1)
+
     runs_base = Path(os.environ.get("AGENT_EVAL_RUNS_DIR", "eval/runs"))
     runs_dir = runs_base / eval_name if eval_name else runs_base
     run_dir = runs_dir / args.run_id

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -28,7 +28,7 @@ from typing import Optional
 
 import yaml
 
-from agent_eval.config import EvalConfig, _is_valid_eval_name
+from agent_eval.config import EvalConfig, _is_valid_eval_name, _validate_path_segment
 
 
 def _get_runs_dir(eval_name: str = ""):
@@ -1695,6 +1695,12 @@ def main():
     reg_p.add_argument("--baseline", default=None)
 
     args = parser.parse_args()
+
+    # Validate run_id / baseline to prevent path traversal (CWE-22)
+    _validate_path_segment(args.run_id, "--run-id")
+    if getattr(args, "baseline", None):
+        _validate_path_segment(args.baseline, "--baseline")
+
     {"judges": cmd_judges, "pairwise": cmd_pairwise,
      "regression": cmd_regression}[args.command](args)
 

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -1698,7 +1698,7 @@ def main():
 
     # Validate run_id / baseline to prevent path traversal (CWE-22)
     _validate_path_segment(args.run_id, "--run-id")
-    if getattr(args, "baseline", None):
+    if getattr(args, "baseline", None) is not None:
         _validate_path_segment(args.baseline, "--baseline")
 
     {"judges": cmd_judges, "pairwise": cmd_pairwise,

--- a/tests/test_path_validation.py
+++ b/tests/test_path_validation.py
@@ -1,0 +1,98 @@
+"""Tests for path segment validation (CWE-22 prevention)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.config import _validate_path_segment, _is_valid_eval_name
+
+
+class TestValidatePathSegment:
+    """Test _validate_path_segment helper."""
+
+    def test_valid_run_ids(self):
+        """Valid timestamp-style run_ids should pass through unchanged."""
+        valid = [
+            "2026-06-01-opus",
+            "test-run-123",
+            "my_eval_run",
+            "run.2026.06.01",
+        ]
+        for value in valid:
+            assert _validate_path_segment(value, "run_id") == value
+
+    def test_rejects_forward_slash(self):
+        with pytest.raises(ValueError, match="path separator"):
+            _validate_path_segment("foo/bar", "run_id")
+
+    def test_rejects_backslash(self):
+        with pytest.raises(ValueError, match="path separator"):
+            _validate_path_segment("foo\\bar", "run_id")
+
+    def test_rejects_parent_directory(self):
+        with pytest.raises(ValueError, match="directory reference"):
+            _validate_path_segment("..", "run_id")
+
+    def test_rejects_current_directory(self):
+        with pytest.raises(ValueError, match="directory reference"):
+            _validate_path_segment(".", "run_id")
+
+    def test_rejects_path_traversal_attack(self):
+        """Classic CWE-22 path traversal attempts."""
+        attacks = [
+            "../../../tmp/evil",
+            "../../etc/passwd",
+            "foo/../bar",
+        ]
+        for attack in attacks:
+            with pytest.raises(ValueError):
+                _validate_path_segment(attack, "run_id")
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            _validate_path_segment("", "run_id")
+
+    def test_rejects_none(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            _validate_path_segment(None, "run_id")
+
+    def test_rejects_control_characters(self):
+        with pytest.raises(ValueError, match="invalid characters"):
+            _validate_path_segment("run\x00id", "run_id")
+
+    def test_error_includes_param_name(self):
+        """Error messages should reference the parameter name."""
+        with pytest.raises(ValueError, match="--run-id"):
+            _validate_path_segment("../evil", "--run-id")
+
+    def test_dotfile_names_allowed(self):
+        """Names starting with dot (but not . or ..) should be allowed."""
+        assert _validate_path_segment(".hidden-run", "run_id") == ".hidden-run"
+
+    def test_consistent_with_is_valid_eval_name(self):
+        """_validate_path_segment should accept exactly what
+        _is_valid_eval_name accepts."""
+        cases = [
+            "valid-name",
+            "2026-06-01-opus",
+            "name_with_underscores",
+            "name.with.dots",
+        ]
+        for case in cases:
+            assert _is_valid_eval_name(case) is True
+            assert _validate_path_segment(case, "test") == case
+
+        invalid = [
+            "../traversal",
+            "has/slash",
+            "has\\backslash",
+            "..",
+            ".",
+        ]
+        for case in invalid:
+            assert _is_valid_eval_name(case) is False
+            with pytest.raises(ValueError):
+                _validate_path_segment(case, "test")


### PR DESCRIPTION
## Summary

- Adds `_validate_path_segment()` helper in `agent_eval/config.py` that delegates to the existing `_is_valid_eval_name()` regex with descriptive error messages
- Refactors existing `config.skill` validation to use the new helper
- Validates `args.run_id` and `args.baseline` in all 5 affected CLI entry points before path construction
- `report.py` uses inline validation to respect its standalone (no `agent_eval` imports) convention

Closes #89

## Description
- `_validate_path_segment` is a private function imported across modules, following the existing pattern (`score.py` already imports `_is_valid_eval_name`). Happy to promote to public API if preferred.
- Also validated `args.baseline` in preflight, score, and report -- same path-construction pattern as `run_id`, not in the original issue but same vulnerability class.

## How Has This Been Tested?
- [x] 12 new tests in `tests/test_path_validation.py` (valid IDs, slashes, traversal attacks, empty/None, control chars, consistency with `_is_valid_eval_name`)
- [x] 20 existing config tests pass (no regressions)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation for run IDs, baseline IDs, and skill names across CLI commands to prevent invalid characters and path traversal attempts. Invalid inputs now produce clear, targeted error messages.

* **Tests**
  * Added comprehensive test coverage for path segment validation logic to ensure security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->