### PR TITLE
fix(harbor): upload files in chunks to avoid E2BIG on large dirs

### DIFF
--- a/agent_eval/harbor/kubernetes.py
+++ b/agent_eval/harbor/kubernetes.py
@@ -550,15 +550,45 @@ class KubernetesEnvironment(BaseEnvironment):
     # --- file transfer (tar + base64 over exec) -----------------------------
     #
     # cp goes through `exec` + base64 rather than the websocket stdin channel
-    # (which has no clean half-close for tar's EOF). Uploads (env dir, tests)
-    # are small; downloads stream a base64'd tar out via stdout.
+    # (which has no clean half-close for tar's EOF). The base64 blob is written
+    # to a temp file in chunks (see _write_b64_chunked) rather than passed as a
+    # single argument: Linux caps one argv entry at MAX_ARG_STRLEN (128 KiB)
+    # regardless of the larger total ARG_MAX, so a big blob as one `printf` arg
+    # fails with E2BIG (this silently broke "upload agent logs back to
+    # environment" for every multi-step trial). Downloads stream out via stdout,
+    # which has no such limit.
+
+    # Stay well under Linux's 128 KiB single-argument cap (MAX_ARG_STRLEN), with
+    # headroom for the rest of the command line.
+    _B64_CHUNK = 100_000
+
+    async def _write_b64_chunked(self, b64: str, remote_path: str, what: str) -> None:
+        """Write a base64 string to *remote_path* in sub-arg-limit chunks.
+
+        Each chunk is one exec (`printf %s <chunk> >> file`); the first truncates,
+        the rest append. Transient establishment failures are retried by _ws_exec.
+        """
+        q = shlex.quote(remote_path)
+        if not b64:
+            await self._checked_exec(f": > {q}", f"{what}: create empty")
+            return
+        for offset in range(0, len(b64), self._B64_CHUNK):
+            chunk = b64[offset:offset + self._B64_CHUNK]
+            redir = ">" if offset == 0 else ">>"
+            await self._checked_exec(
+                f"printf %s {shlex.quote(chunk)} {redir} {q}",
+                f"{what}: chunk @{offset}")
 
     async def upload_file(self, source_path: Path | str, target_path: str) -> None:
         b64 = base64.b64encode(Path(source_path).read_bytes()).decode()
         parent = shlex.quote(str(Path(target_path).parent))
-        cmd = (f"mkdir -p {parent} && printf %s {shlex.quote(b64)} | base64 -d "
-               f"> {shlex.quote(target_path)}")
-        await self._checked_exec(cmd, f"upload_file -> {target_path}")
+        tmp = f"{target_path}.aeh-b64.tmp"
+        qt, qtmp = shlex.quote(target_path), shlex.quote(tmp)
+        await self._checked_exec(f"mkdir -p {parent}", f"upload_file mkdir -> {target_path}")
+        await self._write_b64_chunked(b64, tmp, f"upload_file -> {target_path}")
+        await self._checked_exec(
+            f"base64 -d {qtmp} > {qt} && rm -f {qtmp}",
+            f"upload_file decode -> {target_path}")
 
     async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
         def _reset_perms(info):
@@ -567,16 +597,22 @@ class KubernetesEnvironment(BaseEnvironment):
             info.mode = 0o755 if info.isdir() else 0o644
             return info
 
+        # gzip the tar — agent-log dirs are text and compress ~5-10x, which keeps
+        # the chunk count (and thus exec count) low.
         buf = io.BytesIO()
-        with tarfile.open(fileobj=buf, mode="w") as tf:
+        with tarfile.open(fileobj=buf, mode="w:gz") as tf:
             for item in sorted(Path(source_dir).iterdir()):
                 tf.add(item, arcname=item.name, filter=_reset_perms)
         b64 = base64.b64encode(buf.getvalue()).decode()
         tgt = shlex.quote(target_dir)
-        cmd = (f"mkdir -p {tgt} && printf %s {shlex.quote(b64)} | base64 -d "
-               f"| tar xmf - --no-same-owner --no-same-permissions -C {tgt} 2>/dev/null; "
-               f"true")
-        await self._checked_exec(cmd, f"upload_dir -> {target_dir}")
+        tmp = "/tmp/aeh-upload-dir.b64"
+        qtmp = shlex.quote(tmp)
+        await self._checked_exec(f"mkdir -p {tgt}", f"upload_dir mkdir -> {target_dir}")
+        await self._write_b64_chunked(b64, tmp, f"upload_dir -> {target_dir}")
+        await self._checked_exec(
+            f"base64 -d {qtmp} | tar xzmf - --no-same-owner --no-same-permissions "
+            f"-C {tgt} 2>/dev/null; rm -f {qtmp}; true",
+            f"upload_dir extract -> {target_dir}")
 
     async def download_file(self, source_path: str, target_path: Path | str) -> None:
         res = await self.exec(f"base64 -w0 {shlex.quote(source_path)}")

--- a/tests/test_harbor_upload.py
+++ b/tests/test_harbor_upload.py
@@ -1,0 +1,119 @@
+"""Tests for chunked file upload in KubernetesEnvironment.
+
+upload_dir/upload_file must not pass the whole base64 blob as a single shell
+argument: Linux caps one argv entry at MAX_ARG_STRLEN (128 KiB) regardless of
+the larger total ARG_MAX, so a big blob fails with E2BIG. This silently broke
+"upload agent logs back to environment" (a ~0.5-1.5 MB dir) on every multi-step
+trial. The blob is now written to a temp file in sub-limit chunks.
+
+kubernetes.py imports the `harbor` library (present only in the Harbor CLI's
+interpreter), so skip cleanly where it is absent.
+"""
+
+import asyncio
+import base64
+import io
+import logging
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+# Probe the exact submodule kubernetes.py needs: an unrelated top-level `harbor`
+# module in CI would pass importorskip("harbor") but then fail collection on
+# `from harbor.environments.base import ...`.
+pytest.importorskip("harbor.environments.base")
+pytest.importorskip("kubernetes")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.harbor.kubernetes import KubernetesEnvironment
+
+_MAX_ARG_STRLEN = 131072  # Linux per-argument cap
+
+
+def _env():
+    env = object.__new__(KubernetesEnvironment)
+    env.logger = logging.getLogger("test-upload")
+    return env
+
+
+def test_chunked_write_stays_under_single_arg_limit():
+    env = _env()
+    cmds = []
+
+    async def fake_checked(cmd, what):
+        cmds.append(cmd)
+
+    env._checked_exec = fake_checked
+    asyncio.run(env._write_b64_chunked("a" * 250_000, "/tmp/x.b64", "t"))
+
+    assert len(cmds) == 3                          # 100k + 100k + 50k
+    assert " > " in cmds[0] and " >> " not in cmds[0]   # first truncates
+    assert all(" >> " in c for c in cmds[1:])           # rest append
+    for c in cmds:                                  # no oversized argv entry
+        assert all(len(tok) < _MAX_ARG_STRLEN for tok in c.split())
+
+
+def test_chunked_write_empty_creates_file():
+    env = _env()
+    cmds = []
+
+    async def fake_checked(cmd, what):
+        cmds.append(cmd)
+
+    env._checked_exec = fake_checked
+    asyncio.run(env._write_b64_chunked("", "/tmp/x.b64", "t"))
+    assert len(cmds) == 1 and cmds[0].startswith(":")
+
+
+def test_upload_dir_gzips_and_chunks(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "claude-code.txt").write_text("x" * 50_000)
+    (src / "b.txt").write_text("hello")
+
+    env = _env()
+    captured = {}
+    cmds = []
+
+    async def fake_chunked(b64, path, what):
+        captured["b64"] = b64
+
+    async def fake_checked(cmd, what):
+        cmds.append(cmd)
+
+    env._write_b64_chunked = fake_chunked
+    env._checked_exec = fake_checked
+    asyncio.run(env.upload_dir(src, "/workspace/logs"))
+
+    # The blob handed to the chunked writer must be a gzip tar of the dir.
+    raw = base64.b64decode(captured["b64"])
+    with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tf:
+        assert sorted(tf.getnames()) == ["b.txt", "claude-code.txt"]
+    # Extraction decodes from the temp file and untars with gzip.
+    extract = [c for c in cmds if "tar xz" in c]
+    assert extract and "base64 -d" in extract[0]
+
+
+def test_upload_file_chunks_and_decodes(tmp_path):
+    f = tmp_path / "f.bin"
+    f.write_bytes(b"\x00\x01" * 100_000)  # 200 KB binary
+
+    env = _env()
+    captured = {}
+    cmds = []
+
+    async def fake_chunked(b64, path, what):
+        captured["b64"] = b64
+
+    async def fake_checked(cmd, what):
+        cmds.append(cmd)
+
+    env._write_b64_chunked = fake_chunked
+    env._checked_exec = fake_checked
+    asyncio.run(env.upload_file(f, "/workspace/f.bin"))
+
+    assert base64.b64decode(captured["b64"]) == b"\x00\x01" * 100_000
+    assert any("base64 -d" in c and "/workspace/f.bin" in c for c in cmds)


### PR DESCRIPTION
## Problem

`Failed to upload agent logs back to environment` appeared on **every** multi-step Kubernetes trial (passing ones too). Harbor's `_upload_agent_logs()` (`trial.py`) calls `env.upload_dir(agent_dir)` inside a bare `except Exception:` that logs only that generic line and swallows the real error.

`upload_dir`/`upload_file` passed the entire base64'd payload as a **single shell argument** (`printf %s <blob> | base64 -d`). Linux caps one argv entry at `MAX_ARG_STRLEN` = **128 KiB** (independent of the larger ~2 MB total `ARG_MAX`), so any payload over ~128 KiB fails with **E2BIG**. The agent log dir is **~0.5–1.5 MB** → base64 **~0.7–2 MB** as one arg → fails every time. The 100% recurrence (vs an intermittent transient) is the tell.

Consequence: agent logs/artifacts were never restored into the pod, and every trial logged a scary-looking error.

## Fix

Write the base64 to a temp file in **sub-128-KiB chunks** (first truncates, the rest append), then `base64 -d | tar xz` on the pod. `upload_dir` also **gzips** the tar — agent logs are text and compress ~5–10×, keeping the chunk (and thus exec) count low. The extra short execs are covered by the establishment retry in `_ws_exec` (#137).

```
1.6 MB blob → 16 sub-128KB chunks (old code: one 1.6 MB arg → E2BIG)
```

Downloads are unchanged — they stream base64 out via stdout, which has no arg limit.

> Stacked on #137 (which is stacked on #136). Merge order: #136 → #137 → #138. Until they merge, this PR shows their commits too.

## Tests

`tests/test_harbor_upload.py`: chunks stay under the single-arg limit (first truncates, rest append); `upload_dir` produces a gzip tar and extracts with `base64 -d | tar xz`; `upload_file` round-trips binary content. Verified against the real upload path under the Harbor interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)