### PR TITLE
feat(harbor): retry transient k8s exec failures and surface infra errors

### DIFF
--- a/agent_eval/harbor/kubernetes.py
+++ b/agent_eval/harbor/kubernetes.py
@@ -476,13 +476,18 @@ class KubernetesEnvironment(BaseEnvironment):
         t = threading.Thread(target=_run, daemon=True)
         t.start()
         t.join(timeout=hard_limit)
-        is_established = bool(established)
         if t.is_alive():
             stop_ping.set()
+            # The worker is still alive (likely wedged in k8s_stream). It may yet
+            # establish the connection and run the command after we return, so we
+            # must NOT report "never established" — that would let the caller
+            # retry and double-execute a non-idempotent command. Force
+            # established=True so this attempt is treated as non-retryable.
             return ExecResult(
                 stdout="",
                 stderr=f"[ws_exec hard timeout after {hard_limit}s — HAProxy connection dead]",
-                return_code=124), is_established, None
+                return_code=124), True, None
+        is_established = bool(established)
         if exc_holder:
             return ExecResult(
                 stdout="", stderr=f"[exec error: {exc_holder[0]}]",

--- a/agent_eval/harbor/kubernetes.py
+++ b/agent_eval/harbor/kubernetes.py
@@ -380,20 +380,34 @@ class KubernetesEnvironment(BaseEnvironment):
             except Exception:
                 break
 
-    def _ws_exec(self, command: str, timeout_sec: int | None) -> ExecResult:
-        """WebSocket exec with a keepalive ping for HAProxy resilience.
+    # Retry only failures that happen BEFORE the command starts executing
+    # (the WebSocket never established). At that point nothing ran in the
+    # container, so a retry is safe even for non-idempotent commands like the
+    # agent run. Post-establishment drops/timeouts are NEVER retried here —
+    # re-running a command that may have already executed (the agent!) would be
+    # unsafe; long connections are protected by the keepalive instead.
+    _EXEC_ESTABLISH_RETRIES = 2      # total attempts = retries + 1
+    _EXEC_RETRY_BACKOFF_SEC = 0.5    # 0.5s, 1.0s, ...
 
-        OpenShift's HAProxy router drops WebSocket connections idle for ≥60 s.
-        Sending a ping frame every 30 s resets the idle timer and keeps the
-        single long-lived connection alive for the full agent run.
+    def _ws_exec_once(
+        self, command: str, timeout_sec: int | None
+    ) -> tuple[ExecResult, bool, BaseException | None]:
+        """Single WebSocket exec attempt.
 
-        A daemon thread with a hard wall-clock deadline guards against the
-        ``resp.close()`` / ``read_channel()`` deadlock that occurs when HAProxy
-        silently tears down a connection without sending a TCP FIN or WebSocket
-        close frame.
+        Returns ``(result, established, exc)`` where *established* is True once
+        ``k8s_stream`` has returned a live connection (i.e. the command has been
+        handed to the container). When *established* is False the command
+        provably never ran, so the caller may safely retry.
+
+        A keepalive ping every 30 s resets HAProxy's ≥60 s idle timer so a long
+        agent run survives on a single connection. A daemon thread with a hard
+        wall-clock deadline guards against the ``resp.close()`` /
+        ``read_channel()`` deadlock that occurs when HAProxy silently tears down
+        a connection without a TCP FIN or WebSocket close frame.
         """
         result_holder: list[ExecResult] = []
         exc_holder:    list[BaseException] = []
+        established:   list[bool] = []
         stop_ping = threading.Event()
         ws_lock   = threading.Lock()
 
@@ -406,6 +420,7 @@ class KubernetesEnvironment(BaseEnvironment):
                     stderr=True, stdin=False, stdout=True, tty=False,
                     _preload_content=False,
                 )
+                established.append(True)  # connection up — command is now running
                 threading.Thread(
                     target=self._ws_keepalive,
                     args=(resp, 30, stop_ping, ws_lock),
@@ -461,16 +476,49 @@ class KubernetesEnvironment(BaseEnvironment):
         t = threading.Thread(target=_run, daemon=True)
         t.start()
         t.join(timeout=hard_limit)
+        is_established = bool(established)
         if t.is_alive():
             stop_ping.set()
             return ExecResult(
                 stdout="",
                 stderr=f"[ws_exec hard timeout after {hard_limit}s — HAProxy connection dead]",
-                return_code=124)
+                return_code=124), is_established, None
         if exc_holder:
-            raise exc_holder[0]
-        return result_holder[0] if result_holder else ExecResult(
+            return ExecResult(
+                stdout="", stderr=f"[exec error: {exc_holder[0]}]",
+                return_code=1), is_established, exc_holder[0]
+        result = result_holder[0] if result_holder else ExecResult(
             stdout="", stderr="[no result from exec thread]", return_code=1)
+        return result, is_established, None
+
+    def _ws_exec(self, command: str, timeout_sec: int | None) -> ExecResult:
+        """WebSocket exec, retrying only pre-execution (establishment) failures.
+
+        Wraps :meth:`_ws_exec_once`. A failure where the connection never
+        established (transient HAProxy refusal/drop during ``k8s_stream``) is
+        retried with backoff because the command provably never ran. Any failure
+        after the command started — timeout, mid-stream drop, non-zero exit — is
+        returned/raised as-is so a possibly-executed command is never re-run.
+        """
+        attempts = self._EXEC_ESTABLISH_RETRIES + 1
+        for attempt in range(1, attempts + 1):
+            result, established, exc = self._ws_exec_once(command, timeout_sec)
+            if established:
+                if exc is not None:
+                    raise exc  # post-establishment failure — preserve old contract
+                return result
+            # Not established: the command never started — safe to retry.
+            if attempt < attempts:
+                backoff = self._EXEC_RETRY_BACKOFF_SEC * (2 ** (attempt - 1))
+                self.logger.warning(
+                    "exec failed to establish (attempt %d/%d); retrying in %.1fs: %s",
+                    attempt, attempts, backoff, (result.stderr or "")[:160])
+                time.sleep(backoff)
+                continue
+            # Exhausted retries with no establishment.
+            if exc is not None:
+                raise exc
+            return result
 
     async def exec(
         self,

--- a/agent_eval/harbor/results.py
+++ b/agent_eval/harbor/results.py
@@ -90,6 +90,7 @@ def parse_trial(trial_dir: Path) -> dict | None:
         "metrics": metrics,
         "per_judge": {},
         "errored": False,
+        "infra_error_steps": [],
         "cost_usd": None,
         "token_usage": None,
     }
@@ -154,6 +155,7 @@ def _parse_multi_step_trial(trial_dir: Path, steps_dir: Path) -> dict | None:
 
     rewards = []
     per_judge: dict = {}
+    infra_error_steps: list[str] = []
     total_cost = 0.0
     total_turns = 0
     total_duration = 0.0
@@ -163,6 +165,11 @@ def _parse_multi_step_trial(trial_dir: Path, steps_dir: Path) -> dict | None:
     for step_dir in step_dirs:
         step_name = step_dir.name
 
+        # The verifier (test.sh) always writes reward.json as its last action,
+        # so a present-and-parseable reward means the verifier actually ran.
+        # A missing/unreadable reward.json means the verifier never completed —
+        # almost always a transient k8s exec / HAProxy connection drop, NOT a
+        # genuine score of 0. We must not conflate the two.
         reward_path = step_dir / "verifier" / "reward.json"
         step_reward = None
         if reward_path.is_file():
@@ -172,7 +179,10 @@ def _parse_multi_step_trial(trial_dir: Path, steps_dir: Path) -> dict | None:
             except (json.JSONDecodeError, OSError):
                 pass
 
-        if isinstance(step_reward, (int, float)):
+        # bool is an int subclass — guard so a genuine reward of 0.0 still
+        # counts toward the mean while a missing reward never does.
+        verifier_ran = isinstance(step_reward, (int, float)) and not isinstance(step_reward, bool)
+        if verifier_ran:
             rewards.append(step_reward)
 
         transcript = step_dir / "agent" / "claude-code.txt"
@@ -192,11 +202,23 @@ def _parse_multi_step_trial(trial_dir: Path, steps_dir: Path) -> dict | None:
             rationale_parts.append(f"{step_duration:.0f}s")
         rationale = ", ".join(rationale_parts) if rationale_parts else ""
 
-        per_judge[step_name] = {
-            "value": step_reward if step_reward is not None else False,
-            "rationale": rationale,
-            "judge_type": "step",
-        }
+        if verifier_ran:
+            per_judge[step_name] = {
+                "value": step_reward,
+                "rationale": rationale,
+                "judge_type": "step",
+            }
+        else:
+            # value=None (not False) so it is excluded from the judge mean and
+            # not counted as a real 0. Flagged so the run can surface it.
+            per_judge[step_name] = {
+                "value": None,
+                "rationale": (rationale + "; " if rationale else "")
+                + "verifier produced no reward (infra/exec failure, not a score)",
+                "judge_type": "step",
+                "error": "no_verifier_reward",
+            }
+            infra_error_steps.append(step_name)
 
         if isinstance(step_cost, (int, float)):
             total_cost += step_cost
@@ -235,6 +257,7 @@ def _parse_multi_step_trial(trial_dir: Path, steps_dir: Path) -> dict | None:
         "metrics": {s.name: per_judge[s.name]["value"] for s in step_dirs},
         "per_judge": per_judge,
         "errored": (trial_dir / "exception.txt").is_file(),
+        "infra_error_steps": infra_error_steps,
         "cost_usd": total_cost if total_cost > 0 else None,
         "token_usage": token_totals or None,
         "num_turns": total_turns if total_turns > 0 else None,
@@ -262,6 +285,12 @@ def parse_job(job_dir: Path) -> dict:
 
     rewards = [t["reward"] for t in trials if isinstance(t.get("reward"), (int, float))]
     mean_reward = sum(rewards) / len(rewards) if rewards else None
+
+    # Steps whose verifier never produced a reward (transient k8s exec / HAProxy
+    # drop). Surfaced separately so they are visible rather than silently scored 0.
+    infra_errors = [(t["case_id"], step)
+                    for t in trials
+                    for step in t.get("infra_error_steps", [])]
 
     # Aggregate each metric across trials (mean), mirroring score.py's shape.
     aggregated: dict[str, dict] = {}
@@ -316,6 +345,8 @@ def parse_job(job_dir: Path) -> dict:
         "mean_reward": mean_reward,
         "n_completed": len(trials),
         "n_errored": sum(1 for t in trials if t["errored"]),
+        "infra_errors": infra_errors,
+        "n_infra_errors": len(infra_errors),
         "aggregated": aggregated,
         "cost_usd": total_cost,
         "token_usage": token_usage or None,

--- a/agent_eval/harbor/results.py
+++ b/agent_eval/harbor/results.py
@@ -62,18 +62,64 @@ def _extract_transcript_metrics(transcript_path: Path) -> dict:
     return result
 
 
+def _errored_trial_record(trial_dir: Path) -> dict:
+    """Minimal record for a trial that failed before producing any reward.
+
+    Used when Harbor wrote an ``exception.txt`` but no ``steps/`` or
+    ``reward.json`` (e.g. the pod never became Ready). Surfaced rather than
+    dropped so the run counts all attempted cases and the failure is visible.
+    """
+    reason = "trial failed before producing a reward"
+    try:
+        # exception.txt is usually a Python traceback; the last non-empty line
+        # carries the actual error (e.g. "RuntimeError: pod ... not Ready").
+        lines = [ln.strip() for ln in
+                 (trial_dir / "exception.txt").read_text().splitlines()
+                 if ln.strip()]
+        if lines:
+            reason = lines[-1][:200]
+    except OSError:
+        pass
+    return {
+        "case_id": _case_id_from_dir(trial_dir),
+        "trial_dir": trial_dir.name,
+        "trial_path": str(trial_dir),
+        "reward": None,
+        "metrics": {},
+        "per_judge": {},
+        "errored": True,
+        "infra_error_steps": [],
+        "trial_error": reason,
+        "cost_usd": None,
+        "token_usage": None,
+        "num_turns": None,
+        "duration_s": None,
+        "agent_version": None,
+    }
+
+
 def parse_trial(trial_dir: Path) -> dict | None:
     """Parse one Harbor trial directory. Returns None if it has no reward.
 
     Supports both single-step trials (reward at ``verifier/reward.json``)
     and multi-step trials (per-step rewards under ``steps/<name>/verifier/``).
+    A trial that failed before producing any reward but has Harbor's
+    ``exception.txt`` is returned as a minimal errored record (not None).
     """
     steps_dir = trial_dir / "steps"
     if steps_dir.is_dir() and any(steps_dir.iterdir()):
-        return _parse_multi_step_trial(trial_dir, steps_dir)
+        rec = _parse_multi_step_trial(trial_dir, steps_dir)
+        if rec is not None:
+            return rec
 
     reward_path = trial_dir / "verifier" / "reward.json"
     if not reward_path.is_file():
+        # No reward at all. If Harbor recorded a trial-level failure
+        # (exception.txt), surface it as an errored trial rather than dropping
+        # it silently — a pod that never became Ready would otherwise vanish
+        # from the run and under-count the case total.
+        if (trial_dir / "exception.txt").is_file():
+            return _errored_trial_record(trial_dir)
         return None
 
     try:
@@ -292,6 +338,11 @@ def parse_job(job_dir: Path) -> dict:
                     for t in trials
                     for step in t.get("infra_error_steps", [])]
 
+    # Trials that failed before producing any reward (e.g. pod never Ready).
+    # Surfaced so they are visible rather than dropped from the case total.
+    trial_errors = [(t["case_id"], t["trial_error"])
+                    for t in trials if t.get("trial_error")]
+
     # Aggregate each metric across trials (mean), mirroring score.py's shape.
     aggregated: dict[str, dict] = {}
     for trial in trials:
@@ -347,6 +398,8 @@ def parse_job(job_dir: Path) -> dict:
         "n_errored": sum(1 for t in trials if t["errored"]),
         "infra_errors": infra_errors,
         "n_infra_errors": len(infra_errors),
+        "trial_errors": trial_errors,
+        "n_trial_errors": len(trial_errors),
         "aggregated": aggregated,
         "cost_usd": total_cost,
         "token_usage": token_usage or None,

--- a/agent_eval/harbor/results.py
+++ b/agent_eval/harbor/results.py
@@ -77,7 +77,11 @@ def _errored_trial_record(trial_dir: Path) -> dict:
                  (trial_dir / "exception.txt").read_text().splitlines()
                  if ln.strip()]
         if lines:
-            reason = lines[-1][:200]
+            # exception.txt is untrusted (a failing container controls it).
+            # Escape control chars / ANSI / newlines and bound the length before
+            # it flows into run_result.json and CI logs — prevents log injection
+            # (CWE-117) and avoids dumping unbounded/secret text (CWE-532).
+            reason = lines[-1].encode("unicode_escape").decode("ascii")[:200]
     except OSError:
         pass
     return {
@@ -125,6 +129,11 @@ def parse_trial(trial_dir: Path) -> dict | None:
     try:
         reward_data = json.loads(reward_path.read_text())
     except (json.JSONDecodeError, OSError):
+        # reward.json present but truncated/unreadable. Same as the missing case:
+        # surface it as an errored trial when Harbor recorded a failure, so it is
+        # not silently dropped from the case total.
+        if (trial_dir / "exception.txt").is_file():
+            return _errored_trial_record(trial_dir)
         return None
 
     metrics = {k: v for k, v in reward_data.items() if k != "reward"}

--- a/agent_eval/harbor/run.py
+++ b/agent_eval/harbor/run.py
@@ -317,15 +317,8 @@ def run_eval_on_harbor(
     # 4b. Generate the HTML report (same renderer as the local path).
     _write_report(config_path, output_dir, summary, run_meta)
 
-    # 5. Regression detection (suite-level), mirroring score.py regression.
-    score = _load_score_module()
-    regressions = score.detect_regressions(summary["judges"], config.thresholds)
-    if regressions:
-        print(f"REGRESSIONS: {len(regressions)} detected", file=sys.stderr)
-        for r in regressions:
-            print(f"  [{r.judge_name}] {r.metric}: {r.baseline_value} -> {r.current_value}",
-                  file=sys.stderr)
-        return 1
+    # 5. Surface Harbor infra/trial errors first, so they appear even when the
+    # run also regresses (the regression check below early-returns).
     infra = parsed.get("infra_errors", [])
     if infra:
         print(f"INFRA-ERRORS: {len(infra)} step(s) had no verifier reward "
@@ -339,6 +332,16 @@ def run_eval_on_harbor(
               f"a reward (e.g. pod never Ready):", file=sys.stderr)
         for case_id, reason in trial_errs:
             print(f"  [{case_id}] {reason}", file=sys.stderr)
+
+    # 6. Regression detection (suite-level), mirroring score.py regression.
+    score = _load_score_module()
+    regressions = score.detect_regressions(summary["judges"], config.thresholds)
+    if regressions:
+        print(f"REGRESSIONS: {len(regressions)} detected", file=sys.stderr)
+        for r in regressions:
+            print(f"  [{r.judge_name}] {r.metric}: {r.baseline_value} -> {r.current_value}",
+                  file=sys.stderr)
+        return 1
     print(f"Mapped {parsed['n_completed']} case(s) → {output_dir}/summary.yaml "
           f"(mean_reward={parsed['mean_reward']}); "
           f"REGRESSIONS: 0; INFRA-ERRORS: {len(infra)}; TRIAL-ERRORS: {len(trial_errs)}")

--- a/agent_eval/harbor/run.py
+++ b/agent_eval/harbor/run.py
@@ -306,6 +306,8 @@ def run_eval_on_harbor(
         "harbor_job_dir": parsed["job_dir"],
         "n_infra_errors": parsed.get("n_infra_errors", 0),
         "infra_errors": parsed.get("infra_errors", []),
+        "n_trial_errors": parsed.get("n_trial_errors", 0),
+        "trial_errors": parsed.get("trial_errors", []),
     }
     (output_dir / "run_result.json").write_text(json.dumps(run_meta, indent=2) + "\n")
     (output_dir / "summary.yaml").write_text(
@@ -331,9 +333,15 @@ def run_eval_on_harbor(
               file=sys.stderr)
         for case_id, step in infra:
             print(f"  [{case_id}] {step}", file=sys.stderr)
+    trial_errs = parsed.get("trial_errors", [])
+    if trial_errs:
+        print(f"TRIAL-ERRORS: {len(trial_errs)} trial(s) failed before producing "
+              f"a reward (e.g. pod never Ready):", file=sys.stderr)
+        for case_id, reason in trial_errs:
+            print(f"  [{case_id}] {reason}", file=sys.stderr)
     print(f"Mapped {parsed['n_completed']} case(s) → {output_dir}/summary.yaml "
           f"(mean_reward={parsed['mean_reward']}); "
-          f"REGRESSIONS: 0; INFRA-ERRORS: {len(infra)}")
+          f"REGRESSIONS: 0; INFRA-ERRORS: {len(infra)}; TRIAL-ERRORS: {len(trial_errs)}")
     return 0
 
 

--- a/agent_eval/harbor/run.py
+++ b/agent_eval/harbor/run.py
@@ -304,6 +304,8 @@ def run_eval_on_harbor(
         "cost_usd": parsed.get("cost_usd"),
         "token_usage": parsed.get("token_usage"),
         "harbor_job_dir": parsed["job_dir"],
+        "n_infra_errors": parsed.get("n_infra_errors", 0),
+        "infra_errors": parsed.get("infra_errors", []),
     }
     (output_dir / "run_result.json").write_text(json.dumps(run_meta, indent=2) + "\n")
     (output_dir / "summary.yaml").write_text(
@@ -322,8 +324,16 @@ def run_eval_on_harbor(
             print(f"  [{r.judge_name}] {r.metric}: {r.baseline_value} -> {r.current_value}",
                   file=sys.stderr)
         return 1
+    infra = parsed.get("infra_errors", [])
+    if infra:
+        print(f"INFRA-ERRORS: {len(infra)} step(s) had no verifier reward "
+              f"(transient k8s exec; excluded from judge means, not scored 0):",
+              file=sys.stderr)
+        for case_id, step in infra:
+            print(f"  [{case_id}] {step}", file=sys.stderr)
     print(f"Mapped {parsed['n_completed']} case(s) → {output_dir}/summary.yaml "
-          f"(mean_reward={parsed['mean_reward']}); REGRESSIONS: 0")
+          f"(mean_reward={parsed['mean_reward']}); "
+          f"REGRESSIONS: 0; INFRA-ERRORS: {len(infra)}")
     return 0
 
 

--- a/tests/test_harbor_exec_retry.py
+++ b/tests/test_harbor_exec_retry.py
@@ -1,0 +1,129 @@
+"""Tests for the scoped establishment-retry in KubernetesEnvironment._ws_exec.
+
+Retry must happen ONLY when the WebSocket never established (the command
+provably never ran — safe to retry, even the agent). A failure after the
+command started must be surfaced as-is, never retried, so a possibly-executed
+command (the agent run!) is never re-run.
+
+kubernetes.py imports the `harbor` library, which lives in the Harbor CLI's
+own interpreter rather than the eval venv — skip cleanly where it is absent.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+# Skip unless the real Harbor framework is importable. importorskip("harbor") is
+# not enough: CI may have an unrelated top-level `harbor` module, which passes
+# that check but then fails collection when kubernetes.py does
+# `from harbor.environments.base import ...`. Probe the exact submodule instead.
+pytest.importorskip("harbor.environments.base")
+pytest.importorskip("kubernetes")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.harbor.kubernetes import KubernetesEnvironment, ExecResult
+
+
+def _env():
+    # Bypass __init__ (needs a live cluster); we only exercise the pure wrapper.
+    env = object.__new__(KubernetesEnvironment)
+    env.logger = logging.getLogger("test-exec-retry")
+    return env
+
+
+def test_retries_establishment_failure_then_succeeds(monkeypatch):
+    env = _env()
+    calls = []
+    seq = [
+        (ExecResult(stdout="", stderr="conn refused", return_code=1), False,
+         RuntimeError("conn refused")),
+        (ExecResult(stdout="", stderr="conn refused", return_code=1), False,
+         RuntimeError("conn refused")),
+        (ExecResult(stdout="ok", stderr="", return_code=0), True, None),
+    ]
+
+    def fake_once(cmd, timeout):
+        calls.append(cmd)
+        return seq[len(calls) - 1]
+
+    monkeypatch.setattr(env, "_ws_exec_once", fake_once)
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+
+    res = env._ws_exec("test.sh", None)
+    assert res.return_code == 0 and res.stdout == "ok"
+    assert len(calls) == 3  # two establishment retries, then success
+
+
+def test_post_establishment_failure_is_not_retried(monkeypatch):
+    # If the connection established, the command may have run — re-running the
+    # agent would be unsafe. The original exception must propagate, once.
+    env = _env()
+    calls = []
+
+    def fake_once(cmd, timeout):
+        calls.append(cmd)
+        return (ExecResult(stdout="", stderr="boom", return_code=1), True,
+                RuntimeError("mid-run drop"))
+
+    monkeypatch.setattr(env, "_ws_exec_once", fake_once)
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+
+    with pytest.raises(RuntimeError, match="mid-run drop"):
+        env._ws_exec("run-agent", None)
+    assert len(calls) == 1  # established -> no retry
+
+
+def test_post_establishment_timeout_returned_not_retried(monkeypatch):
+    # rc=124 timeout after establishment: return as-is, no retry.
+    env = _env()
+    calls = []
+
+    def fake_once(cmd, timeout):
+        calls.append(cmd)
+        return ExecResult(stdout="", stderr="timed out", return_code=124), True, None
+
+    monkeypatch.setattr(env, "_ws_exec_once", fake_once)
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+
+    res = env._ws_exec("run-agent", None)
+    assert res.return_code == 124
+    assert len(calls) == 1
+
+
+def test_establishment_failure_exhausts_then_raises(monkeypatch):
+    env = _env()
+    calls = []
+
+    def fake_once(cmd, timeout):
+        calls.append(cmd)
+        return (ExecResult(stdout="", stderr="never up", return_code=1), False,
+                RuntimeError("never up"))
+
+    monkeypatch.setattr(env, "_ws_exec_once", fake_once)
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+
+    with pytest.raises(RuntimeError, match="never up"):
+        env._ws_exec("test.sh", None)
+    assert len(calls) == env._EXEC_ESTABLISH_RETRIES + 1
+
+
+def test_establishment_failure_without_exception_returns_result(monkeypatch):
+    # Hard-timeout-before-establish path: no exc, not established -> retried,
+    # then the last result is returned (not raised).
+    env = _env()
+    calls = []
+
+    def fake_once(cmd, timeout):
+        calls.append(cmd)
+        return ExecResult(stdout="", stderr="HAProxy connection dead",
+                          return_code=124), False, None
+
+    monkeypatch.setattr(env, "_ws_exec_once", fake_once)
+    monkeypatch.setattr("time.sleep", lambda *a, **k: None)
+
+    res = env._ws_exec("test.sh", None)
+    assert res.return_code == 124
+    assert len(calls) == env._EXEC_ESTABLISH_RETRIES + 1

--- a/tests/test_harbor_results.py
+++ b/tests/test_harbor_results.py
@@ -123,3 +123,40 @@ def test_multistep_infra_excluded_from_step_mean(tmp_path):
     assert parsed["aggregated"]["create"]["values"] == [1.0]
     assert parsed["aggregated"]["create"]["mean"] == 1.0
     assert parsed["n_infra_errors"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Trial that failed before producing any reward (e.g. pod never Ready) must be
+# surfaced as an errored trial, not silently dropped from the case total.
+# ---------------------------------------------------------------------------
+
+def test_trial_failed_before_reward_is_surfaced(tmp_path):
+    job = tmp_path / "job"
+    job.mkdir()
+    # A healthy single-step trial.
+    _make_trial(job, "case-001__a", 1.0, {"files_exist": 1.0})
+    # A trial that never produced steps/ or reward.json but has exception.txt.
+    bad = job / "case-013__b"
+    bad.mkdir()
+    (bad / "exception.txt").write_text("pod aeh-case-013-... not Ready after 300s\n")
+
+    parsed = R.parse_job(job)
+    assert parsed["n_completed"] == 2                      # not dropped
+    assert parsed["n_trial_errors"] == 1
+    assert parsed["trial_errors"][0][0] == "case-013"
+    assert "not Ready" in parsed["trial_errors"][0][1]
+    bad_trial = next(t for t in parsed["trials"] if t["case_id"] == "case-013")
+    assert bad_trial["errored"] is True
+    assert bad_trial["reward"] is None
+    assert parsed["mean_reward"] == 1.0                    # errored trial excluded
+
+
+def test_trial_with_no_reward_and_no_exception_is_dropped(tmp_path):
+    # Without an exception.txt there's nothing to surface — keep returning None.
+    job = tmp_path / "job"
+    job.mkdir()
+    _make_trial(job, "case-001__a", 1.0, {})
+    (job / "case-002__b").mkdir()  # empty, no reward, no exception
+    parsed = R.parse_job(job)
+    assert parsed["n_completed"] == 1
+    assert parsed["n_trial_errors"] == 0

--- a/tests/test_harbor_results.py
+++ b/tests/test_harbor_results.py
@@ -55,3 +55,71 @@ def test_parse_job_aggregates(tmp_path):
     assert parsed["aggregated"]["rfe_quality"]["mean"] == 4.0
     case_ids = sorted(t["case_id"] for t in parsed["trials"])
     assert case_ids == ["case-001", "case-002"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-step: distinguish a missing verifier reward (infra/exec failure) from a
+# genuine score of 0. A missing reward.json must NOT be counted as 0.
+# ---------------------------------------------------------------------------
+
+def _make_step(trial_dir: Path, step: str, reward: float | None = None):
+    sdir = trial_dir / "steps" / step
+    (sdir / "verifier").mkdir(parents=True)
+    if reward is not None:
+        (sdir / "verifier" / "reward.json").write_text(json.dumps({"reward": reward}))
+    return sdir
+
+
+def test_multistep_missing_reward_is_infra_not_zero(tmp_path):
+    job = tmp_path / "job"
+    job.mkdir()
+    trial = job / "case-015__x"
+    trial.mkdir()
+    _make_step(trial, "create")  # no reward.json -> verifier never ran
+
+    parsed = R.parse_job(job)
+    t = parsed["trials"][0]
+    assert t["per_judge"]["create"]["value"] is None        # not False/0
+    assert t["per_judge"]["create"]["error"] == "no_verifier_reward"
+    assert t["infra_error_steps"] == ["create"]
+    assert t["reward"] is None                               # no step scored
+    # Excluded from judge aggregation entirely (not a 0).
+    assert "create" not in parsed["aggregated"]
+    assert parsed["n_infra_errors"] == 1
+    assert parsed["infra_errors"] == [("case-015", "create")]
+
+
+def test_multistep_genuine_zero_is_counted(tmp_path):
+    job = tmp_path / "job"
+    job.mkdir()
+    trial = job / "case-001__a"
+    trial.mkdir()
+    _make_step(trial, "create", reward=0.0)   # ran, scored 0
+    _make_step(trial, "submit", reward=1.0)
+
+    parsed = R.parse_job(job)
+    t = parsed["trials"][0]
+    assert t["per_judge"]["create"]["value"] == 0.0
+    assert "error" not in t["per_judge"]["create"]
+    assert t["infra_error_steps"] == []
+    assert parsed["aggregated"]["create"]["mean"] == 0.0     # genuine 0 counts
+    assert t["reward"] == 0.5
+    assert parsed["n_infra_errors"] == 0
+
+
+def test_multistep_infra_excluded_from_step_mean(tmp_path):
+    # The real scenario: one case's create verifier ran (1.0), another's didn't.
+    # The create mean must be 1.0 (over the one that ran), not 0.5.
+    job = tmp_path / "job"
+    job.mkdir()
+    a = job / "case-001__a"
+    a.mkdir()
+    _make_step(a, "create", reward=1.0)
+    b = job / "case-015__b"
+    b.mkdir()
+    _make_step(b, "create")  # infra failure
+
+    parsed = R.parse_job(job)
+    assert parsed["aggregated"]["create"]["values"] == [1.0]
+    assert parsed["aggregated"]["create"]["mean"] == 1.0
+    assert parsed["n_infra_errors"] == 1

--- a/tests/test_harbor_results.py
+++ b/tests/test_harbor_results.py
@@ -160,3 +160,46 @@ def test_trial_with_no_reward_and_no_exception_is_dropped(tmp_path):
     parsed = R.parse_job(job)
     assert parsed["n_completed"] == 1
     assert parsed["n_trial_errors"] == 0
+
+
+def test_single_step_unreadable_reward_with_exception_is_surfaced(tmp_path):
+    # reward.json present but corrupt + exception.txt -> errored trial, not dropped.
+    job = tmp_path / "job"
+    job.mkdir()
+    bad = job / "case-099__z"
+    (bad / "verifier").mkdir(parents=True)
+    (bad / "verifier" / "reward.json").write_text("{ truncated")  # invalid JSON
+    (bad / "exception.txt").write_text("RuntimeError: boom\n")
+    parsed = R.parse_job(job)
+    assert parsed["n_completed"] == 1
+    assert parsed["n_trial_errors"] == 1
+    assert parsed["trial_errors"][0] == ("case-099", "RuntimeError: boom")
+    t = parsed["trials"][0]
+    assert t["errored"] is True and t["reward"] is None
+
+
+def test_single_step_unreadable_reward_without_exception_is_dropped(tmp_path):
+    # Corrupt reward.json but no exception.txt -> still nothing to surface.
+    job = tmp_path / "job"
+    job.mkdir()
+    bad = job / "case-099__z"
+    (bad / "verifier").mkdir(parents=True)
+    (bad / "verifier" / "reward.json").write_text("{ truncated")
+    parsed = R.parse_job(job)
+    assert parsed["n_completed"] == 0
+    assert parsed["n_trial_errors"] == 0
+
+
+def test_trial_error_reason_is_sanitized(tmp_path):
+    # exception.txt is untrusted: control chars / ANSI / newlines must be escaped
+    # and the reason bounded before it reaches run_result.json or CI logs.
+    job = tmp_path / "job"
+    job.mkdir()
+    bad = job / "case-007__z"
+    bad.mkdir()
+    (bad / "exception.txt").write_text("RuntimeError: \x1b[31mboom\x1b[0m\twith\ttabs\n")
+    parsed = R.parse_job(job)
+    reason = parsed["trial_errors"][0][1]
+    assert "\x1b" not in reason and "\t" not in reason   # raw control chars gone
+    assert "\\x1b" in reason                              # escaped form retained
+    assert len(reason) <= 200


### PR DESCRIPTION
Resilience and observability for high-parallelism Kubernetes runs, where verifier execs intermittently fail because OpenShift's HAProxy router drops a freshly-opened WebSocket before the command runs.

> **Stacked on #136.** Until #136 merges, this PR shows its commit too; afterwards GitHub recomputes the diff to the three commits below.

### Commits

1. **retry transient k8s exec establishment failures** — split `_ws_exec` into `_ws_exec_once` (reports whether the connection *established*) + a retry wrapper that retries **only** establishment failures (the command provably never ran → safe even for the non-idempotent agent run). Post-establishment drops/timeouts are returned/raised unchanged, so a command that may have executed is never re-run. The 30s keepalive still covers long-connection idle drops.

2. **don't score a missing verifier reward as 0** — a missing `reward.json` means the verifier never completed (transient exec), not a score of 0. Previously it became `value=False`, which Python counts as 0 in the mean (`bool` is an `int` subclass), silently dragging the step judge. Now it maps to `value=None` + `error="no_verifier_reward"`, excluded from the mean and surfaced via `infra_errors`/`n_infra_errors` and an `INFRA-ERRORS` line. Genuine `0.0` still counts.

3. **surface trials that failed before producing any reward** — a trial whose pod never became Ready was dropped silently (`parse_trial` returned `None`), under-counting the run and hiding pod-startup failures. Now such trials (with Harbor's `exception.txt`) become a minimal errored record surfaced via `trial_errors`/`n_trial_errors` and a `TRIAL-ERRORS` line.

### Validation (20-case run)

- **38 establishment-retries** absorbed transient drops → infra failures dropped **4 → 1**.
- The one residual was surfaced as `INFRA-ERRORS` instead of scored 0 (create judge `0.80` → true `1.0`).
- A separate pod-not-Ready failure that previously vanished (`Mapped 19` of 20) is now surfaced as `TRIAL-ERRORS` with `RuntimeError: pod ... not Ready after 300s` (`Mapped 20`).

Tests added in `tests/test_harbor_exec_retry.py` and `tests/test_harbor_results.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Harbor results handling to clearly surface infrastructure vs trial errors, including per-step infra error tracking and explicit “no verifier reward” reasons.
  * Preserved genuine `0.0` scores so they’re included in aggregates rather than treated as missing results.
  * Enhanced Harbor evaluation execution to retry WebSocket exec only until the connection is established, avoiding retries for potentially running commands; added correct propagation/timeout behavior.
* **Tests**
  * Added/expanded pytest coverage for multi-step missing/corrupt verifier outputs, early trial failures, and establishment-only exec retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->