### PR TITLE
fix(harbor): restore project ConfigMap into workspace directory tree

### DIFF
--- a/agent_eval/harbor/kubernetes.py
+++ b/agent_eval/harbor/kubernetes.py
@@ -289,6 +289,30 @@ class KubernetesEnvironment(BaseEnvironment):
         await self._wait_ready(timeout_sec=300)
         self._started = True
         await self._upload_environment_dir_after_start()
+        await self._restore_project_from_configmap()
+
+    async def _restore_project_from_configmap(self) -> None:
+        """Reconstruct project tree from flat ConfigMap after environment upload.
+
+        ConfigMap keys use ``--`` instead of ``/``. This copies them into
+        /workspace with the original directory structure so Claude finds
+        skills at ``.claude/skills/``, scripts at ``scripts/``, etc.
+        """
+        project_mount = os.environ.get("AGENT_EVAL_K8S_PROJECT_MOUNT",
+                                       "/opt/project") \
+            if os.environ.get("AGENT_EVAL_K8S_PROJECT_CONFIGMAP") else None
+        if not project_mount:
+            return
+        cmd = (
+            f'for f in {project_mount}/* {project_mount}/.*; do '
+            '[ -f "$f" ] || continue; '
+            'n=$(basename "$f"); '
+            't=$(echo "$n" | sed "s/--/\\//g"); '
+            'mkdir -p "$(dirname "/workspace/$t")"; '
+            'cp "$f" "/workspace/$t"; '
+            'done'
+        )
+        await self._checked_exec(cmd, "restore project from configmap")
 
     def _delete_pod_quiet(self) -> None:
         try:


### PR DESCRIPTION
## Summary
- After pod startup, reconstruct the project directory tree from the flat ConfigMap mounted at `/opt/project`
- ConfigMap keys use `--` as path separator (e.g., `.claude--skills--rfe.create--SKILL.md`); this restores the original structure under `/workspace`

## Problem
When running Harbor eval cases, the agent pod mounts project files (skills, scripts, CLAUDE.md) via a ConfigMap. But ConfigMap keys are flat — they can't contain `/`. The `create_project_configmap` helper replaces `/` with `--`, but nothing on the pod side restored the original paths. Claude Code couldn't find `.claude/skills/` and skill invocation failed.

## Test plan
- [ ] Run a Harbor eval case that uses project skills (e.g., `rfe.create`) — skills should be discovered and invoked
- [ ] Run without `AGENT_EVAL_K8S_PROJECT_CONFIGMAP` set — no-op, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Kubernetes environment configuration handling to improve project structure restoration during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->