### PR TITLE
feat(eval-replay): add skill for outcome-anchored evaluation from historical PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ venv/
 eval/runs/
 tmp/
 
+# Eval-replay working state
+.eval-replay/
+
 # MLflow
 mlflow.db
 mlruns/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install -e ./agent-eval-harness
 claude --plugin-dir ./agent-eval-harness
 ```
 
-This makes all eval skills available: `/eval-setup`, `/eval-analyze`, `/eval-dataset`, `/eval-run`, `/eval-review`, `/eval-mlflow`, `/eval-optimize`, and `/eval-check`.
+This makes all eval skills available: `/eval-setup`, `/eval-analyze`, `/eval-dataset`, `/eval-run`, `/eval-review`, `/eval-mlflow`, `/eval-optimize`, `/eval-check`, and `/eval-replay`.
 
 ### 2. Set up environment
 
@@ -508,6 +508,21 @@ Scan the full configuration (skills, commands, CLAUDE.md, hooks) as a system. Fi
 /eval-check --output my-report.md  # Custom output path
 ```
 
+### /eval-replay
+
+Generate evaluation cases from real merged GitHub PRs for ground-truth skill testing. Fetches PR diffs, review comments, and verdicts, creates contamination-safe repo snapshots at the merge-base, and produces eval.yaml with an LLM alignment judge that scores skill output against actual PR outcomes.
+
+```bash
+/eval-replay --repo org/repo --pr 123 --pr 456 --skill code-review
+/eval-replay --repo org/repo --pr 789 --skill fix-bugs --strategy fix
+/eval-replay --repo org/repo --pr 101 --skill security-scan --strategy scan
+```
+
+Strategies:
+- **review** (default) — tests code-review skills against reviewer comments and verdicts
+- **fix** — tests bug-fix skills against accepted patches
+- **scan** — tests security scan skills against vulnerability fixes
+
 ## Architecture
 
 ```
@@ -532,7 +547,8 @@ skills/
   eval-review/           # Interactive human review
   eval-mlflow/           # MLflow integration
   eval-optimize/         # Automated refinement loop
-  eval-check/    # Full-harness configuration health check
+  eval-check/            # Full-harness configuration health check
+  eval-replay/           # Ground-truth eval from historical PRs
 ```
 
 ## Agent Support

--- a/skills/eval-analyze/scripts/find_skills.py
+++ b/skills/eval-analyze/scripts/find_skills.py
@@ -23,7 +23,8 @@ DEFAULT_SKILL_DIRS = [".claude/skills", "skills"]
 
 # Skills from the eval harness — excluded from discovery
 HARNESS_SKILLS = {"eval-setup", "eval-analyze", "eval-dataset", "eval-run",
-                   "eval-review", "eval-mlflow", "eval-optimize"}
+                   "eval-review", "eval-mlflow", "eval-optimize", "eval-check",
+                   "eval-replay"}
 
 
 def _resolve_under_cwd(raw, base):

--- a/skills/eval-replay/SKILL.md
+++ b/skills/eval-replay/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: eval-replay
+description: Generate evaluation cases from real merged pull requests for ground-truth skill testing. Fetches PR diffs, review comments, and verdicts from GitHub, creates contamination-safe repo snapshots, and produces eval.yaml with an LLM alignment judge that scores skill output against actual PR outcomes. Use when you want to test a skill against real-world outcomes, verify a code-review skill catches what humans caught, or benchmark a fix skill against accepted patches. Triggers on "replay PRs", "test against real PRs", "ground truth eval", "historical PR test", "outcome-anchored eval".
+user-invocable: true
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent, AskUserQuestion, Skill
+---
+
+You generate evaluation cases from historical GitHub PRs. Real merged PRs provide ground truth — review comments, accepted diffs, verdicts — that an LLM judge scores skill output against. The judge answers: "would acting on this skill's output have converged toward what was actually merged?"
+
+## Step 0: Parse Arguments
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--repo <org/name>` | **yes** | — | GitHub repository |
+| `--pr <N>` | **yes** | — | PR number (repeatable) |
+| `--skill <name>` | **yes** | — | Skill under test |
+| `--strategy <type>` | no | `review` | Evaluation strategy: `review`, `fix`, or `scan` |
+| `--output-dir <path>` | **yes** | — | Case output directory (**outside** the project, e.g. `../eval-replay-output/cases`) |
+| `--config-output <path>` | **yes** | — | Generated eval.yaml (alongside cases, e.g. `../eval-replay-output/eval.yaml`) |
+| `--skip-clone` | no | false | Skip repo cloning (for testing) |
+
+## Step 1: Validate Prerequisites
+
+Check that `gh` CLI is authenticated:
+
+```bash
+gh auth status
+```
+
+If not authenticated, tell the user to run `gh auth login` first.
+
+## Step 2: Generate Cases
+
+Run `from_pr.py` for each PR. This fetches metadata, diffs, and review comments, then creates a contamination-safe shallow clone at the merge-base.
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/from_pr.py \
+    --repo <repo> --pr <N> [--pr <M>] \
+    --strategy <strategy> \
+    --output-dir <output-dir>
+```
+
+Each case directory (`<output-dir>/pr-<N>/`) contains:
+- `input.yaml` — PR context visible to the skill (title, body, changed files, repo path)
+- `annotations.yaml` — ground truth for judges only (verdict, review comments, expected files)
+- `reference.patch` — the accepted diff
+- `repo/` — shallow clone at merge-base (no post-merge objects, no remote)
+
+Verify at least one case was created:
+
+```bash
+ls <output-dir>/pr-*/input.yaml
+```
+
+## Step 3: Generate eval.yaml
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/generate_eval.py \
+    --skill <skill> \
+    --strategy <strategy> \
+    --dataset-path <output-dir> \
+    --output <config-output>
+```
+
+This produces a complete harness-compliant config with:
+
+- **`outcome_alignment`** (LLM judge) — the primary evaluator. Given the accepted diff, reviewer comments, and the skill's output, scores 1-5 how well the skill's work aligns with what was actually needed. Strategy-specific prompts in `prompts/`.
+- **`has_output`** (deterministic) — sanity check that the skill produced non-trivial output.
+- **`references_diff_files`** (deterministic) — sanity check that the skill referenced at least one file from the PR diff.
+
+## Step 4: Run Evaluation
+
+Hand off to `/eval-run`:
+
+```text
+Use the Skill tool to invoke /eval-run --config <config-output> --model <model>
+```
+
+## Step 5: Report
+
+After `/eval-run` completes, present the results with context:
+
+1. **Per-judge pass rates** — which judges passed/failed across cases
+2. **Per-case breakdown** — which PRs the skill handled well vs poorly
+3. **Ground truth comparison** — what reviewers found vs what the skill found
+
+Suggest next steps:
+- `/eval-review --run-id <id>` to inspect individual cases
+- `/eval-optimize --model <model>` to iterate on the skill
+- Add more PRs with `--pr` to expand the dataset
+
+## Strategies
+
+### review (default)
+Tests code-review skills. Ground truth: reviewer comments, verdict, and accepted diff.
+LLM judge scores whether the skill's review would have guided the author toward the accepted outcome.
+
+### fix
+Tests bug-fix skills. Ground truth: the accepted patch.
+LLM judge scores whether the skill's fix addresses the same root cause in a structurally similar way.
+
+### scan
+Tests security scan skills. Ground truth: the vulnerability fix.
+LLM judge scores whether the skill identified the vulnerability the accepted PR fixes.
+
+## Rules
+
+- **Never put ground truth in the agent workspace** — `annotations.yaml` stays in the dataset dir; only `input.yaml` reaches the skill
+- **The LLM judge has ground truth** — unlike typical LLM judges that assess "quality," `outcome_alignment` compares against the actual accepted diff and reviewer comments. It answers: "would acting on this skill's output have converged toward what was actually merged?"
+- **Contamination is prevented** — shallow clones have no remote, no refs, no post-merge objects
+- **Don't modify the skill** — this skill generates cases and config; `/eval-optimize` handles skill changes
+
+$ARGUMENTS

--- a/skills/eval-replay/SKILL.md
+++ b/skills/eval-replay/SKILL.md
@@ -17,6 +17,7 @@ You generate evaluation cases from historical GitHub PRs. Real merged PRs provid
 | `--strategy <type>` | no | `review` | Evaluation strategy: `review`, `fix`, or `scan` |
 | `--output-dir <path>` | **yes** | — | Case output directory (**outside** the project, e.g. `../eval-replay-output/cases`) |
 | `--config-output <path>` | **yes** | — | Generated eval.yaml (alongside cases, e.g. `../eval-replay-output/eval.yaml`) |
+| `--clone-dir <path>` | no | temp dir | Repo clone root, isolated from case data. Defaults to a temp dir so the agent can't traverse to ground truth. |
 | `--skip-clone` | no | false | Skip repo cloning (for testing) |
 
 ## Step 1: Validate Prerequisites
@@ -37,14 +38,16 @@ Run `from_pr.py` for each PR. This fetches metadata, diffs, and review comments,
 python3 ${CLAUDE_SKILL_DIR}/scripts/from_pr.py \
     --repo <repo> --pr <N> [--pr <M>] \
     --strategy <strategy> \
-    --output-dir <output-dir>
+    --output-dir <output-dir> \
+    [--clone-dir <clone-dir>]
 ```
 
 Each case directory (`<output-dir>/pr-<N>/`) contains:
-- `input.yaml` — PR context visible to the skill (title, body, changed files, repo path)
+- `input.yaml` — PR context visible to the skill (title, body, changed files, `repo_path` pointing to the isolated clone)
 - `annotations.yaml` — ground truth for judges only (verdict, review comments, expected files)
 - `reference.patch` — the accepted diff
-- `repo/` — shallow clone at merge-base (no post-merge objects, no remote)
+
+Repo clones live in a **separate directory tree** (temp dir by default, or `--clone-dir`) so the agent cannot traverse from the clone to ground truth.
 
 Verify at least one case was created:
 
@@ -107,7 +110,7 @@ LLM judge scores whether the skill identified the vulnerability the accepted PR 
 
 - **Never put ground truth in the agent workspace** — `annotations.yaml` stays in the dataset dir; only `input.yaml` reaches the skill
 - **The LLM judge has ground truth** — unlike typical LLM judges that assess "quality," `outcome_alignment` compares against the actual accepted diff and reviewer comments. It answers: "would acting on this skill's output have converged toward what was actually merged?"
-- **Contamination is prevented** — shallow clones have no remote, no refs, no post-merge objects
+- **Contamination is prevented** — shallow clones have no remote, no refs, no post-merge objects. Clones live in a separate directory tree (temp dir by default) so the agent cannot traverse from `repo_path` to ground truth files.
 - **Don't modify the skill** — this skill generates cases and config; `/eval-optimize` handles skill changes
 
 $ARGUMENTS

--- a/skills/eval-replay/prompts/fix-alignment.md
+++ b/skills/eval-replay/prompts/fix-alignment.md
@@ -1,0 +1,33 @@
+You are evaluating whether a bug-fix skill's output aligns with the actual accepted fix for a real pull request.
+
+You have the ground truth:
+1. The **accepted diff** — what was actually merged to fix the issue
+2. The **reviewer comments** — feedback on the approach
+3. The **PR description** — what the issue was
+
+## Accepted Diff and Review Context
+
+{{ annotations }}
+
+## Skill's Output
+
+{{ conversation }}
+
+## Evaluation Criteria
+
+Score 1-5 based on how closely the skill's fix aligns with the accepted solution:
+
+- **5**: The skill produced changes that address the same root cause in a structurally similar way. The fix would be functionally equivalent to what was merged.
+- **4**: The skill identified the right problem and touched the right code areas. The approach differs but would likely work. May need minor adjustments.
+- **3**: The skill partially addressed the issue — right area but incomplete fix, or correct diagnosis but wrong approach.
+- **2**: The skill attempted a fix but in the wrong location or with a fundamentally different (likely incorrect) approach.
+- **1**: The skill's output doesn't address the actual problem, introduces new issues, or would not resolve the bug.
+
+Key question: **Would this skill's fix have resolved the same issue the accepted PR resolved?**
+
+A skill that produces a cleaner or more thorough fix than the accepted one should score 5 — the accepted diff is the baseline, not the ceiling.
+
+Respond with a JSON object:
+```json
+{"score": <1-5>, "rationale": "<explanation>"}
+```

--- a/skills/eval-replay/prompts/review-alignment.md
+++ b/skills/eval-replay/prompts/review-alignment.md
@@ -1,0 +1,33 @@
+You are evaluating whether a code review skill's output aligns with the actual outcome of a real pull request.
+
+You have three sources of ground truth:
+1. The **accepted diff** — what was actually merged (the definitive answer)
+2. The **reviewer comments** — what human reviewers flagged during the review process
+3. The **verdict** — whether reviewers approved or requested changes
+
+## Accepted Diff and Review Context
+
+{{ annotations }}
+
+## Skill's Output
+
+{{ conversation }}
+
+## Evaluation Criteria
+
+Score 1-5 based on how useful the skill's review would have been in reaching the accepted outcome:
+
+- **5**: The skill identified the same core issues reviewers raised AND its feedback would have guided the author toward the accepted diff. Demonstrates understanding of what needed to change and why.
+- **4**: The skill caught most of the substantive issues and its direction aligns with the accepted changes. Minor gaps but would have been genuinely helpful.
+- **3**: The skill identified some relevant issues but missed key problems, or found real issues but gave vague/unhelpful guidance. Partially useful.
+- **2**: The skill's feedback has little overlap with what actually mattered. It may have focused on superficial issues while missing structural problems the reviewers caught.
+- **1**: The skill's output is irrelevant to the actual PR, contradicts the accepted changes, or would have sent the author in the wrong direction.
+
+Key question: **If someone acted only on this skill's review, would the PR have converged toward the accepted diff?**
+
+A skill that finds legitimate issues the reviewers missed should NOT be penalized — that's a bonus. But the primary measure is alignment with what was actually needed.
+
+Respond with a JSON object:
+```json
+{"score": <1-5>, "rationale": "<explanation>"}
+```

--- a/skills/eval-replay/prompts/scan-alignment.md
+++ b/skills/eval-replay/prompts/scan-alignment.md
@@ -1,0 +1,31 @@
+You are evaluating whether a security scan skill's output aligns with the actual vulnerability fix in a real pull request.
+
+You have the ground truth:
+1. The **accepted diff** — the security fix that was merged
+2. The **reviewer comments** — discussion about the vulnerability and fix approach
+3. The **PR description** — what vulnerability was addressed
+
+## Accepted Diff and Review Context
+
+{{ annotations }}
+
+## Skill's Output
+
+{{ conversation }}
+
+## Evaluation Criteria
+
+Score 1-5 based on whether the skill identified the vulnerability that this PR fixes:
+
+- **5**: The skill correctly identified the vulnerability, its location, and its impact. The findings align with what the security fix addresses.
+- **4**: The skill identified the vulnerability area and gave actionable guidance. May have missed some nuance about impact or specific attack vectors.
+- **3**: The skill flagged the right files or general area but was vague about the actual vulnerability, or identified the class of vulnerability but not the specific instance.
+- **2**: The skill produced findings with minimal overlap to the actual vulnerability. Mostly noise.
+- **1**: The skill missed the vulnerability entirely, or its findings are unrelated to the actual security issue.
+
+Key question: **Would this skill's scan have caught the vulnerability before it was reported?**
+
+Respond with a JSON object:
+```json
+{"score": <1-5>, "rationale": "<explanation>"}
+```

--- a/skills/eval-replay/scripts/from_pr.py
+++ b/skills/eval-replay/scripts/from_pr.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Generate eval cases from historical GitHub PRs.
+
+Fetches PR metadata, diffs, and review comments via the `gh` CLI, then
+writes a case directory per PR that eval-run can score against.
+
+Usage:
+    python3 from_pr.py --repo org/name --pr 123 [--pr 456] \
+        --strategy review --output-dir /absolute/path/to/cases
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReviewComment:
+    path: str
+    line: int | None
+    body: str
+    author: str
+    state: str  # review-level: APPROVED, CHANGES_REQUESTED, COMMENTED
+
+
+@dataclass
+class PrMeta:
+    number: int
+    title: str
+    body: str
+    author: str
+    state: str  # MERGED, OPEN, CLOSED
+    base_ref: str
+    head_ref: str
+    head_sha: str
+    merge_commit_sha: str
+    reviewers: list[str]
+    labels: list[str]
+    merged_at: str
+    changed_files: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Forge adapter protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ForgeAdapter(Protocol):
+    def fetch_pr_meta(self, repo: str, pr: int) -> PrMeta: ...
+    def fetch_diff(self, repo: str, pr: int) -> str: ...
+    def fetch_reviews(self, repo: str, pr: int) -> list[ReviewComment]: ...
+    def compute_merge_base(self, repo: str, pr: int) -> str: ...
+
+
+# ---------------------------------------------------------------------------
+# GitHub adapter (gh CLI)
+# ---------------------------------------------------------------------------
+
+
+class GitHubAdapter:
+    """Fetch PR data via the gh CLI — no PyGitHub dependency."""
+
+    def _gh(self, *args: str) -> str:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"gh {' '.join(args)} failed (rc={result.returncode}): "
+                f"{result.stderr.strip()}"
+            )
+        return result.stdout
+
+    def _gh_api(self, endpoint: str) -> Any:
+        raw = self._gh("api", endpoint, "--paginate").strip()
+        if not raw:
+            return []
+        chunks = [json.loads(line) for line in raw.splitlines() if line.strip()]
+        if len(chunks) == 1:
+            return chunks[0]
+        merged: list[Any] = []
+        for chunk in chunks:
+            merged.extend(chunk if isinstance(chunk, list) else [chunk])
+        return merged
+
+    def fetch_pr_meta(self, repo: str, pr: int) -> PrMeta:
+        data = self._gh_api(f"repos/{repo}/pulls/{pr}")
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected dict for PR #{pr}, got {type(data).__name__}")
+
+        files_data = self._gh_api(f"repos/{repo}/pulls/{pr}/files")
+        reviews_data = self._gh_api(f"repos/{repo}/pulls/{pr}/reviews")
+
+        reviewers = sorted(
+            {
+                r["user"]["login"]
+                for r in reviews_data
+                if r.get("user") and r["state"] != "COMMENTED"
+            }
+        )
+
+        state = "MERGED" if data.get("merged_at") else data["state"].upper()
+
+        return PrMeta(
+            number=data["number"],
+            title=data["title"],
+            body=data.get("body") or "",
+            author=data["user"]["login"],
+            state=state,
+            base_ref=data["base"]["ref"],
+            head_ref=data["head"]["ref"],
+            head_sha=data["head"]["sha"],
+            merge_commit_sha=data.get("merge_commit_sha") or "",
+            reviewers=reviewers,
+            labels=[lbl["name"] for lbl in data.get("labels", [])],
+            merged_at=data.get("merged_at") or "",
+            changed_files=[f["filename"] for f in files_data],
+        )
+
+    def fetch_diff(self, repo: str, pr: int) -> str:
+        return self._gh(
+            "api",
+            f"repos/{repo}/pulls/{pr}",
+            "-H",
+            "Accept: application/vnd.github.v3.diff",
+        )
+
+    def fetch_reviews(self, repo: str, pr: int) -> list[ReviewComment]:
+        reviews = self._gh_api(f"repos/{repo}/pulls/{pr}/reviews")
+        comments = self._gh_api(f"repos/{repo}/pulls/{pr}/comments")
+
+        state_by_review_id: dict[int, str] = {r["id"]: r["state"] for r in reviews}
+
+        result: list[ReviewComment] = []
+
+        for c in comments:
+            rid = c.get("pull_request_review_id")
+            result.append(
+                ReviewComment(
+                    path=c.get("path", ""),
+                    line=c.get("original_line") or c.get("line"),
+                    body=c.get("body", ""),
+                    author=c["user"]["login"] if c.get("user") else "",
+                    state=state_by_review_id.get(rid, "COMMENTED")
+                    if rid
+                    else "COMMENTED",
+                )
+            )
+
+        for r in reviews:
+            body = (r.get("body") or "").strip()
+            if body:
+                result.append(
+                    ReviewComment(
+                        path="",
+                        line=None,
+                        body=body,
+                        author=r["user"]["login"] if r.get("user") else "",
+                        state=r["state"],
+                    )
+                )
+
+        return result
+
+    def compute_merge_base(self, repo: str, pr: int) -> str:
+        data = self._gh_api(f"repos/{repo}/pulls/{pr}")
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected dict for PR #{pr}, got {type(data).__name__}")
+        compare = self._gh_api(
+            f"repos/{repo}/compare/{data['base']['sha']}...{data['head']['sha']}"
+        )
+        if not isinstance(compare, dict):
+            return data["base"]["sha"]
+        return compare.get("merge_base_commit", {}).get("sha", data["base"]["sha"])
+
+
+# ---------------------------------------------------------------------------
+# Shallow clone isolation
+# ---------------------------------------------------------------------------
+
+
+def _run_git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def _purge_refs(clone_dir: Path) -> None:
+    refs = _run_git("for-each-ref", "--format=%(refname)", cwd=clone_dir)
+    for ref in refs.splitlines():
+        if ref.strip():
+            _run_git("update-ref", "-d", ref.strip(), cwd=clone_dir)
+    _run_git("reflog", "expire", "--expire=now", "--all", cwd=clone_dir)
+    _run_git("gc", "--prune=now", cwd=clone_dir)
+
+
+def _check_contamination(clone_dir: Path, post_merge_sha: str) -> None:
+    if not post_merge_sha:
+        return
+    check = subprocess.run(
+        ["git", "cat-file", "-t", post_merge_sha],
+        capture_output=True,
+        text=True,
+        cwd=clone_dir,
+    )
+    if check.returncode == 0:
+        print(
+            f"WARNING: post-merge SHA {post_merge_sha[:12]} still reachable "
+            f"— contamination prevention may have failed",
+            file=sys.stderr,
+        )
+
+
+def create_isolated_clone(
+    repo: str,
+    merge_base_sha: str,
+    post_merge_sha: str,
+    output_dir: Path,
+) -> Path:
+    """Create a contamination-safe shallow clone at the merge-base."""
+    clone_dir = output_dir / "repo"
+    if clone_dir.exists():
+        return clone_dir
+
+    clone_dir.mkdir(parents=True)
+    repo_url = f"https://github.com/{repo}.git"
+
+    _run_git("init", cwd=clone_dir)
+    _run_git("remote", "add", "origin", repo_url, cwd=clone_dir)
+    _run_git("fetch", "--depth", "1", "origin", merge_base_sha, cwd=clone_dir)
+    _run_git("checkout", "FETCH_HEAD", cwd=clone_dir)
+    _run_git("remote", "remove", "origin", cwd=clone_dir)
+
+    _purge_refs(clone_dir)
+    _check_contamination(clone_dir, post_merge_sha)
+
+    return clone_dir
+
+
+# ---------------------------------------------------------------------------
+# Case generation
+# ---------------------------------------------------------------------------
+
+PROMPT_TEMPLATES: dict[str, str] = {
+    "review": (
+        "Review the following pull request.\n\n"
+        "Title: {title}\n"
+        "Description: {body}\n\n"
+        "Changed files:\n{files}\n\n"
+        "Provide your review with a verdict (approve or request_changes) "
+        "and list any issues found with file paths and line numbers."
+    ),
+    "fix": (
+        "Fix the issue described in this pull request.\n\n"
+        "Title: {title}\n"
+        "Description: {body}\n\n"
+        "Files that need changes:\n{files}"
+    ),
+    "scan": (
+        "Scan the following files for security vulnerabilities.\n\n"
+        "Context: {title}\n"
+        "Description: {body}\n\n"
+        "Files to scan:\n{files}"
+    ),
+}
+
+
+def _build_prompt(meta: PrMeta, strategy: str) -> str:
+    template = PROMPT_TEMPLATES.get(strategy)
+    if template is None:
+        raise ValueError(f"Unknown strategy: {strategy}")
+    files_list = "\n".join(f"  - {f}" for f in meta.changed_files)
+    return template.format(title=meta.title, body=meta.body, files=files_list)
+
+
+def _derive_verdict(reviews: list[ReviewComment]) -> str:
+    states = {r.state for r in reviews}
+    if "CHANGES_REQUESTED" in states:
+        return "changes_requested"
+    if "APPROVED" in states:
+        return "approved"
+    return "commented"
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+def generate_case(
+    adapter: ForgeAdapter,
+    repo: str,
+    pr: int,
+    strategy: str,
+    output_dir: Path,
+    *,
+    skip_clone: bool = False,
+) -> Path:
+    """Fetch PR data and write a single eval case directory."""
+    meta = adapter.fetch_pr_meta(repo, pr)
+    diff = adapter.fetch_diff(repo, pr)
+    reviews = adapter.fetch_reviews(repo, pr)
+    merge_base = adapter.compute_merge_base(repo, pr)
+
+    case_dir = output_dir / f"pr-{pr}"
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    repo_path = ""
+    if not skip_clone:
+        clone_dir = create_isolated_clone(
+            repo, merge_base, meta.merge_commit_sha, case_dir
+        )
+        repo_path = str(clone_dir.resolve())
+
+    _write_yaml(
+        case_dir / "input.yaml",
+        {
+            "prompt": _build_prompt(meta, strategy),
+            "pr_title": meta.title,
+            "pr_body": meta.body,
+            "changed_files": meta.changed_files,
+            "repo_path": repo_path,
+            "strategy": strategy,
+        },
+    )
+
+    (case_dir / "reference.patch").write_text(diff)
+
+    _write_yaml(
+        case_dir / "annotations.yaml",
+        {
+            "pr_number": meta.number,
+            "author": meta.author,
+            "reviewers": meta.reviewers,
+            "labels": meta.labels,
+            "merge_timestamp": meta.merged_at,
+            "verdict": _derive_verdict(reviews),
+            "expected_files": sorted({r.path for r in reviews if r.path}),
+            "review_comments": [
+                {
+                    "file": r.path,
+                    "line": r.line,
+                    "body": r.body,
+                    "author": r.author,
+                    "review_state": r.state,
+                }
+                for r in reviews
+            ],
+            "expected_diff": "reference.patch",
+            "merge_base_sha": merge_base,
+            "strategy": strategy,
+        },
+    )
+
+    return case_dir
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--repo", required=True, help="GitHub repo (org/name)")
+    parser.add_argument(
+        "--pr",
+        type=int,
+        action="append",
+        required=True,
+        help="PR number (repeatable)",
+    )
+    parser.add_argument(
+        "--strategy",
+        choices=["review", "fix", "scan"],
+        default="review",
+        help="Evaluation strategy (default: review)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Output directory for cases (absolute path)",
+    )
+    parser.add_argument(
+        "--skip-clone",
+        action="store_true",
+        help="Skip shallow clone (use for testing without git)",
+    )
+
+    args = parser.parse_args()
+    adapter = GitHubAdapter()
+    output = Path(args.output_dir).resolve()
+
+    for pr_num in args.pr:
+        print(f"Generating case for PR #{pr_num}...", file=sys.stderr)
+        case_dir = generate_case(
+            adapter,
+            args.repo,
+            pr_num,
+            args.strategy,
+            output,
+            skip_clone=args.skip_clone,
+        )
+        print(f"  -> {case_dir}", file=sys.stderr)
+
+    print(f"Generated {len(args.pr)} case(s) in {output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/eval-replay/scripts/from_pr.py
+++ b/skills/eval-replay/scripts/from_pr.py
@@ -13,13 +13,21 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 import yaml
+
+GH_BIN = shutil.which("gh")
+GIT_BIN = shutil.which("git")
+if GH_BIN is None or GIT_BIN is None:
+    _missing = [n for n, b in [("gh", GH_BIN), ("git", GIT_BIN)] if b is None]
+    raise RuntimeError(f"Required executables not found: {', '.join(_missing)}")
 
 
 # ---------------------------------------------------------------------------
@@ -34,6 +42,7 @@ class ReviewComment:
     body: str
     author: str
     state: str  # review-level: APPROVED, CHANGES_REQUESTED, COMMENTED
+    submitted_at: str = ""  # ISO 8601 timestamp for ordering
 
 
 @dataclass
@@ -76,7 +85,7 @@ class GitHubAdapter:
 
     def _gh(self, *args: str) -> str:
         result = subprocess.run(
-            ["gh", *args],
+            [GH_BIN, *args],
             capture_output=True,
             text=True,
             timeout=60,
@@ -146,21 +155,24 @@ class GitHubAdapter:
         reviews = self._gh_api(f"repos/{repo}/pulls/{pr}/reviews")
         comments = self._gh_api(f"repos/{repo}/pulls/{pr}/comments")
 
-        state_by_review_id: dict[int, str] = {r["id"]: r["state"] for r in reviews}
+        review_lookup: dict[int, dict[str, str]] = {
+            r["id"]: {"state": r["state"], "submitted_at": r.get("submitted_at", "")}
+            for r in reviews
+        }
 
         result: list[ReviewComment] = []
 
         for c in comments:
             rid = c.get("pull_request_review_id")
+            rl = review_lookup.get(rid, {}) if rid else {}
             result.append(
                 ReviewComment(
                     path=c.get("path", ""),
                     line=c.get("original_line") or c.get("line"),
                     body=c.get("body", ""),
                     author=c["user"]["login"] if c.get("user") else "",
-                    state=state_by_review_id.get(rid, "COMMENTED")
-                    if rid
-                    else "COMMENTED",
+                    state=rl.get("state", "COMMENTED"),
+                    submitted_at=rl.get("submitted_at", ""),
                 )
             )
 
@@ -174,6 +186,7 @@ class GitHubAdapter:
                         body=body,
                         author=r["user"]["login"] if r.get("user") else "",
                         state=r["state"],
+                        submitted_at=r.get("submitted_at", ""),
                     )
                 )
 
@@ -198,7 +211,7 @@ class GitHubAdapter:
 
 def _run_git(*args: str, cwd: Path) -> str:
     result = subprocess.run(
-        ["git", *args],
+        [GIT_BIN, *args],
         capture_output=True,
         text=True,
         cwd=cwd,
@@ -222,7 +235,7 @@ def _check_contamination(clone_dir: Path, post_merge_sha: str) -> None:
     if not post_merge_sha:
         return
     check = subprocess.run(
-        ["git", "cat-file", "-t", post_merge_sha],
+        [GIT_BIN, "cat-file", "-t", post_merge_sha],
         capture_output=True,
         text=True,
         cwd=clone_dir,
@@ -239,12 +252,17 @@ def create_isolated_clone(
     repo: str,
     merge_base_sha: str,
     post_merge_sha: str,
-    output_dir: Path,
+    clone_dir: Path,
 ) -> Path:
-    """Create a contamination-safe shallow clone at the merge-base."""
-    clone_dir = output_dir / "repo"
-    if clone_dir.exists():
-        return clone_dir
+    """Create a contamination-safe shallow clone at the merge-base.
+
+    clone_dir must not exist — caller is responsible for choosing a path
+    that is not a descendant/ancestor of the ground truth case directory.
+    """
+    if clone_dir.exists() or clone_dir.is_symlink():
+        raise FileExistsError(
+            f"{clone_dir} already exists; remove it or use a fresh output directory"
+        )
 
     clone_dir.mkdir(parents=True)
     repo_url = f"https://github.com/{repo}.git"
@@ -271,6 +289,7 @@ PROMPT_TEMPLATES: dict[str, str] = {
         "Title: {title}\n"
         "Description: {body}\n\n"
         "Changed files:\n{files}\n\n"
+        "Diff:\n{diff}\n\n"
         "Provide your review with a verdict (approve or request_changes) "
         "and list any issues found with file paths and line numbers."
     ),
@@ -284,24 +303,38 @@ PROMPT_TEMPLATES: dict[str, str] = {
         "Scan the following files for security vulnerabilities.\n\n"
         "Context: {title}\n"
         "Description: {body}\n\n"
-        "Files to scan:\n{files}"
+        "Files to scan:\n{files}\n\n"
+        "Diff:\n{diff}"
     ),
 }
 
 
-def _build_prompt(meta: PrMeta, strategy: str) -> str:
+def _build_prompt(meta: PrMeta, strategy: str, diff: str = "") -> str:
     template = PROMPT_TEMPLATES.get(strategy)
     if template is None:
         raise ValueError(f"Unknown strategy: {strategy}")
     files_list = "\n".join(f"  - {f}" for f in meta.changed_files)
-    return template.format(title=meta.title, body=meta.body, files=files_list)
+    return template.format(
+        title=meta.title, body=meta.body, files=files_list, diff=diff
+    )
 
 
 def _derive_verdict(reviews: list[ReviewComment]) -> str:
-    states = {r.state for r in reviews}
-    if "CHANGES_REQUESTED" in states:
+    """Derive verdict from the latest non-comment review per reviewer.
+
+    A reviewer may submit CHANGES_REQUESTED then later APPROVED; only
+    their final actionable review state counts.
+    """
+    latest_by_reviewer: dict[str, str] = {}
+    ordered = sorted(reviews, key=lambda r: r.submitted_at)
+    for r in ordered:
+        if r.author and r.state not in ("COMMENTED", ""):
+            latest_by_reviewer[r.author] = r.state
+
+    final_states = set(latest_by_reviewer.values())
+    if "CHANGES_REQUESTED" in final_states:
         return "changes_requested"
-    if "APPROVED" in states:
+    if "APPROVED" in final_states:
         return "approved"
     return "commented"
 
@@ -317,11 +350,21 @@ def generate_case(
     pr: int,
     strategy: str,
     output_dir: Path,
+    clone_root: Path | None = None,
     *,
     skip_clone: bool = False,
 ) -> Path:
-    """Fetch PR data and write a single eval case directory."""
+    """Fetch PR data and write a single eval case directory.
+
+    clone_root: if provided, clones go to clone_root/pr-<N>/ — a path
+    with no filesystem relationship to output_dir, so the agent cannot
+    traverse from the clone to ground truth.  Defaults to a temp dir.
+    """
     meta = adapter.fetch_pr_meta(repo, pr)
+    if meta.state != "MERGED":
+        raise ValueError(
+            f"PR #{pr} is {meta.state}, not MERGED — replay requires merged PRs"
+        )
     diff = adapter.fetch_diff(repo, pr)
     reviews = adapter.fetch_reviews(repo, pr)
     merge_base = adapter.compute_merge_base(repo, pr)
@@ -331,22 +374,28 @@ def generate_case(
 
     repo_path = ""
     if not skip_clone:
+        if clone_root is None:
+            clone_root = Path(tempfile.mkdtemp(prefix="eval-replay-"))
+        clone_target = clone_root / f"pr-{pr}"
         clone_dir = create_isolated_clone(
-            repo, merge_base, meta.merge_commit_sha, case_dir
+            repo, merge_base, meta.merge_commit_sha, clone_target
         )
         repo_path = str(clone_dir.resolve())
 
-    _write_yaml(
-        case_dir / "input.yaml",
-        {
-            "prompt": _build_prompt(meta, strategy),
-            "pr_title": meta.title,
-            "pr_body": meta.body,
-            "changed_files": meta.changed_files,
-            "repo_path": repo_path,
-            "strategy": strategy,
-        },
-    )
+    input_data: dict[str, Any] = {
+        "prompt": _build_prompt(
+            meta, strategy, diff=diff if strategy in ("review", "scan") else ""
+        ),
+        "pr_title": meta.title,
+        "pr_body": meta.body,
+        "changed_files": meta.changed_files,
+        "repo_path": repo_path,
+        "strategy": strategy,
+    }
+    if strategy in ("review", "scan"):
+        input_data["diff"] = diff
+
+    _write_yaml(case_dir / "input.yaml", input_data)
 
     (case_dir / "reference.patch").write_text(diff)
 
@@ -409,6 +458,15 @@ def main() -> None:
         help="Output directory for cases (absolute path)",
     )
     parser.add_argument(
+        "--clone-dir",
+        default=None,
+        help=(
+            "Root directory for repo clones, isolated from case data. "
+            "Defaults to a temp directory so the agent cannot traverse "
+            "from the clone to ground truth."
+        ),
+    )
+    parser.add_argument(
         "--skip-clone",
         action="store_true",
         help="Skip shallow clone (use for testing without git)",
@@ -418,6 +476,17 @@ def main() -> None:
     adapter = GitHubAdapter()
     output = Path(args.output_dir).resolve()
 
+    if args.clone_dir:
+        clone_root: Path | None = Path(args.clone_dir).resolve()
+        clone_root.mkdir(parents=True, exist_ok=True)
+    elif not args.skip_clone:
+        clone_root = Path(tempfile.mkdtemp(prefix="eval-replay-"))
+    else:
+        clone_root = None
+
+    if clone_root:
+        print(f"Clones directory: {clone_root}", file=sys.stderr)
+
     for pr_num in args.pr:
         print(f"Generating case for PR #{pr_num}...", file=sys.stderr)
         case_dir = generate_case(
@@ -426,6 +495,7 @@ def main() -> None:
             pr_num,
             args.strategy,
             output,
+            clone_root=clone_root,
             skip_clone=args.skip_clone,
         )
         print(f"  -> {case_dir}", file=sys.stderr)

--- a/skills/eval-replay/scripts/generate_eval.py
+++ b/skills/eval-replay/scripts/generate_eval.py
@@ -53,11 +53,11 @@ STRATEGY_DESCRIPTIONS: dict[str, str] = {
 SANITY_JUDGES: list[dict[str, str]] = [
     {
         "name": "has_output",
-        "description": "Skill produced non-trivial output.",
+        "description": "Skill produced non-empty output.",
         "check": textwrap.dedent("""\
             conversation = outputs.get("conversation", "")
-            if len(conversation.strip()) < 50:
-                return False, f"Output too short ({len(conversation.strip())} chars)"
+            if not conversation.strip():
+                return False, "Output is empty"
             return True, f"Output has {len(conversation.strip())} chars"
         """),
     },
@@ -79,10 +79,10 @@ SANITY_JUDGES: list[dict[str, str]] = [
     },
 ]
 
-# Thresholds are identical across strategies
 _DEFAULT_THRESHOLDS: dict[str, dict[str, float]] = {
     "outcome_alignment": {"min_mean": 3.0},
     "has_output": {"min_pass_rate": 1.0},
+    "references_diff_files": {"min_pass_rate": 0.5},
 }
 
 # ---------------------------------------------------------------------------

--- a/skills/eval-replay/scripts/generate_eval.py
+++ b/skills/eval-replay/scripts/generate_eval.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Generate a complete eval.yaml for PR replay evaluation.
+
+Produces a harness-compliant config with an LLM alignment judge as the
+primary evaluator (compares skill output against accepted diff + reviewer
+comments) and lightweight deterministic checks as sanity guards.
+
+Usage:
+    python3 generate_eval.py --skill code-review --strategy review \
+        --dataset-path /path/to/cases --output /path/to/eval.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Prompt file paths (resolved absolute via SKILL_DIR)
+# ---------------------------------------------------------------------------
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+
+STRATEGY_PROMPT_FILES: dict[str, str] = {
+    "review": str(SKILL_DIR / "prompts" / "review-alignment.md"),
+    "fix": str(SKILL_DIR / "prompts" / "fix-alignment.md"),
+    "scan": str(SKILL_DIR / "prompts" / "scan-alignment.md"),
+}
+
+STRATEGY_DESCRIPTIONS: dict[str, str] = {
+    "review": (
+        "Evaluates whether the skill's review aligns with the accepted "
+        "PR outcome: did its feedback point toward what was actually merged?"
+    ),
+    "fix": (
+        "Evaluates whether the skill's fix aligns with the accepted patch: "
+        "would it have resolved the same issue?"
+    ),
+    "scan": (
+        "Evaluates whether the skill's scan identified the vulnerability "
+        "that the accepted PR fixes."
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Deterministic sanity-check judges (strategy-independent)
+# ---------------------------------------------------------------------------
+
+SANITY_JUDGES: list[dict[str, str]] = [
+    {
+        "name": "has_output",
+        "description": "Skill produced non-trivial output.",
+        "check": textwrap.dedent("""\
+            conversation = outputs.get("conversation", "")
+            if len(conversation.strip()) < 50:
+                return False, f"Output too short ({len(conversation.strip())} chars)"
+            return True, f"Output has {len(conversation.strip())} chars"
+        """),
+    },
+    {
+        "name": "references_diff_files",
+        "description": "Skill referenced at least one file from the PR diff.",
+        "check": textwrap.dedent("""\
+            ann = outputs.get("annotations", {})
+            expected = ann.get("expected_files", []) or []
+            changed = outputs.get("annotations", {}).get("changed_files", expected)
+            if not changed:
+                return True, "No files to check"
+            conversation = outputs.get("conversation", "")
+            found = [f for f in changed if f in conversation]
+            if found:
+                return True, f"Referenced {len(found)}/{len(changed)} diff files"
+            return False, "Skill output does not reference any files from the diff"
+        """),
+    },
+]
+
+# Thresholds are identical across strategies
+_DEFAULT_THRESHOLDS: dict[str, dict[str, float]] = {
+    "outcome_alignment": {"min_mean": 3.0},
+    "has_output": {"min_pass_rate": 1.0},
+}
+
+# ---------------------------------------------------------------------------
+# Config generation
+# ---------------------------------------------------------------------------
+
+
+def generate_config(
+    skill: str,
+    strategy: str,
+    dataset_path: str,
+) -> dict[str, Any]:
+    """Build a complete eval.yaml dict."""
+    prompt_file = STRATEGY_PROMPT_FILES.get(strategy)
+    if prompt_file is None:
+        raise ValueError(f"Unknown strategy: {strategy}")
+
+    alignment_judge = {
+        "name": "outcome_alignment",
+        "description": STRATEGY_DESCRIPTIONS[strategy],
+        "prompt_file": prompt_file,
+        "feedback_type": "int",
+    }
+
+    return {
+        "name": f"{skill}-pr-replay",
+        "description": f"Replay historical PRs against {skill} (strategy: {strategy})",
+        "skill": skill,
+        "execution": {
+            "mode": "case",
+            "arguments": "{prompt}",
+        },
+        "dataset": {
+            "path": dataset_path,
+            "schema": (
+                "Each case (pr-<N>/) contains input.yaml with PR context "
+                "and annotations.yaml with reviewer ground truth."
+            ),
+        },
+        "outputs": [{"path": "review_output"}],
+        "traces": {
+            "events": True,
+            "stdout": True,
+            "stderr": True,
+            "metrics": True,
+        },
+        "judges": [alignment_judge, *SANITY_JUDGES],
+        "thresholds": _DEFAULT_THRESHOLDS,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--skill", required=True, help="Name of the skill under test")
+    parser.add_argument(
+        "--strategy", choices=["review", "fix", "scan"], default="review"
+    )
+    parser.add_argument(
+        "--dataset-path",
+        required=True,
+        help="Path to cases directory (resolved to absolute)",
+    )
+    parser.add_argument(
+        "--output", required=True, help="Output path for generated eval.yaml"
+    )
+
+    args = parser.parse_args()
+    output_path = Path(args.output).resolve()
+    dataset_path = str(Path(args.dataset_path).resolve())
+
+    config = generate_config(args.skill, args.strategy, dataset_path)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+    print(f"Generated {output_path} (skill={args.skill}, strategy={args.strategy})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds the following to provide the user historical evaluation of the skill:

- Add `/eval-replay` skill that generates evaluation cases from real merged GitHub PRs — fetches diffs, review comments, and verdicts via `gh` CLI, creates contamination-safe shallow clones at the merge-base, and produces eval.yaml with an LLM alignment judge
- The `outcome_alignment` judge scores 1-5 how well a skill's output aligns with what was actually merged, using the accepted diff and reviewer comments as ground truth — not LLM "quality" assessment
- Supports three strategies (review, fix, scan) with strategy-specific prompt templates

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I used agent-eval-harness with a library I help maintain, but I wanted to actually compare skill execution against PRs in a relatively isolated way. This also aligns with some research infra completed here: https://arxiv.org/abs/2602.11988

Generated 13 cases from that OSS repo spanning different subsystems within it. For each:

- Verified `from_pr.py` produces correct input.yaml (agent-visible only), annotations.yaml (judge-only ground truth), and reference.patch
- Verified annotations.yaml is never copied to the agent workspace — only input.yaml crosses the contamination wall
- Confirmed `generate_eval.py` output has absolute paths throughout (dataset, prompt files, repo clones) so the harness resolves them regardless of cwd
- Ran the LLM judge against simulated skill outputs at different quality levels. Looked for score discrimination: a review that got the architectural insight right but missed a naming nit scored 4; a review that focused on the wrong concern scored 2; a review that referenced files not in the diff scored 1. Rationales cited specific evidence from the accepted diff
- Traced score.py's template rendering to confirm `{{ annotations }}` includes auto-loaded file content (reference.patch via the annotation file-ref mechanism) and `{{ conversation }}` pulls extracted assistant text from events

This gave me more confidence in the evaluation because it anchors scoring to what actually happened — real reviewer comments, the accepted diff, the merge verdict — rather than hand-written references or LLM judges assessing "quality" without knowing what the right answer was.

Open to feedback on the approach.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `/eval-replay` workflow for generating evaluation cases from real merged pull requests.
  * Included new replay strategies for review, fix, and scan scenarios.
  * Added support files and scripts to create replay datasets and generate evaluation configurations.

* **Documentation**
  * Updated the README with setup, usage examples, supported strategies, and architecture details for the new replay capability.

* **Chores**
  * Added ignore rules so local replay working files aren’t tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->