### PR TITLE
feat(harbor): add grpo_reward judge and 
  configurable score range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ Skills projects create an `eval.yaml` config file with:
 - `traces` — execution data to capture: stdout/stderr, events, metrics (exit code, tokens, cost)
 - `judges` — `builtin` reusable judges (from `agent_eval/judges/`), inline `check` scripts, LLM `prompt`/`prompt_file` (Jinja2 rendered), external `module`/`function`. Optional `arguments` dict for parameterization. Optional `if` condition to skip judges per case based on annotations. Judges receive `outputs["annotations"]` from dataset `annotations.yaml`.
 - `thresholds` — per-judge regression detection. Valid keys: `min_mean`, `min_pass_rate`, `min_win_rate`
+- `reward` — optional. Collapses per-judge results into a single scalar in `[0, 1]` for RL training (GRPO). `formula` selects the mode: `weighted` (weighted sum of `weights`), a single `<judge_name>` (normalized via `score_range`; list in `raw` if already `[0, 1]`), or a Python `<expression>` over judge names (allowed calls: `min`/`max`/`abs`/`round`/`sum`/`len`/`mean`). `gate: true` zeros the reward on any false boolean judge — it gates on *every* boolean judge, so expressions using booleans as their own gate want `gate: false`. Expressions are AST-validated and checked at config load. Resolution order: `reward:` section → legacy `grpo_reward` judge → default (boolean gates + averaged normalized numerics).
 
 Runs are stored in `$AGENT_EVAL_RUNS_DIR` (default `eval/runs`), configured during `/eval-setup`.
 

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -563,19 +563,41 @@ class EvalConfig:
             )
 
         # Reward composition
-        reward_raw = raw.get("reward")
-        if reward_raw and isinstance(reward_raw, dict):
+        if "reward" in raw:
+            reward_raw = raw.get("reward")
+            if not isinstance(reward_raw, dict):
+                raise ValueError("reward must be a mapping when provided")
             sr = reward_raw.get("score_range", [1, 5])
             if not isinstance(sr, list) or len(sr) != 2:
                 raise ValueError("reward.score_range must be a [min, max] list")
+            try:
+                score_min = float(sr[0])
+                score_max = float(sr[1])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "reward.score_range values must be numeric") from exc
+            if not score_min < score_max:
+                raise ValueError(
+                    "reward.score_range must be increasing [min, max]")
+            weights = reward_raw.get("weights", {}) or {}
+            if not isinstance(weights, dict):
+                raise ValueError("reward.weights must be a mapping")
+            try:
+                weights = {str(k): float(v) for k, v in weights.items()}
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "reward.weights values must be numeric") from exc
+            gate = reward_raw.get("gate", True)
+            if not isinstance(gate, bool):
+                raise ValueError("reward.gate must be a boolean")
             raw_list = reward_raw.get("raw", []) or []
             if not isinstance(raw_list, list):
                 raw_list = [raw_list]
             config.reward = RewardConfig(
                 formula=str(reward_raw.get("formula", "weighted")),
-                weights=reward_raw.get("weights", {}) or {},
-                gate=bool(reward_raw.get("gate", True)),
-                score_range=[float(sr[0]), float(sr[1])],
+                weights=weights,
+                gate=gate,
+                score_range=[score_min, score_max],
                 raw=[str(r) for r in raw_list],
             )
 

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -302,10 +302,15 @@ class RewardConfig:
 
     Modes (determined by formula value):
     - "weighted": weighted sum of named judges, normalized via score_range.
-    - "<judge_name>": use that single judge's value directly.
+    - "<judge_name>": that single judge's value, normalized via score_range
+      (list it in ``raw`` if it is already in [0, 1]).
     - "<expression>": Python expression with judge names as variables.
 
     When gate is True, any boolean judge that returned False zeros the reward.
+    Note this gates on *every* boolean judge, independent of whether the
+    formula references it — so an ``<expression>`` that uses booleans as its
+    own gate (e.g. ``passed * score``) usually wants ``gate: false`` to avoid
+    double-gating.
     score_range normalizes numeric judge scores to [0, 1].
     raw: list of judge names whose values are already in [0, 1] and should
          NOT be normalized via score_range (e.g. efficiency).
@@ -587,14 +592,29 @@ class EvalConfig:
             except (TypeError, ValueError) as exc:
                 raise ValueError(
                     "reward.weights values must be numeric") from exc
+            if any(v < 0 for v in weights.values()):
+                raise ValueError("reward.weights values must be non-negative")
             gate = reward_raw.get("gate", True)
             if not isinstance(gate, bool):
                 raise ValueError("reward.gate must be a boolean")
             raw_list = reward_raw.get("raw", []) or []
             if not isinstance(raw_list, list):
                 raw_list = [raw_list]
+            formula = str(reward_raw.get("formula", "weighted"))
+            # Validate expression formulas now so a typo or unsafe construct
+            # fails loudly here, not silently as reward 0.0 on every case at
+            # run time. Bare references ("weighted" or a single judge name —
+            # which may legitimately contain dots/dashes) are resolved by name
+            # at compute time, so skip the expression check for them.
+            if not re.fullmatch(r"[A-Za-z_][\w.\-]*", formula.strip()):
+                from agent_eval.harbor.reward import validate_formula
+                try:
+                    validate_formula(formula)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"reward.formula is invalid: {exc}") from exc
             config.reward = RewardConfig(
-                formula=str(reward_raw.get("formula", "weighted")),
+                formula=formula,
                 weights=weights,
                 gate=gate,
                 score_range=[score_min, score_max],

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -297,6 +297,28 @@ class JudgeConfig:
 
 
 @dataclass
+class RewardConfig:
+    """Reward composition from judge results for RL training.
+
+    Modes (determined by formula value):
+    - "weighted": weighted sum of named judges, normalized via score_range.
+    - "<judge_name>": use that single judge's value directly.
+    - "<expression>": Python expression with judge names as variables.
+
+    When gate is True, any boolean judge that returned False zeros the reward.
+    score_range normalizes numeric judge scores to [0, 1].
+    raw: list of judge names whose values are already in [0, 1] and should
+         NOT be normalized via score_range (e.g. efficiency).
+    """
+
+    formula: str = "weighted"
+    weights: dict = field(default_factory=dict)
+    gate: bool = True
+    score_range: list = field(default_factory=lambda: [1, 5])
+    raw: list = field(default_factory=list)
+
+
+@dataclass
 class EvalConfig:
     """Complete evaluation suite configuration.
 
@@ -339,6 +361,9 @@ class EvalConfig:
 
     # Judges (inline checks, LLM, pairwise, external code)
     judges: list = field(default_factory=list)
+
+    # Reward composition for RL training (optional)
+    reward: Optional[RewardConfig] = None
 
     # Regression thresholds
     thresholds: dict = field(default_factory=dict)
@@ -535,6 +560,23 @@ class EvalConfig:
                     arguments=args_val,
                     samples=int(j.get("samples", 1)),
                 )
+            )
+
+        # Reward composition
+        reward_raw = raw.get("reward")
+        if reward_raw and isinstance(reward_raw, dict):
+            sr = reward_raw.get("score_range", [1, 5])
+            if not isinstance(sr, list) or len(sr) != 2:
+                raise ValueError("reward.score_range must be a [min, max] list")
+            raw_list = reward_raw.get("raw", []) or []
+            if not isinstance(raw_list, list):
+                raw_list = [raw_list]
+            config.reward = RewardConfig(
+                formula=str(reward_raw.get("formula", "weighted")),
+                weights=reward_raw.get("weights", {}) or {},
+                gate=bool(reward_raw.get("gate", True)),
+                score_range=[float(sr[0]), float(sr[1])],
+                raw=[str(r) for r in raw_list],
             )
 
         # Thresholds

--- a/agent_eval/harbor/reward.py
+++ b/agent_eval/harbor/reward.py
@@ -46,13 +46,19 @@ _GRPO_REWARD_JUDGE = "grpo_reward"
 _SAFE_AST_NODES = (
     ast.Module, ast.Expr, ast.Expression, ast.Assign,
     ast.BinOp, ast.UnaryOp, ast.Compare,
-    ast.Add, ast.Sub, ast.Mult, ast.Div, ast.FloorDiv, ast.Mod, ast.Pow,
+    ast.Add, ast.Sub, ast.Mult, ast.Div, ast.FloorDiv, ast.Mod,
     ast.USub, ast.UAdd,
     ast.Gt, ast.GtE, ast.Lt, ast.LtE, ast.Eq, ast.NotEq,
     ast.Constant, ast.Name, ast.Load, ast.Store,
     ast.Call, ast.List, ast.Tuple,
     ast.IfExp, ast.BoolOp, ast.And, ast.Or,
 )
+# ast.Pow (**) is intentionally excluded: integer exponentiation is the cheap
+# path to a CPU/memory blow-up (e.g. 2 ** 10**9) and reward formulas never need
+# it. Reward formulas are bounded numeric arithmetic, so cap overall size and
+# literal magnitude as defence-in-depth even though eval.yaml is trusted config.
+_MAX_FORMULA_NODES = 200
+_MAX_CONSTANT_ABS = 1e6
 
 # Functions callable from within a reward formula expression. The keys double
 # as the allow-list of permitted call names during AST validation.
@@ -78,8 +84,46 @@ def _validate_ast(node: ast.AST, allowed_calls: set[str]) -> None:
         if node.id.startswith('_'):
             raise ValueError(
                 f"Disallowed variable name: {node.id}")
+    if isinstance(node, ast.Constant):
+        v = node.value
+        if isinstance(v, bool) or v is None:
+            pass  # bool/None are fine (e.g. ternary fallbacks)
+        elif isinstance(v, (int, float)):
+            if abs(v) > _MAX_CONSTANT_ABS:
+                raise ValueError(f"Constant magnitude too large: {v}")
+        else:
+            # Reject str/bytes constants — they have no place in numeric
+            # arithmetic and enable repetition blow-ups (e.g. "x" * 10**6).
+            raise ValueError(
+                f"Disallowed constant type: {type(v).__name__}")
     for child in ast.iter_child_nodes(node):
         _validate_ast(child, allowed_calls)
+
+
+def _parse_and_validate(formula: str, allowed_calls: set[str]) -> ast.Module:
+    """Parse a formula and reject anything outside the safe subset.
+
+    Enforces: parses cleanly, stays under the node-count cap, uses only
+    allow-listed AST nodes/calls/constants, and ends in an expression (the
+    return value). Returns the parsed module for evaluation.
+    """
+    try:
+        tree = ast.parse(formula.strip(), mode="exec")
+    except SyntaxError as exc:
+        raise ValueError(f"could not parse formula: {exc}") from exc
+    node_count = sum(1 for _ in ast.walk(tree))
+    if node_count > _MAX_FORMULA_NODES:
+        raise ValueError(
+            f"reward formula too complex ({node_count} nodes > "
+            f"{_MAX_FORMULA_NODES})")
+    _validate_ast(tree, allowed_calls)
+    if not tree.body:
+        raise ValueError("Empty reward formula")
+    if not isinstance(tree.body[-1], ast.Expr):
+        raise ValueError(
+            "Last line of reward formula must be an expression "
+            "(the return value), not an assignment")
+    return tree
 
 
 def _safe_eval_formula(formula: str, variables: dict[str, float],
@@ -90,18 +134,8 @@ def _safe_eval_formula(formula: str, variables: dict[str, float],
     last must be assignments. The last statement must be an expression
     whose value is returned as the reward.
     """
-    allowed_calls = set(safe_funcs.keys())
-    tree = ast.parse(formula.strip(), mode="exec")
-    _validate_ast(tree, allowed_calls)
-
-    if not tree.body:
-        raise ValueError("Empty reward formula")
-
+    tree = _parse_and_validate(formula, set(safe_funcs.keys()))
     last_stmt = tree.body[-1]
-    if not isinstance(last_stmt, ast.Expr):
-        raise ValueError(
-            "Last line of reward formula must be an expression "
-            "(the return value), not an assignment")
 
     ns = {**variables, **safe_funcs}
 
@@ -124,19 +158,11 @@ def validate_formula(formula: str) -> None:
     disallowed construct/function, or does not end in an expression. Called at
     config-load time (see ``EvalConfig.from_yaml``) so a malformed or unsafe
     formula fails loudly there instead of silently yielding reward 0.0 on
-    every case during a run.
+    every case during a run. Note this validates structure only; runtime
+    failures (e.g. an undefined judge name, division by zero) are still
+    caught at evaluation time and degrade to reward 0.0 with a warning.
     """
-    try:
-        tree = ast.parse(formula.strip(), mode="exec")
-    except SyntaxError as exc:
-        raise ValueError(f"could not parse formula: {exc}") from exc
-    _validate_ast(tree, set(_SAFE_FUNCS))
-    if not tree.body:
-        raise ValueError("Empty reward formula")
-    if not isinstance(tree.body[-1], ast.Expr):
-        raise ValueError(
-            "Last line of reward formula must be an expression "
-            "(the return value), not an assignment")
+    _parse_and_validate(formula, set(_SAFE_FUNCS))
 
 
 # Harbor's canonical verifier output directory inside the container.

--- a/agent_eval/harbor/reward.py
+++ b/agent_eval/harbor/reward.py
@@ -34,12 +34,79 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+import ast
+
 from agent_eval.config import EvalConfig, RewardConfig
 
 _SCORE_MIN_DEFAULT = 1.0
 _SCORE_MAX_DEFAULT = 5.0
 
 _GRPO_REWARD_JUDGE = "grpo_reward"
+
+_SAFE_AST_NODES = (
+    ast.Module, ast.Expr, ast.Expression, ast.Assign,
+    ast.BinOp, ast.UnaryOp, ast.Compare,
+    ast.Add, ast.Sub, ast.Mult, ast.Div, ast.FloorDiv, ast.Mod, ast.Pow,
+    ast.USub, ast.UAdd,
+    ast.Gt, ast.GtE, ast.Lt, ast.LtE, ast.Eq, ast.NotEq,
+    ast.Constant, ast.Name, ast.Load, ast.Store,
+    ast.Call, ast.List, ast.Tuple,
+    ast.IfExp, ast.BoolOp, ast.And, ast.Or,
+)
+
+
+def _validate_ast(node: ast.AST, allowed_calls: set[str]) -> None:
+    """Walk AST and reject any node not in the safe allowlist."""
+    if not isinstance(node, _SAFE_AST_NODES):
+        raise ValueError(
+            f"Disallowed expression node: {type(node).__name__}")
+    if isinstance(node, ast.Call):
+        if not (isinstance(node.func, ast.Name)
+                and node.func.id in allowed_calls):
+            func_name = getattr(node.func, 'id', '?')
+            raise ValueError(
+                f"Disallowed function call: {func_name}")
+    if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+        if node.id.startswith('_'):
+            raise ValueError(
+                f"Disallowed variable name: {node.id}")
+    for child in ast.iter_child_nodes(node):
+        _validate_ast(child, allowed_calls)
+
+
+def _safe_eval_formula(formula: str, variables: dict[str, float],
+                       safe_funcs: dict) -> float:
+    """Evaluate a reward formula using AST validation (no raw exec/eval).
+
+    The formula is parsed as a Python module. All statements except the
+    last must be assignments. The last statement must be an expression
+    whose value is returned as the reward.
+    """
+    allowed_calls = set(safe_funcs.keys())
+    tree = ast.parse(formula.strip(), mode="exec")
+    _validate_ast(tree, allowed_calls)
+
+    if not tree.body:
+        raise ValueError("Empty reward formula")
+
+    last_stmt = tree.body[-1]
+    if not isinstance(last_stmt, ast.Expr):
+        raise ValueError(
+            "Last line of reward formula must be an expression "
+            "(the return value), not an assignment")
+
+    ns = {**variables, **safe_funcs}
+
+    if len(tree.body) > 1:
+        setup = ast.Module(body=tree.body[:-1], type_ignores=[])
+        ast.fix_missing_locations(setup)
+        code = compile(setup, "<reward>", "exec")
+        exec(code, {"__builtins__": {}}, ns)  # noqa: S102 — AST-validated
+
+    expr = ast.Expression(body=last_stmt.value)
+    ast.fix_missing_locations(expr)
+    code = compile(expr, "<reward>", "eval")
+    return eval(code, {"__builtins__": {}}, ns)  # noqa: S307 — AST-validated
 
 # Harbor's canonical verifier output directory inside the container.
 _DEFAULT_OUT_DIR = "/logs/verifier"
@@ -151,7 +218,7 @@ def compute_reward_from_config(per_judge: dict,
             if jv is not None:
                 total += float(weight) * jv
                 weight_sum += float(weight)
-        return max(0.0, min(1.0, total)) if weight_sum > 0 else 0.0
+        return max(0.0, min(1.0, total / weight_sum)) if weight_sum > 0 else 0.0
 
     if formula in per_judge:
         rec = per_judge[formula]
@@ -166,21 +233,13 @@ def compute_reward_from_config(per_judge: dict,
         if jv is not None:
             judge_vars[name] = jv
 
-    safe_builtins = {
+    safe_funcs = {
         "min": min, "max": max, "abs": abs, "round": round,
         "sum": sum, "len": len,
         "mean": lambda xs: sum(xs) / len(xs) if xs else 0.0,
     }
     try:
-        ns = {**judge_vars, **safe_builtins}
-        lines = [l for l in formula.splitlines() if l.strip()]
-        if len(lines) > 1:
-            exec(compile("\n".join(lines[:-1]), "<reward>", "exec"),
-                 {"__builtins__": safe_builtins}, ns)
-            result = eval(compile(lines[-1].strip(), "<reward>", "eval"),
-                          {"__builtins__": {}}, ns)
-        else:
-            result = eval(formula, {"__builtins__": {}}, ns)
+        result = _safe_eval_formula(formula, judge_vars, safe_funcs)
         return max(0.0, min(1.0, float(result)))
     except Exception as exc:
         import sys
@@ -248,13 +307,7 @@ def build_reward(config: EvalConfig, case_dir: Path,
 
     reward_cfg = getattr(config, "reward", None)
 
-    score_range = getattr(config, "score_range", None) or {}
-    score_min = float(score_range.get("min", _SCORE_MIN_DEFAULT))
-    score_max = float(score_range.get("max", _SCORE_MAX_DEFAULT))
-
-    reward, metrics = compose_reward(per_judge,
-                                     score_min=score_min, score_max=score_max,
-                                     reward_cfg=reward_cfg)
+    reward, metrics = compose_reward(per_judge, reward_cfg=reward_cfg)
     return {"reward": reward, "metrics": metrics, "per_judge": per_judge}
 
 

--- a/agent_eval/harbor/reward.py
+++ b/agent_eval/harbor/reward.py
@@ -11,12 +11,14 @@ container, the verifier (``tests/test.sh``) calls this module, which reuses
 the same engine the local ``/eval-run`` path uses — so per-case grading is
 identical whether run locally or in a Harbor trial.
 
-Reward composition (default, configurable):
-- Boolean judges (inline ``check`` + bool LLM judges) are GATES: if any fails,
-  the overall ``reward`` is 0.0.
-- Numeric judges (score LLM judges, 1-5) are normalized to 0-1 via
-  ``(score - 1) / 4`` and averaged.
-- If all gates pass and there are no numeric judges, ``reward`` is 1.0.
+Reward composition:
+- If a ``grpo_reward`` judge exists in the eval config, its value is used
+  directly as the overall reward. This lets the eval.yaml define the full
+  aggregation formula (weighted layers, gating, efficiency) in one place.
+- Otherwise falls back to the legacy default: boolean judges are GATES
+  (any fail -> 0.0), numeric judges (1-N) are normalized and averaged.
+- Score range is auto-detected from the eval config (``score_range`` field)
+  or defaults to 1-5 for backward compatibility.
 
 Pairwise comparison and regression thresholds are SUITE-level (need >=2 runs /
 the full set) and stay above Harbor — they are not computed here.
@@ -35,10 +37,14 @@ from typing import Optional
 
 from agent_eval.config import EvalConfig
 
-# Numeric LLM judges emit an integer score in this inclusive range
-# (see _SCORE_JUDGE_TOOL in score.py). Used to normalize to 0-1.
-_SCORE_MIN = 1.0
-_SCORE_MAX = 5.0
+# Legacy default score range for backward compatibility.
+# Overridden when a grpo_reward judge handles aggregation, or when
+# the eval config specifies a different range.
+_SCORE_MIN_DEFAULT = 1.0
+_SCORE_MAX_DEFAULT = 5.0
+
+# Judge name that, when present, provides the pre-aggregated reward.
+_GRPO_REWARD_JUDGE = "grpo_reward"
 
 # Harbor's canonical verifier output directory inside the container.
 _DEFAULT_OUT_DIR = "/logs/verifier"
@@ -80,30 +86,52 @@ def score_case(config: EvalConfig, case_dir: Path,
     return result.get("per_case", {}).get(case_dir.name, {})
 
 
-def compose_reward(per_judge: dict) -> tuple[float, dict]:
+def compose_reward(per_judge: dict, *,
+                   score_min: float = _SCORE_MIN_DEFAULT,
+                   score_max: float = _SCORE_MAX_DEFAULT) -> tuple[float, dict]:
     """Collapse per-judge results into an overall reward + flat metric dict.
 
     Returns ``(reward, metrics)`` where ``metrics`` maps each judge name to a
     number (bool -> 1.0/0.0, numeric -> raw score). Judges that were skipped
     (condition false) or errored have ``value is None`` and are recorded with
     no value rather than gated on.
+
+    If a ``grpo_reward`` judge is present and produced a numeric value, that
+    value is used directly as the reward (it already encodes gating, weighted
+    aggregation, and efficiency). Individual judge scores are still recorded
+    in metrics for diagnostics.
     """
-    gate_ok = True
-    normalized_scores: list[float] = []
     metrics: dict[str, float] = {}
 
     for name, rec in per_judge.items():
         value = rec.get("value")
         if value is None:
-            continue  # skipped or errored — don't gate, don't average
+            continue
         if isinstance(value, bool):
             metrics[name] = 1.0 if value else 0.0
-            if not value:
-                gate_ok = False
         elif isinstance(value, (int, float)):
             metrics[name] = float(value)
-            span = _SCORE_MAX - _SCORE_MIN
-            norm = (float(value) - _SCORE_MIN) / span if span else 0.0
+
+    grpo_rec = per_judge.get(_GRPO_REWARD_JUDGE, {})
+    grpo_val = grpo_rec.get("value")
+    if grpo_val is not None and isinstance(grpo_val, (int, float)):
+        reward = max(0.0, min(1.0, float(grpo_val)))
+        return reward, metrics
+
+    gate_ok = True
+    normalized_scores: list[float] = []
+
+    for name, rec in per_judge.items():
+        if name == _GRPO_REWARD_JUDGE:
+            continue
+        value = rec.get("value")
+        if value is None:
+            continue
+        if isinstance(value, bool) and not value:
+            gate_ok = False
+        elif isinstance(value, (int, float)) and not isinstance(value, bool):
+            span = score_max - score_min
+            norm = (float(value) - score_min) / span if span else 0.0
             normalized_scores.append(max(0.0, min(1.0, norm)))
 
     if not gate_ok:
@@ -123,7 +151,13 @@ def build_reward(config: EvalConfig, case_dir: Path,
     the full ``per_judge`` detail (value + rationale) for the sidecar.
     """
     per_judge = score_case(config, case_dir, run_id=run_id)
-    reward, metrics = compose_reward(per_judge)
+
+    score_range = getattr(config, "score_range", None) or {}
+    score_min = float(score_range.get("min", _SCORE_MIN_DEFAULT))
+    score_max = float(score_range.get("max", _SCORE_MAX_DEFAULT))
+
+    reward, metrics = compose_reward(per_judge,
+                                     score_min=score_min, score_max=score_max)
     return {"reward": reward, "metrics": metrics, "per_judge": per_judge}
 
 

--- a/agent_eval/harbor/reward.py
+++ b/agent_eval/harbor/reward.py
@@ -54,6 +54,14 @@ _SAFE_AST_NODES = (
     ast.IfExp, ast.BoolOp, ast.And, ast.Or,
 )
 
+# Functions callable from within a reward formula expression. The keys double
+# as the allow-list of permitted call names during AST validation.
+_SAFE_FUNCS = {
+    "min": min, "max": max, "abs": abs, "round": round,
+    "sum": sum, "len": len,
+    "mean": lambda xs: sum(xs) / len(xs) if xs else 0.0,
+}
+
 
 def _validate_ast(node: ast.AST, allowed_calls: set[str]) -> None:
     """Walk AST and reject any node not in the safe allowlist."""
@@ -107,6 +115,29 @@ def _safe_eval_formula(formula: str, variables: dict[str, float],
     ast.fix_missing_locations(expr)
     code = compile(expr, "<reward>", "eval")
     return eval(code, {"__builtins__": {}}, ns)  # noqa: S307 — AST-validated
+
+
+def validate_formula(formula: str) -> None:
+    """Parse and AST-validate a reward formula without evaluating it.
+
+    Raises ``ValueError`` if the formula is syntactically invalid, uses a
+    disallowed construct/function, or does not end in an expression. Called at
+    config-load time (see ``EvalConfig.from_yaml``) so a malformed or unsafe
+    formula fails loudly there instead of silently yielding reward 0.0 on
+    every case during a run.
+    """
+    try:
+        tree = ast.parse(formula.strip(), mode="exec")
+    except SyntaxError as exc:
+        raise ValueError(f"could not parse formula: {exc}") from exc
+    _validate_ast(tree, set(_SAFE_FUNCS))
+    if not tree.body:
+        raise ValueError("Empty reward formula")
+    if not isinstance(tree.body[-1], ast.Expr):
+        raise ValueError(
+            "Last line of reward formula must be an expression "
+            "(the return value), not an assignment")
+
 
 # Harbor's canonical verifier output directory inside the container.
 _DEFAULT_OUT_DIR = "/logs/verifier"
@@ -194,7 +225,8 @@ def compute_reward_from_config(per_judge: dict,
 
     Supports three formula modes:
     - "weighted": weighted sum of named judges
-    - single judge name: use that judge's value directly
+    - single judge name: that judge's value, normalized via score_range
+      (list it in ``raw`` if it is already in [0, 1])
     - expression: Python expression with judge names as variables
     """
     score_range = reward_cfg.score_range
@@ -221,11 +253,8 @@ def compute_reward_from_config(per_judge: dict,
         return max(0.0, min(1.0, total / weight_sum)) if weight_sum > 0 else 0.0
 
     if formula in per_judge:
-        rec = per_judge[formula]
-        val = rec.get("value")
-        if isinstance(val, (int, float)):
-            return max(0.0, min(1.0, float(val)))
-        return 0.0
+        jv = _judge_value(per_judge, formula, score_range, raw_judges)
+        return jv if jv is not None else 0.0
 
     judge_vars: dict[str, float] = {}
     for name, rec in per_judge.items():
@@ -233,16 +262,10 @@ def compute_reward_from_config(per_judge: dict,
         if jv is not None:
             judge_vars[name] = jv
 
-    safe_funcs = {
-        "min": min, "max": max, "abs": abs, "round": round,
-        "sum": sum, "len": len,
-        "mean": lambda xs: sum(xs) / len(xs) if xs else 0.0,
-    }
     try:
-        result = _safe_eval_formula(formula, judge_vars, safe_funcs)
+        result = _safe_eval_formula(formula, judge_vars, _SAFE_FUNCS)
         return max(0.0, min(1.0, float(result)))
     except Exception as exc:
-        import sys
         print(f"Warning: reward formula evaluation failed: {exc}",
               file=sys.stderr)
         return 0.0

--- a/agent_eval/harbor/reward.py
+++ b/agent_eval/harbor/reward.py
@@ -11,14 +11,13 @@ container, the verifier (``tests/test.sh``) calls this module, which reuses
 the same engine the local ``/eval-run`` path uses — so per-case grading is
 identical whether run locally or in a Harbor trial.
 
-Reward composition:
-- If a ``grpo_reward`` judge exists in the eval config, its value is used
-  directly as the overall reward. This lets the eval.yaml define the full
-  aggregation formula (weighted layers, gating, efficiency) in one place.
-- Otherwise falls back to the legacy default: boolean judges are GATES
-  (any fail -> 0.0), numeric judges (1-N) are normalized and averaged.
-- Score range is auto-detected from the eval config (``score_range`` field)
-  or defaults to 1-5 for backward compatibility.
+Reward composition (resolution order):
+1. If a ``reward:`` section exists in eval.yaml, use its formula/weights
+   to compose the reward from judge results. Supports ``weighted``,
+   single judge reference, or Python expression modes.
+2. If a ``grpo_reward`` judge exists (legacy), use its value directly.
+3. Otherwise: boolean judges gate (any fail -> 0.0), numeric judges
+   normalized to [0,1] and averaged.
 
 Pairwise comparison and regression thresholds are SUITE-level (need >=2 runs /
 the full set) and stay above Harbor — they are not computed here.
@@ -35,15 +34,11 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from agent_eval.config import EvalConfig
+from agent_eval.config import EvalConfig, RewardConfig
 
-# Legacy default score range for backward compatibility.
-# Overridden when a grpo_reward judge handles aggregation, or when
-# the eval config specifies a different range.
 _SCORE_MIN_DEFAULT = 1.0
 _SCORE_MAX_DEFAULT = 5.0
 
-# Judge name that, when present, provides the pre-aggregated reward.
 _GRPO_REWARD_JUDGE = "grpo_reward"
 
 # Harbor's canonical verifier output directory inside the container.
@@ -86,23 +81,9 @@ def score_case(config: EvalConfig, case_dir: Path,
     return result.get("per_case", {}).get(case_dir.name, {})
 
 
-def compose_reward(per_judge: dict, *,
-                   score_min: float = _SCORE_MIN_DEFAULT,
-                   score_max: float = _SCORE_MAX_DEFAULT) -> tuple[float, dict]:
-    """Collapse per-judge results into an overall reward + flat metric dict.
-
-    Returns ``(reward, metrics)`` where ``metrics`` maps each judge name to a
-    number (bool -> 1.0/0.0, numeric -> raw score). Judges that were skipped
-    (condition false) or errored have ``value is None`` and are recorded with
-    no value rather than gated on.
-
-    If a ``grpo_reward`` judge is present and produced a numeric value, that
-    value is used directly as the reward (it already encodes gating, weighted
-    aggregation, and efficiency). Individual judge scores are still recorded
-    in metrics for diagnostics.
-    """
+def _extract_metrics(per_judge: dict) -> dict[str, float]:
+    """Build flat metric dict from per-judge results."""
     metrics: dict[str, float] = {}
-
     for name, rec in per_judge.items():
         value = rec.get("value")
         if value is None:
@@ -111,6 +92,119 @@ def compose_reward(per_judge: dict, *,
             metrics[name] = 1.0 if value else 0.0
         elif isinstance(value, (int, float)):
             metrics[name] = float(value)
+    return metrics
+
+
+def _normalize(value: float, score_range: list[float]) -> float:
+    """Normalize a score to [0, 1] given a [min, max] range."""
+    lo, hi = score_range
+    span = hi - lo
+    if span <= 0:
+        return 0.0
+    return max(0.0, min(1.0, (value - lo) / span))
+
+
+def _judge_value(per_judge: dict, name: str,
+                 score_range: list[float],
+                 raw_judges: list[str] = ()) -> Optional[float]:
+    """Extract a judge's value as a float in [0, 1]."""
+    rec = per_judge.get(name, {})
+    val = rec.get("value")
+    if val is None:
+        return None
+    if isinstance(val, bool):
+        return 1.0 if val else 0.0
+    if isinstance(val, (int, float)):
+        if name in raw_judges:
+            return max(0.0, min(1.0, float(val)))
+        return _normalize(float(val), score_range)
+    return None
+
+
+def compute_reward_from_config(per_judge: dict,
+                               reward_cfg: RewardConfig) -> float:
+    """Compute reward using the eval.yaml reward: section.
+
+    Supports three formula modes:
+    - "weighted": weighted sum of named judges
+    - single judge name: use that judge's value directly
+    - expression: Python expression with judge names as variables
+    """
+    score_range = reward_cfg.score_range
+    raw_judges = reward_cfg.raw
+
+    if reward_cfg.gate:
+        for name, rec in per_judge.items():
+            val = rec.get("value")
+            if isinstance(val, bool) and not val:
+                return 0.0
+
+    formula = reward_cfg.formula.strip()
+
+    if formula == "weighted":
+        if not reward_cfg.weights:
+            return 0.0
+        total = 0.0
+        weight_sum = 0.0
+        for judge_name, weight in reward_cfg.weights.items():
+            jv = _judge_value(per_judge, judge_name, score_range, raw_judges)
+            if jv is not None:
+                total += float(weight) * jv
+                weight_sum += float(weight)
+        return max(0.0, min(1.0, total)) if weight_sum > 0 else 0.0
+
+    if formula in per_judge:
+        rec = per_judge[formula]
+        val = rec.get("value")
+        if isinstance(val, (int, float)):
+            return max(0.0, min(1.0, float(val)))
+        return 0.0
+
+    judge_vars: dict[str, float] = {}
+    for name, rec in per_judge.items():
+        jv = _judge_value(per_judge, name, score_range, raw_judges)
+        if jv is not None:
+            judge_vars[name] = jv
+
+    safe_builtins = {
+        "min": min, "max": max, "abs": abs, "round": round,
+        "sum": sum, "len": len,
+        "mean": lambda xs: sum(xs) / len(xs) if xs else 0.0,
+    }
+    try:
+        ns = {**judge_vars, **safe_builtins}
+        lines = [l for l in formula.splitlines() if l.strip()]
+        if len(lines) > 1:
+            exec(compile("\n".join(lines[:-1]), "<reward>", "exec"),
+                 {"__builtins__": safe_builtins}, ns)
+            result = eval(compile(lines[-1].strip(), "<reward>", "eval"),
+                          {"__builtins__": {}}, ns)
+        else:
+            result = eval(formula, {"__builtins__": {}}, ns)
+        return max(0.0, min(1.0, float(result)))
+    except Exception as exc:
+        import sys
+        print(f"Warning: reward formula evaluation failed: {exc}",
+              file=sys.stderr)
+        return 0.0
+
+
+def compose_reward(per_judge: dict, *,
+                   score_min: float = _SCORE_MIN_DEFAULT,
+                   score_max: float = _SCORE_MAX_DEFAULT,
+                   reward_cfg: Optional[RewardConfig] = None) -> tuple[float, dict]:
+    """Collapse per-judge results into an overall reward + flat metric dict.
+
+    Resolution order:
+    1. If reward_cfg is provided (from eval.yaml reward: section), use it.
+    2. If a grpo_reward judge exists (legacy), use its value directly.
+    3. Otherwise fall back to: boolean gates + average of normalized numerics.
+    """
+    metrics = _extract_metrics(per_judge)
+
+    if reward_cfg is not None:
+        reward = compute_reward_from_config(per_judge, reward_cfg)
+        return reward, metrics
 
     grpo_rec = per_judge.get(_GRPO_REWARD_JUDGE, {})
     grpo_val = grpo_rec.get("value")
@@ -152,12 +246,15 @@ def build_reward(config: EvalConfig, case_dir: Path,
     """
     per_judge = score_case(config, case_dir, run_id=run_id)
 
+    reward_cfg = getattr(config, "reward", None)
+
     score_range = getattr(config, "score_range", None) or {}
     score_min = float(score_range.get("min", _SCORE_MIN_DEFAULT))
     score_max = float(score_range.get("max", _SCORE_MAX_DEFAULT))
 
     reward, metrics = compose_reward(per_judge,
-                                     score_min=score_min, score_max=score_max)
+                                     score_min=score_min, score_max=score_max,
+                                     reward_cfg=reward_cfg)
     return {"reward": reward, "metrics": metrics, "per_judge": per_judge}
 
 

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -266,10 +266,11 @@ reward:
 ```
 
 Resolution order at scoring time: (1) a `reward:` section if present, else
-(2) a judge literally named `grpo_reward` (its value is used directly, legacy),
-else (3) the default — boolean judges gate, numeric judges are normalized and
-averaged. Invalid expression formulas are rejected at config load, not silently
-scored as 0.0.
+(2) a judge literally named `grpo_reward` (its numeric value is clamped to
+[0, 1], legacy), else (3) the default — boolean judges gate, numeric judges are
+normalized and averaged. Syntax- or AST-invalid formulas are rejected at config
+load; evaluation-time errors (e.g. an undefined judge name) still warn and
+return 0.0.
 
 ## Writing Good Schema Descriptions
 

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -239,7 +239,37 @@ thresholds:
   <judge_name>:
     min_pass_rate: 1.0     # for boolean judges (check, builtin)
     # min_mean: 3.5        # for numeric judges (llm)
+
+# Reward composition (OPTIONAL) — collapse per-judge results into a single
+# scalar in [0, 1] for RL training (GRPO). Only needed when training; the
+# normal /eval-run report path does not require it.
+reward:
+  # formula selects the mode:
+  #   "weighted"      weighted sum of the judges named in `weights`
+  #   "<judge_name>"  a single judge's value (normalized via score_range;
+  #                   list it in `raw` if it is already in [0, 1])
+  #   "<expression>"  a Python expression over judge names as variables,
+  #                   e.g. "0.6 * quality + 0.4 * efficiency".
+  #                   Allowed calls: min, max, abs, round, sum, len, mean.
+  #                   Multi-line is allowed; the last line is the result.
+  formula: weighted
+  weights:                 # used only by the "weighted" formula
+    quality: 0.7
+    efficiency: 0.3
+  score_range: [1, 5]      # numeric judge range, normalized to [0, 1]
+  raw: [efficiency]        # judges already in [0, 1] — skip normalization
+  gate: true               # any boolean judge returning false zeros the reward.
+                           # Gates on EVERY boolean judge regardless of the
+                           # formula — for an expression that uses booleans as
+                           # its own gate (e.g. "passed * quality"), set
+                           # gate: false to avoid double-gating.
 ```
+
+Resolution order at scoring time: (1) a `reward:` section if present, else
+(2) a judge literally named `grpo_reward` (its value is used directly, legacy),
+else (3) the default — boolean judges gate, numeric judges are normalized and
+averaged. Invalid expression formulas are rejected at config load, not silently
+scored as 0.0.
 
 ## Writing Good Schema Descriptions
 

--- a/tests/test_harbor_reward.py
+++ b/tests/test_harbor_reward.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from agent_eval.config import EvalConfig
+from agent_eval.config import EvalConfig, RewardConfig
 from agent_eval.harbor import reward as reward_mod
 
 
@@ -59,6 +59,46 @@ def test_compose_reward_ignores_skipped_and_errored():
     assert reward == 1.0           # None values neither gate nor average
     assert "skipped" not in metrics
     assert "errored" not in metrics
+
+
+def test_compose_reward_grpo_reward_takes_precedence():
+    """When a grpo_reward judge is present, its value is used directly."""
+    per_judge = {
+        "files_exist": {"value": True, "judge_type": "check"},
+        "frontmatter_valid": {"value": False, "judge_type": "check"},
+        "rfe_quality": {"value": 7, "judge_type": "llm"},
+        "grpo_reward": {"value": 0.73, "judge_type": "check"},
+    }
+    reward, metrics = reward_mod.compose_reward(per_judge)
+    assert reward == pytest.approx(0.73)
+    assert metrics["grpo_reward"] == pytest.approx(0.73)
+    assert metrics["frontmatter_valid"] == 0.0
+
+
+def test_compose_reward_grpo_reward_clamped():
+    """grpo_reward values outside [0, 1] are clamped."""
+    per_judge = {
+        "grpo_reward": {"value": 1.5, "judge_type": "check"},
+    }
+    reward, _ = reward_mod.compose_reward(per_judge)
+    assert reward == 1.0
+
+    per_judge_neg = {
+        "grpo_reward": {"value": -0.2, "judge_type": "check"},
+    }
+    reward_neg, _ = reward_mod.compose_reward(per_judge_neg)
+    assert reward_neg == 0.0
+
+
+def test_compose_reward_grpo_reward_none_falls_back():
+    """If grpo_reward has value=None, fall back to legacy averaging."""
+    per_judge = {
+        "ok": {"value": True, "judge_type": "check"},
+        "rfe_quality": {"value": 5, "judge_type": "llm"},
+        "grpo_reward": {"value": None, "judge_type": "check"},
+    }
+    reward, metrics = reward_mod.compose_reward(per_judge)
+    assert reward == pytest.approx(1.0)  # score 5 -> normalized 1.0 on 1-5 scale
 
 
 # --- end-to-end with inline check judges -------------------------------------
@@ -135,3 +175,192 @@ def test_build_reward_failing_check_zeroes_reward(tmp_path):
     payload = reward_mod.build_reward(config, case_dir)
     assert payload["reward"] == 0.0
     assert payload["metrics"]["requires_missing"] == 0.0
+
+
+# --- RewardConfig: weighted mode ---------------------------------------------
+
+def test_reward_weighted_basic():
+    per_judge = {
+        "a": {"value": 5},
+        "b": {"value": 3},
+    }
+    cfg = RewardConfig(
+        formula="weighted",
+        weights={"a": 0.7, "b": 0.3},
+        gate=False,
+        score_range=[1, 5],
+    )
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    expected = (0.7 * 1.0 + 0.3 * 0.5) / 1.0
+    assert r == pytest.approx(expected)
+
+
+def test_reward_weighted_normalizes_by_weight_sum():
+    """Weights that don't sum to 1.0 are still normalized."""
+    per_judge = {"a": {"value": 5}, "b": {"value": 5}}
+    cfg = RewardConfig(
+        formula="weighted",
+        weights={"a": 1.0, "b": 1.0},
+        gate=False,
+        score_range=[1, 5],
+    )
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    assert r == pytest.approx(1.0)
+
+
+def test_reward_weighted_gate_zeros():
+    per_judge = {
+        "gate": {"value": False},
+        "score": {"value": 5},
+    }
+    cfg = RewardConfig(
+        formula="weighted",
+        weights={"score": 1.0},
+        gate=True,
+        score_range=[1, 5],
+    )
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    assert r == 0.0
+
+
+# --- RewardConfig: expression mode -------------------------------------------
+
+def test_reward_expression_simple():
+    per_judge = {"x": {"value": 3}, "y": {"value": 5}}
+    cfg = RewardConfig(
+        formula="0.5 * x + 0.5 * y",
+        gate=False,
+        score_range=[1, 5],
+    )
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    assert r == pytest.approx(0.5 * 0.5 + 0.5 * 1.0)
+
+
+def test_reward_expression_multiline():
+    per_judge = {
+        "a": {"value": True},
+        "b": {"value": False},
+        "score": {"value": 4},
+    }
+    formula = "gate = mean([a, b])\ngate * score"
+    cfg = RewardConfig(formula=formula, gate=False, score_range=[1, 5])
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    expected = 0.5 * 0.75  # mean([1.0, 0.0]) * (4-1)/(5-1)
+    assert r == pytest.approx(expected)
+
+
+def test_reward_expression_raw_judges():
+    """Judges in the raw list skip score_range normalization."""
+    per_judge = {"eff": {"value": 0.5}, "score": {"value": 4}}
+    cfg = RewardConfig(
+        formula="0.5 * score + 0.5 * eff",
+        gate=False,
+        score_range=[1, 5],
+        raw=["eff"],
+    )
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    expected = 0.5 * 0.75 + 0.5 * 0.5  # score normalized, eff raw
+    assert r == pytest.approx(expected)
+
+
+def test_reward_expression_malformed_returns_zero():
+    per_judge = {"x": {"value": 3}}
+    cfg = RewardConfig(formula="this is not valid python !!!", gate=False)
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    assert r == 0.0
+
+
+def test_reward_expression_rejects_dangerous_code():
+    """AST validation blocks import/attribute access attempts."""
+    per_judge = {"x": {"value": 3}}
+    cfg = RewardConfig(
+        formula='__import__("os").system("id")',
+        gate=False,
+        score_range=[1, 5],
+    )
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    assert r == 0.0
+
+
+# --- RewardConfig: single judge reference ------------------------------------
+
+def test_reward_single_judge_ref():
+    """Single judge reference returns raw value clamped to [0, 1]."""
+    per_judge = {"my_score": {"value": 0.73}}
+    cfg = RewardConfig(formula="my_score", gate=False, score_range=[1, 5])
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    assert r == pytest.approx(0.73)
+
+
+# --- RewardConfig: compose_reward integration --------------------------------
+
+def test_compose_reward_uses_reward_cfg():
+    per_judge = {"a": {"value": 5}, "b": {"value": 3}}
+    cfg = RewardConfig(
+        formula="weighted",
+        weights={"a": 0.6, "b": 0.4},
+        gate=False,
+        score_range=[1, 5],
+    )
+    reward, metrics = reward_mod.compose_reward(per_judge, reward_cfg=cfg)
+    expected = (0.6 * 1.0 + 0.4 * 0.5) / 1.0
+    assert reward == pytest.approx(expected)
+    assert metrics["a"] == 5.0
+    assert metrics["b"] == 3.0
+
+
+def test_compose_reward_falls_back_without_cfg():
+    """No reward_cfg = legacy gate+average behavior."""
+    per_judge = {
+        "gate": {"value": True},
+        "s": {"value": 3},
+    }
+    reward, _ = reward_mod.compose_reward(per_judge)
+    assert reward == pytest.approx(0.5)  # (3-1)/(5-1)
+
+
+# --- EvalConfig parsing ------------------------------------------------------
+
+def test_reward_config_parsed_from_yaml(tmp_path):
+    raw = {
+        "name": "t", "skill": "t",
+        "reward": {
+            "formula": "weighted",
+            "weights": {"a": 0.5, "b": 0.5},
+            "gate": False,
+            "score_range": [1, 10],
+            "raw": ["b"],
+        },
+    }
+    cfg_path = tmp_path / "eval.yaml"
+    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    config = EvalConfig.from_yaml(cfg_path)
+
+    assert config.reward is not None
+    assert config.reward.formula == "weighted"
+    assert config.reward.weights == {"a": 0.5, "b": 0.5}
+    assert config.reward.gate is False
+    assert config.reward.score_range == [1.0, 10.0]
+    assert config.reward.raw == ["b"]
+
+
+def test_reward_config_rejects_bad_gate(tmp_path):
+    raw = {
+        "name": "t", "skill": "t",
+        "reward": {"gate": "false"},
+    }
+    cfg_path = tmp_path / "eval.yaml"
+    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    with pytest.raises(ValueError, match="gate must be a boolean"):
+        EvalConfig.from_yaml(cfg_path)
+
+
+def test_reward_config_rejects_inverted_range(tmp_path):
+    raw = {
+        "name": "t", "skill": "t",
+        "reward": {"score_range": [5, 1]},
+    }
+    cfg_path = tmp_path / "eval.yaml"
+    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    with pytest.raises(ValueError, match="increasing"):
+        EvalConfig.from_yaml(cfg_path)

--- a/tests/test_harbor_reward.py
+++ b/tests/test_harbor_reward.py
@@ -284,12 +284,25 @@ def test_reward_expression_rejects_dangerous_code():
 
 # --- RewardConfig: single judge reference ------------------------------------
 
-def test_reward_single_judge_ref():
-    """Single judge reference returns raw value clamped to [0, 1]."""
+def test_reward_single_judge_ref_raw():
+    """A single judge listed in raw is clamped to [0, 1], not normalized."""
     per_judge = {"my_score": {"value": 0.73}}
-    cfg = RewardConfig(formula="my_score", gate=False, score_range=[1, 5])
+    cfg = RewardConfig(formula="my_score", gate=False,
+                       score_range=[1, 5], raw=["my_score"])
     r = reward_mod.compute_reward_from_config(per_judge, cfg)
     assert r == pytest.approx(0.73)
+
+
+def test_reward_single_judge_ref_normalized():
+    """A single judge not in raw is normalized via score_range.
+
+    This keeps single-judge mode consistent with weighted/expression modes
+    rather than silently clamping a 1-5 score to ~1.0.
+    """
+    per_judge = {"rfe_quality": {"value": 4}}
+    cfg = RewardConfig(formula="rfe_quality", gate=False, score_range=[1, 5])
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    assert r == pytest.approx(0.75)  # (4-1)/(5-1)
 
 
 # --- RewardConfig: compose_reward integration --------------------------------
@@ -364,3 +377,51 @@ def test_reward_config_rejects_inverted_range(tmp_path):
     cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
     with pytest.raises(ValueError, match="increasing"):
         EvalConfig.from_yaml(cfg_path)
+
+
+def test_reward_config_rejects_negative_weight(tmp_path):
+    raw = {
+        "name": "t", "skill": "t",
+        "reward": {"formula": "weighted", "weights": {"a": -0.5, "b": 1.0}},
+    }
+    cfg_path = tmp_path / "eval.yaml"
+    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    with pytest.raises(ValueError, match="non-negative"):
+        EvalConfig.from_yaml(cfg_path)
+
+
+def test_reward_config_rejects_malformed_formula(tmp_path):
+    """A syntactically invalid expression fails at config load, not silently."""
+    raw = {
+        "name": "t", "skill": "t",
+        "reward": {"formula": "0.5 * quality + "},
+    }
+    cfg_path = tmp_path / "eval.yaml"
+    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    with pytest.raises(ValueError, match="formula is invalid"):
+        EvalConfig.from_yaml(cfg_path)
+
+
+def test_reward_config_rejects_unsafe_formula(tmp_path):
+    """An unsafe construct is rejected at config load."""
+    raw = {
+        "name": "t", "skill": "t",
+        "reward": {"formula": '__import__("os").system("id")'},
+    }
+    cfg_path = tmp_path / "eval.yaml"
+    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    with pytest.raises(ValueError, match="formula is invalid"):
+        EvalConfig.from_yaml(cfg_path)
+
+
+def test_reward_config_accepts_valid_expression(tmp_path):
+    """A valid expression formula parses and is stored verbatim."""
+    raw = {
+        "name": "t", "skill": "t",
+        "reward": {"formula": "0.6 * quality + 0.4 * efficiency",
+                   "raw": ["efficiency"]},
+    }
+    cfg_path = tmp_path / "eval.yaml"
+    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    config = EvalConfig.from_yaml(cfg_path)
+    assert config.reward.formula == "0.6 * quality + 0.4 * efficiency"

--- a/tests/test_harbor_reward.py
+++ b/tests/test_harbor_reward.py
@@ -425,3 +425,42 @@ def test_reward_config_accepts_valid_expression(tmp_path):
     cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
     config = EvalConfig.from_yaml(cfg_path)
     assert config.reward.formula == "0.6 * quality + 0.4 * efficiency"
+
+
+# --- formula sandbox hardening (bounded numeric arithmetic) ------------------
+
+def _expect_invalid_formula(tmp_path, formula):
+    raw = {"name": "t", "skill": "t", "reward": {"formula": formula}}
+    cfg_path = tmp_path / "eval.yaml"
+    cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
+    with pytest.raises(ValueError, match="formula is invalid"):
+        EvalConfig.from_yaml(cfg_path)
+
+
+def test_reward_formula_rejects_power_operator(tmp_path):
+    """** is excluded — integer exponentiation is a cheap CPU/memory blow-up."""
+    _expect_invalid_formula(tmp_path, "2 ** quality")
+
+
+def test_reward_formula_rejects_huge_constant(tmp_path):
+    _expect_invalid_formula(tmp_path, "9999999999 * quality")
+
+
+def test_reward_formula_rejects_string_constant(tmp_path):
+    """String literals (and thus "x" * N repetition blow-ups) are rejected."""
+    _expect_invalid_formula(tmp_path, '"x" * 5 + quality')
+
+
+def test_reward_formula_rejects_oversized_ast(tmp_path):
+    """A formula past the node-count cap is rejected at config load."""
+    _expect_invalid_formula(tmp_path, " + ".join(["quality"] * 300))
+
+
+def test_reward_formula_allows_list_for_mean():
+    """List literals stay allowed so mean([...]) keeps working."""
+    reward_mod.validate_formula("mean([a, b, c])")  # must not raise
+    per_judge = {"a": {"value": 5}, "b": {"value": 3}, "c": {"value": 1}}
+    cfg = RewardConfig(formula="mean([a, b, c])", gate=False,
+                       score_range=[1, 5])
+    r = reward_mod.compute_reward_from_config(per_judge, cfg)
+    assert r == pytest.approx((1.0 + 0.5 + 0.0) / 3)


### PR DESCRIPTION
## Summary                            
  - Add grpo_reward judge support: when present, its value is used 
  directly as the overall reward                                          
  - Make score range configurable via score_range in eval config instead  
  of hardcoded 1-5                                                        
  - Fall back to legacy gate+average behavior when no grpo_reward judge 
  exists                                                                  
                  
  ## Test plan                                                            
  - Run existing reward tests to verify backward compatibility
  - Test with eval.yaml containing a grpo_reward judge                    
  - Test with custom score_range config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `reward` configuration in eval YAML to combine per-judge outputs into a single scalar reward in `[0,1]`.
  * Supports reward modes (`weighted`, single-judge with `score_range`, or expression), optional boolean `gate`, and `raw` judges that bypass normalization.

* **Improvements**
  * Reward resolution now follows a defined precedence order: `reward` config first, then legacy `grpo_reward`, otherwise default gating + averaged normalized numerics.
  * Expression handling is safer: validated at config load, with evaluation failures warning and returning `0.0`.

* **Documentation**
  * Updated configuration documentation and the eval YAML template with the new `reward` section.

* **Tests**
  * Expanded unit/integration coverage for reward parsing, normalization/clamping, gating behavior, formula safety, precedence, and fallback paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->