### PR TITLE
fix(harbor): prevent duplicate pod creation from mid-run venv re-exec

### DIFF
--- a/agent_eval/_bootstrap.py
+++ b/agent_eval/_bootstrap.py
@@ -63,17 +63,23 @@ def _patch_syspath(site_dirs):
 
 
 def _is_true_script_entry():
-    """True only for `python script.py` (not `-m`, not `-c`, not exec_module).
+    """True only for `python script.py` (not `-m`, `-c`, `-`, REPL, exec_module).
 
     `python script.py` -> __main__.__spec__ is None, argv[0] is the script.
     `python -m pkg.mod` -> __main__.__spec__ is a ModuleSpec (non-None).
     `python -c "..."`   -> __main__.__spec__ is None, argv[0] == '-c'.
+    `python -` / stdin  -> argv[0] == '-'.
+    REPL / embedded     -> argv[0] == '' (or argv empty).
     exec_module'd file  -> runs under its loader name, __main__ is unchanged.
+
+    Only a real script file can be re-exec'd; the other forms have nothing to
+    rerun, so they must not take the execv path.
     """
     main = sys.modules.get("__main__")
     if main is None or getattr(main, "__spec__", None) is not None:
         return False
-    if sys.argv[:1] == ["-c"]:
+    argv0 = sys.argv[0] if sys.argv else ""
+    if argv0 in {"", "-", "-c"}:
         return False
     return True
 

--- a/agent_eval/_bootstrap.py
+++ b/agent_eval/_bootstrap.py
@@ -1,45 +1,119 @@
-"""Auto-activate the eval harness venv if available.
+"""Make the eval-harness venv's third-party deps importable.
 
-Imported by __init__.py before any third-party deps. Uses only stdlib.
+Imported (as the first line) by every skill script and by score.py/report.py.
 
-For script invocations (python3 script.py), replaces the process with
-the venv python via os.execv(). For inline code (python3 -c "..."),
-patches sys.path so third-party imports resolve from the venv.
+The venv at ``<plugin_root>/.eval-venv`` contains ONLY third-party deps — the
+``agent_eval`` package itself is always resolved from the source tree via
+PYTHONPATH. So the DEFAULT and correct action is to put the venv's
+site-packages on ``sys.path`` of the running interpreter: no process
+replacement, fully re-entrant, safe under pytest and under
+``importlib.util.exec_module`` (how run.py loads report.py / score.py by path).
+
+We re-exec into the venv interpreter via ``os.execv`` ONLY in the single case
+where ``sys.path`` patching is insufficient AND re-exec is safe:
+
+  * INSUFFICIENT: the running interpreter's ABI (major.minor) differs from the
+    venv's, so the venv's compiled wheels (cpXY ``.so`` files) cannot be
+    imported under the running interpreter.
+  * SAFE: this is a genuine top-level *script* entry (``python script.py``),
+    detected via ``__main__.__spec__ is None`` — so the re-exec happens at
+    import time, before the script does any work. ``python -m`` yields a
+    non-None ``__spec__`` and ``-c``/exec_module are likewise excluded, because
+    re-exec there would either re-run ``__main__`` after side effects (the
+    duplicate-run bug) or have no script to re-run.
+
+The env-var sentinel makes activation idempotent and survives ``os.execv``
+(env is inherited by the new process image), so the re-exec'd process
+short-circuits instead of looping.
 """
 import glob
 import os
 import sys
 
+_SENTINEL = "_AGENT_EVAL_BOOTSTRAP_DONE"
+
+
+def _venv_python_and_site(plugin_root):
+    """Return (venv_python_path_or_None, [site_packages_dirs])."""
+    venv_dir = os.path.join(plugin_root, ".eval-venv")
+    v = sys.version_info
+    candidates = [
+        os.path.join(venv_dir, "bin", "python3"),
+        os.path.join(venv_dir, "bin", f"python{v.major}.{v.minor}"),
+    ]
+    venv_python = next((p for p in candidates if os.path.isfile(p)), None)
+    site_dirs = glob.glob(os.path.join(venv_dir, "lib", "python*", "site-packages"))
+    return venv_python, site_dirs
+
+
+def _venv_pyver(site_dirs):
+    """Extract 'X.Y' from a '.../lib/pythonX.Y/site-packages' path."""
+    for d in site_dirs:
+        name = os.path.basename(os.path.dirname(d))  # 'pythonX.Y'
+        if name.startswith("python"):
+            return name[len("python"):]
+    return None
+
+
+def _patch_syspath(site_dirs):
+    real = {os.path.realpath(p) for p in sys.path}
+    for d in site_dirs:
+        if os.path.realpath(d) not in real:
+            sys.path.insert(0, d)
+
+
+def _is_true_script_entry():
+    """True only for `python script.py` (not `-m`, not `-c`, not exec_module).
+
+    `python script.py` -> __main__.__spec__ is None, argv[0] is the script.
+    `python -m pkg.mod` -> __main__.__spec__ is a ModuleSpec (non-None).
+    `python -c "..."`   -> __main__.__spec__ is None, argv[0] == '-c'.
+    exec_module'd file  -> runs under its loader name, __main__ is unchanged.
+    """
+    main = sys.modules.get("__main__")
+    if main is None or getattr(main, "__spec__", None) is not None:
+        return False
+    if sys.argv[:1] == ["-c"]:
+        return False
+    return True
+
 
 def _activate():
+    # Idempotent across re-import and across os.execv (env inherited).
+    if os.environ.get(_SENTINEL):
+        return
+
     pkg_dir = os.path.dirname(os.path.abspath(__file__))
     plugin_root = os.path.dirname(pkg_dir)
-    venv_dir = os.path.join(plugin_root, '.eval-venv')
-    venv_python = os.path.join(venv_dir, 'bin', 'python3')
-    if not os.path.isfile(venv_python):
-        # uv venvs may use versioned name (e.g., python3.14)
-        v = sys.version_info
-        venv_python = os.path.join(venv_dir, 'bin', f'python{v.major}.{v.minor}')
+    venv_python, site_dirs = _venv_python_and_site(plugin_root)
 
-    if not os.path.isfile(venv_python):
+    # No venv (e.g. in-container harbor verifier / evalhub pod) — nothing to do.
+    if not venv_python or not site_dirs:
+        os.environ[_SENTINEL] = "1"
         return
 
-    site_dirs = glob.glob(os.path.join(
-        venv_dir, 'lib', 'python*', 'site-packages'))
+    running = f"{sys.version_info.major}.{sys.version_info.minor}"
+    venv_ver = _venv_pyver(site_dirs)
+    abi_mismatch = venv_ver is not None and venv_ver != running
 
-    # Already activated (venv site-packages on sys.path)
-    if site_dirs and all(d in sys.path for d in site_dirs):
+    # Set before any potential execv so the re-exec'd image short-circuits.
+    os.environ[_SENTINEL] = "1"
+
+    # Default, always-safe path: make deps importable in THIS process.
+    if not abi_mismatch:
+        _patch_syspath(site_dirs)
         return
 
-    # For -c invocations, we can't re-exec (the inline code isn't in
-    # sys.argv). Patch sys.path instead so third-party imports resolve.
-    if sys.argv[:1] == ['-c']:
-        for d in site_dirs:
-            if d not in sys.path:
-                sys.path.insert(0, d)
-        return
-
-    os.execv(venv_python, [venv_python] + sys.argv)
+    # ABI mismatch: sys.path patching would load incompatible compiled wheels.
+    # Re-exec into the venv interpreter ONLY when it is provably safe — a true
+    # top-level script entry, before any side effects. For -m / -c / exec_module
+    # we must NOT execv (it would re-run __main__ after side effects, or there's
+    # no script to re-run); fall back to patching and let an incompatible .so
+    # import fail loudly rather than silently double-running.
+    if _is_true_script_entry():
+        os.execv(venv_python, [venv_python] + sys.argv)
+    else:
+        _patch_syspath(site_dirs)
 
 
 _activate()

--- a/agent_eval/evalhub/runner.py
+++ b/agent_eval/evalhub/runner.py
@@ -17,6 +17,7 @@ OpenShift). The server creates the Job pod; the adapter runs in-process inside
 it (no sub-pods, no Harbor).
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv before 3p imports
 import argparse
 import importlib.util
 import json

--- a/agent_eval/harbor/reward.py
+++ b/agent_eval/harbor/reward.py
@@ -26,6 +26,7 @@ Usage:
         [--run-id <id>] [--out-dir /logs/verifier]
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv before 3p imports
 import argparse
 import importlib.util
 import json

--- a/agent_eval/harbor/run.py
+++ b/agent_eval/harbor/run.py
@@ -12,6 +12,7 @@ so this step does not re-run judges; it aggregates their results. Pairwise stays
 a suite-level step on top (run separately over two run dirs).
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv before 3p imports
 import argparse
 import importlib.util
 import json

--- a/agent_eval/hooks.py
+++ b/agent_eval/hooks.py
@@ -4,6 +4,7 @@ Runs user-defined shell commands at well-defined points in the eval
 lifecycle (before_all, before_each, after_each, before_scoring, after_all).
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv before 3p imports
 import os
 import signal
 import subprocess

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -256,7 +256,15 @@ it handles task generation (or reuse), `harbor run`, per-case judging (in-contai
 result mapping, and report generation in one call:
 
 ```bash
-PYTHONPATH="$(pwd)" python3 -m agent_eval.harbor.run \
+# Run under the eval-harness venv interpreter so compiled deps load with the
+# correct ABI and the process is never re-exec'd mid-run. Falls back to system
+# python3 if the venv is absent. The venv holds only third-party deps, so the
+# plugin root (source of the agent_eval package) must be on PYTHONPATH.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$CLAUDE_SKILL_DIR/../..}"
+VENV_PY="$PLUGIN_ROOT/.eval-venv/bin/python3"
+[ -x "$VENV_PY" ] || VENV_PY=python3
+
+PYTHONPATH="$PLUGIN_ROOT:$(pwd)" "$VENV_PY" -m agent_eval.harbor.run \
     --config <config> --model <model> \
     --output $AGENT_EVAL_RUNS_DIR/<eval-name>/<run-id> \
     --tasks-dir <tasks-dir> --jobs-dir <tmp-jobs> \
@@ -282,7 +290,11 @@ runner instead — it creates ConfigMaps, submits a job to EvalHub, polls for
 completion, and maps the results back:
 
 ```bash
-python3 -m agent_eval.evalhub.runner \
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$CLAUDE_SKILL_DIR/../..}"
+VENV_PY="$PLUGIN_ROOT/.eval-venv/bin/python3"
+[ -x "$VENV_PY" ] || VENV_PY=python3
+
+PYTHONPATH="$PLUGIN_ROOT:$(pwd)" "$VENV_PY" -m agent_eval.evalhub.runner \
     --config <config> --model <model> \
     --output $AGENT_EVAL_RUNS_DIR/<eval-name>/<run-id> \
     [--evalhub-url <url>] [--namespace <ns>] [--project-dir <path>]

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -264,7 +264,7 @@ PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$CLAUDE_SKILL_DIR/../..}"
 VENV_PY="$PLUGIN_ROOT/.eval-venv/bin/python3"
 [ -x "$VENV_PY" ] || VENV_PY=python3
 
-PYTHONPATH="$PLUGIN_ROOT:$(pwd)" "$VENV_PY" -m agent_eval.harbor.run \
+PYTHONPATH="$PLUGIN_ROOT:$(pwd)${PYTHONPATH:+:$PYTHONPATH}" "$VENV_PY" -m agent_eval.harbor.run \
     --config <config> --model <model> \
     --output $AGENT_EVAL_RUNS_DIR/<eval-name>/<run-id> \
     --tasks-dir <tasks-dir> --jobs-dir <tmp-jobs> \
@@ -294,7 +294,7 @@ PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$CLAUDE_SKILL_DIR/../..}"
 VENV_PY="$PLUGIN_ROOT/.eval-venv/bin/python3"
 [ -x "$VENV_PY" ] || VENV_PY=python3
 
-PYTHONPATH="$PLUGIN_ROOT:$(pwd)" "$VENV_PY" -m agent_eval.evalhub.runner \
+PYTHONPATH="$PLUGIN_ROOT:$(pwd)${PYTHONPATH:+:$PYTHONPATH}" "$VENV_PY" -m agent_eval.evalhub.runner \
     --config <config> --model <model> \
     --output $AGENT_EVAL_RUNS_DIR/<eval-name>/<run-id> \
     [--evalhub-url <url>] [--namespace <ns>] [--project-dir <path>]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,171 @@
+"""Tests for agent_eval._bootstrap venv activation.
+
+Regression coverage for the duplicate-run bug: _bootstrap must NEVER os.execv
+when it is reached via `python -m`, `python -c`, or importlib exec_module —
+only for a genuine top-level script entry under an ABI-mismatched interpreter.
+The default action is sys.path patching, which is re-entrant and side-effect-free.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval import _bootstrap
+
+_REPO = Path(__file__).parent.parent
+_RUNNING = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+
+@pytest.fixture
+def clean_sentinel(monkeypatch):
+    monkeypatch.delenv(_bootstrap._SENTINEL, raising=False)
+    yield
+
+
+def _set_main_spec(monkeypatch, spec):
+    main = sys.modules["__main__"]
+    monkeypatch.setattr(main, "__spec__", spec, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _venv_pyver — guards the '.../lib/pythonX.Y/site-packages' parse
+# (a dirname-too-deep bug here silently disables ABI-mismatch detection)
+# ---------------------------------------------------------------------------
+
+def test_venv_pyver_extracts_version():
+    site = "/x/.eval-venv/lib/python3.11/site-packages"
+    assert _bootstrap._venv_pyver([site]) == "3.11"
+
+
+def test_venv_pyver_none_on_nonstandard_layout():
+    assert _bootstrap._venv_pyver(["/x/.eval-venv/weird/site-packages"]) is None
+
+
+# ---------------------------------------------------------------------------
+# _is_true_script_entry — the execv discriminator
+# ---------------------------------------------------------------------------
+
+def test_script_entry_true_for_plain_script(monkeypatch):
+    _set_main_spec(monkeypatch, None)
+    monkeypatch.setattr(sys, "argv", ["/some/script.py", "--flag"])
+    assert _bootstrap._is_true_script_entry() is True
+
+
+def test_script_entry_false_for_dash_c(monkeypatch):
+    _set_main_spec(monkeypatch, None)
+    monkeypatch.setattr(sys, "argv", ["-c"])
+    assert _bootstrap._is_true_script_entry() is False
+
+
+def test_script_entry_false_for_dash_m(monkeypatch):
+    # `python -m pkg.mod` leaves a non-None ModuleSpec on __main__.
+    import importlib.machinery
+    _set_main_spec(monkeypatch, importlib.machinery.ModuleSpec("pkg.mod", None))
+    monkeypatch.setattr(sys, "argv", ["/abs/path/mod.py"])
+    assert _bootstrap._is_true_script_entry() is False
+
+
+# ---------------------------------------------------------------------------
+# _activate — never execv on -m / -c; execv only on script + ABI mismatch
+# ---------------------------------------------------------------------------
+
+def _arm(monkeypatch, venv_ver):
+    """Make _activate see a venv whose site-packages report python<venv_ver>."""
+    site = f"/fake/.eval-venv/lib/python{venv_ver}/site-packages"
+    monkeypatch.setattr(_bootstrap, "_venv_python_and_site",
+                        lambda root: ("/fake/.eval-venv/bin/python3", [site]))
+    execv_calls, patch_calls = [], []
+    monkeypatch.setattr(os, "execv", lambda *a: execv_calls.append(a))
+    monkeypatch.setattr(_bootstrap, "_patch_syspath", lambda s: patch_calls.append(s))
+    return execv_calls, patch_calls
+
+
+def test_activate_abi_match_patches_no_execv(clean_sentinel, monkeypatch):
+    execv_calls, patch_calls = _arm(monkeypatch, _RUNNING)
+    _set_main_spec(monkeypatch, None)
+    monkeypatch.setattr(sys, "argv", ["/some/script.py"])
+    _bootstrap._activate()
+    assert execv_calls == []
+    assert patch_calls and os.environ.get(_bootstrap._SENTINEL) == "1"
+
+
+def test_activate_abi_mismatch_script_execs(clean_sentinel, monkeypatch):
+    execv_calls, patch_calls = _arm(monkeypatch, "2.0")  # != running
+    _set_main_spec(monkeypatch, None)
+    monkeypatch.setattr(sys, "argv", ["/some/script.py"])
+    _bootstrap._activate()
+    assert len(execv_calls) == 1
+    assert execv_calls[0][0] == "/fake/.eval-venv/bin/python3"
+
+
+def test_activate_abi_mismatch_dash_m_does_not_exec(clean_sentinel, monkeypatch):
+    import importlib.machinery
+    execv_calls, patch_calls = _arm(monkeypatch, "2.0")  # mismatch, but -m
+    _set_main_spec(monkeypatch, importlib.machinery.ModuleSpec("agent_eval.harbor.run", None))
+    monkeypatch.setattr(sys, "argv", ["/abs/run.py", "--config", "x"])
+    _bootstrap._activate()
+    assert execv_calls == []           # the duplicate-run bug must not reappear
+    assert patch_calls                  # falls back to sys.path patch
+
+
+def test_activate_sentinel_short_circuits(clean_sentinel, monkeypatch):
+    monkeypatch.setenv(_bootstrap._SENTINEL, "1")
+    called = []
+    monkeypatch.setattr(_bootstrap, "_venv_python_and_site",
+                        lambda root: called.append(1) or (None, []))
+    _bootstrap._activate()
+    assert called == []  # returned before touching anything
+
+
+def test_activate_no_venv_is_noop(clean_sentinel, monkeypatch):
+    monkeypatch.setattr(_bootstrap, "_venv_python_and_site", lambda root: (None, []))
+    execv_calls = []
+    monkeypatch.setattr(os, "execv", lambda *a: execv_calls.append(a))
+    _bootstrap._activate()
+    assert execv_calls == []
+    assert os.environ.get(_bootstrap._SENTINEL) == "1"
+
+
+# ---------------------------------------------------------------------------
+# Integration: faithfully reproduce the harbor path in a fresh process —
+# deferred first import of _bootstrap via exec_module must NOT os.execv.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not (_REPO / ".eval-venv").is_dir(),
+                    reason="no .eval-venv to activate")
+def test_exec_module_deferred_import_never_execs(tmp_path):
+    loaded = tmp_path / "loaded.py"
+    loaded.write_text("import agent_eval._bootstrap\nVALUE = 42\n")
+
+    child = tmp_path / "child.py"
+    child.write_text(textwrap.dedent(f"""
+        import os, sys, importlib.util
+        # Detect any process replacement attempt without performing it.
+        os.execv = lambda *a, **k: (_ for _ in ()).throw(
+            SystemExit("EXECV_CALLED"))
+        # Mimic run.py: import agent_eval WITHOUT _bootstrap, then load a file
+        # by path whose first line imports _bootstrap (the deferred first import).
+        import agent_eval
+        assert "agent_eval._bootstrap" not in sys.modules, "bootstrap leaked early"
+        spec = importlib.util.spec_from_file_location("loaded_mod", {str(loaded)!r})
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        print("OK", mod.VALUE)
+    """))
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_REPO)
+    env.pop("_AGENT_EVAL_BOOTSTRAP_DONE", None)
+    # Run from a neutral cwd under the SYSTEM python (the bug's trigger).
+    proc = subprocess.run([sys.executable, str(child)], cwd=str(tmp_path),
+                          env=env, capture_output=True, text=True, timeout=120)
+    assert "EXECV_CALLED" not in (proc.stdout + proc.stderr), \
+        f"os.execv fired on the exec_module path:\n{proc.stdout}\n{proc.stderr}"
+    assert proc.returncode == 0, f"child failed:\n{proc.stdout}\n{proc.stderr}"
+    assert "OK 42" in proc.stdout

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,12 +1,14 @@
 """Tests for agent_eval._bootstrap venv activation.
 
 Regression coverage for the duplicate-run bug: _bootstrap must NEVER os.execv
-when it is reached via `python -m`, `python -c`, or importlib exec_module —
-only for a genuine top-level script entry under an ABI-mismatched interpreter.
-The default action is sys.path patching, which is re-entrant and side-effect-free.
+when it is reached via `python -m`, `python -c`, `python -`, the REPL, or
+importlib exec_module — only for a genuine top-level script entry under an
+ABI-mismatched interpreter. The default action is sys.path patching, which is
+re-entrant and side-effect-free.
 """
 
 import os
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -18,7 +20,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from agent_eval import _bootstrap
 
-_REPO = Path(__file__).parent.parent
 _RUNNING = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 
@@ -35,7 +36,6 @@ def _set_main_spec(monkeypatch, spec):
 
 # ---------------------------------------------------------------------------
 # _venv_pyver — guards the '.../lib/pythonX.Y/site-packages' parse
-# (a dirname-too-deep bug here silently disables ABI-mismatch detection)
 # ---------------------------------------------------------------------------
 
 def test_venv_pyver_extracts_version():
@@ -61,6 +61,15 @@ def test_script_entry_false_for_dash_c(monkeypatch):
     _set_main_spec(monkeypatch, None)
     monkeypatch.setattr(sys, "argv", ["-c"])
     assert _bootstrap._is_true_script_entry() is False
+
+
+def test_script_entry_false_for_stdin_repl_empty(monkeypatch):
+    # `python -` (stdin), REPL/embedded (argv[0] == ''), and an empty argv have
+    # no real script file to re-exec, so they must not take the execv path.
+    _set_main_spec(monkeypatch, None)
+    for argv in (["-"], [""], []):
+        monkeypatch.setattr(sys, "argv", argv)
+        assert _bootstrap._is_true_script_entry() is False, argv
 
 
 def test_script_entry_false_for_dash_m(monkeypatch):
@@ -133,39 +142,84 @@ def test_activate_no_venv_is_noop(clean_sentinel, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Integration: faithfully reproduce the harbor path in a fresh process —
-# deferred first import of _bootstrap via exec_module must NOT os.execv.
+# Integration: a fresh process with a *fake ABI-mismatched* .eval-venv, so the
+# mismatch branch is exercised regardless of the test runner's interpreter
+# (no skip, never vacuous). The `-m` case faithfully reproduces how the harbor
+# runner is launched; the true-script case is a positive control proving the
+# mismatch branch is actually reachable in this harness.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.skipif(not (_REPO / ".eval-venv").is_dir(),
-                    reason="no .eval-venv to activate")
-def test_exec_module_deferred_import_never_execs(tmp_path):
-    loaded = tmp_path / "loaded.py"
-    loaded.write_text("import agent_eval._bootstrap\nVALUE = 42\n")
+# Spy installed before any agent_eval import: records an execv attempt to a
+# marker file instead of replacing the process.
+_EXECV_SPY = textwrap.dedent("""
+    import os
+    def _spy(*a, **k):
+        with open(os.environ["EXECV_MARKER"], "w") as f:
+            f.write("EXECV")
+        raise SystemExit("execv-attempted")
+    os.execv = _spy
+""")
 
-    child = tmp_path / "child.py"
-    child.write_text(textwrap.dedent(f"""
-        import os, sys, importlib.util
-        # Detect any process replacement attempt without performing it.
-        os.execv = lambda *a, **k: (_ for _ in ()).throw(
-            SystemExit("EXECV_CALLED"))
-        # Mimic run.py: import agent_eval WITHOUT _bootstrap, then load a file
-        # by path whose first line imports _bootstrap (the deferred first import).
+
+def _make_fake_plugin(tmp_path, venv_pyver="0.0"):
+    """Throwaway plugin root: a copy of _bootstrap plus a fake .eval-venv whose
+    python<venv_pyver> never matches the runner -> always the ABI-mismatch path."""
+    root = tmp_path / "plugin"
+    pkg = root / "agent_eval"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")  # no _bootstrap import (mirrors real __init__)
+    shutil.copy(_bootstrap.__file__, pkg / "_bootstrap.py")
+    venv = root / ".eval-venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python3").write_text("")  # only needs to be a regular file
+    (venv / "lib" / f"python{venv_pyver}" / "site-packages").mkdir(parents=True)
+    return root
+
+
+def _run_child(root, code, module=None):
+    marker = root / "execv.marker"
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(root)          # isolate: only the fake agent_eval
+    env["EXECV_MARKER"] = str(marker)
+    env.pop("_AGENT_EVAL_BOOTSTRAP_DONE", None)
+    if module:
+        (root / f"{module}.py").write_text(code)
+        cmd = [sys.executable, "-m", module]
+    else:
+        script = root / "child_script.py"
+        script.write_text(code)
+        cmd = [sys.executable, str(script)]
+    proc = subprocess.run(cmd, cwd=str(root), env=env,
+                          capture_output=True, text=True, timeout=120)
+    return proc, marker.exists()
+
+
+def test_dash_m_under_abi_mismatch_does_not_exec(tmp_path):
+    # `python -m childmod` -> __main__.__spec__ non-None (like the harbor runner).
+    # The deferred exec_module import of _bootstrap must NOT execv even though the
+    # fake venv is ABI-mismatched.
+    root = _make_fake_plugin(tmp_path)
+    (root / "loaded.py").write_text("import agent_eval._bootstrap\nVALUE = 42\n")
+    code = _EXECV_SPY + textwrap.dedent("""
+        import sys, os, importlib.util
         import agent_eval
         assert "agent_eval._bootstrap" not in sys.modules, "bootstrap leaked early"
-        spec = importlib.util.spec_from_file_location("loaded_mod", {str(loaded)!r})
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        print("OK", mod.VALUE)
-    """))
+        p = os.path.join(os.path.dirname(__file__), "loaded.py")
+        spec = importlib.util.spec_from_file_location("loaded_mod", p)
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        print("OK", m.VALUE)
+    """)
+    proc, execd = _run_child(root, code, module="childmod")
+    assert not execd, f"execv fired on the -m path:\n{proc.stdout}\n{proc.stderr}"
+    assert proc.returncode == 0 and "OK 42" in proc.stdout, \
+        f"child failed:\n{proc.stdout}\n{proc.stderr}"
 
-    env = dict(os.environ)
-    env["PYTHONPATH"] = str(_REPO)
-    env.pop("_AGENT_EVAL_BOOTSTRAP_DONE", None)
-    # Run from a neutral cwd under the SYSTEM python (the bug's trigger).
-    proc = subprocess.run([sys.executable, str(child)], cwd=str(tmp_path),
-                          env=env, capture_output=True, text=True, timeout=120)
-    assert "EXECV_CALLED" not in (proc.stdout + proc.stderr), \
-        f"os.execv fired on the exec_module path:\n{proc.stdout}\n{proc.stderr}"
-    assert proc.returncode == 0, f"child failed:\n{proc.stdout}\n{proc.stderr}"
-    assert "OK 42" in proc.stdout
+
+def test_true_script_under_abi_mismatch_execs(tmp_path):
+    # Positive control: a real top-level script under the SAME fake ABI-mismatch
+    # venv DOES take the execv path — so the -m test above is not passing vacuously.
+    root = _make_fake_plugin(tmp_path)
+    code = _EXECV_SPY + "import agent_eval._bootstrap\nprint('NO EXEC')\n"
+    proc, execd = _run_child(root, code)  # plain `python child_script.py`
+    assert execd, f"expected execv on true-script ABI mismatch:\n{proc.stdout}\n{proc.stderr}"

--- a/tests/test_hook_outputs.py
+++ b/tests/test_hook_outputs.py
@@ -12,11 +12,6 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Neutralize _bootstrap before importing execute.py/score.py — prevents
-# os.execv from replacing the pytest process when running under system python.
-_real_execv = os.execv
-os.execv = lambda *a, **kw: None  # no-op during import
-
 from agent_eval.agent.base import RunResult
 from agent_eval.config import DatasetConfig, EvalConfig, HookEntry, HooksConfig
 from agent_eval.hooks import (
@@ -25,8 +20,6 @@ from agent_eval.hooks import (
 )
 from execute import _run_single_case
 from score import load_case_record
-
-os.execv = _real_execv  # restore
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The Harbor runner (`python -m agent_eval.harbor.run`) could launch its pods **twice** — e.g. 40 pods for a 20-case run — with the first run's results abandoned and never reported.

## Root cause

`be6afb6` moved venv activation out of `agent_eval/__init__.py` on the assumption that *"individual skill scripts already import `agent_eval._bootstrap` where needed."* That holds for the `python3 script.py` skill scripts, but **not** for the `-m` entrypoints (`harbor/run.py`, `evalhub/runner.py`, …), which never import `_bootstrap`.

As a result, on the harbor path `_bootstrap`'s **first** import is deferred until `_write_report()` loads `report.py` via `importlib.exec_module` — ~22 min into the run, *after* the pods launched and `summary.yaml` was written. At that point `_activate()` ran `os.execv` to the venv python; because `-m` rewrites `sys.argv[0]` to `run.py`'s path, the re-exec re-ran `main()` → a second `harbor run` → double pods.

## Fix (defense in depth)

- **`_bootstrap.py`**: default to `sys.path` patching (re-entrant, side-effect-free). Use `os.execv` **only** for a genuine top-level script (`__main__.__spec__ is None`, `argv[0] != '-c'`) under an ABI-mismatched interpreter — never for `-m`, `-c`, or `exec_module`. Idempotent via an env-var sentinel that survives `execv`.
- **`SKILL.md`**: run the harbor/evalhub `-m` entrypoints under the venv interpreter (`$VENV_PY -m …` with the plugin root on `PYTHONPATH`).
- **Restore the self-bootstrap invariant** `be6afb6` assumed: add `import agent_eval._bootstrap` to the `-m` entrypoints that lacked it (`run.py`, `evalhub/runner.py`, `harbor/reward.py`, `hooks.py`). Safe now that bootstrap no longer execs for `-m`.
- Drop the now-unneeded `os.execv` monkeypatch in `tests/test_hook_outputs.py`.

## Tests

`tests/test_bootstrap.py`: the execv discriminator, the `sys.path`-patch default, and a **subprocess test reproducing the deferred-import → exec_module path** that asserts `os.execv` never fires (no double-run). Verified end-to-end on a 20-case Kubernetes run: a single `harbor run`, 20 pods (not 40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved startup handling for eval-related commands so they more reliably use the bundled environment when available.
  * Updated runner instructions to automatically prefer the project’s dedicated Python environment, with a safe fallback to system Python.

* **Bug Fixes**
  * Reduced repeated initialization during re-imports and process restarts.
  * Improved behavior when Python version details don’t match the environment, helping avoid incorrect execution paths.
  * Added broader regression coverage for environment activation and hook execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->