### PR TITLE
fix(harbor): root-cause + fix recurring verifier no-reward flake (hung exec establishment)

### DIFF
--- a/agent_eval/harbor/kubernetes.py
+++ b/agent_eval/harbor/kubernetes.py
@@ -388,6 +388,12 @@ class KubernetesEnvironment(BaseEnvironment):
     # unsafe; long connections are protected by the keepalive instead.
     _EXEC_ESTABLISH_RETRIES = 2      # total attempts = retries + 1
     _EXEC_RETRY_BACKOFF_SEC = 0.5    # 0.5s, 1.0s, ...
+    # Max time to *establish* the connection before treating it as a hung
+    # connection (retryable). Establishment is normally <1s; a longer wait means
+    # HAProxy isn't responding. Kept well under typical caller (verifier)
+    # timeouts so the retry actually runs before the caller gives up — otherwise
+    # a hang blocks until the long hard limit and the caller cancels first.
+    _EXEC_ESTABLISH_TIMEOUT_SEC = 30
 
     def _ws_exec_once(
         self, command: str, timeout_sec: int | None
@@ -473,16 +479,35 @@ class KubernetesEnvironment(BaseEnvironment):
         # inside _run fires before the hard limit. When timeout_sec is None
         # there is no soft deadline and the hard limit alone applies (1 h cap).
         hard_limit = (timeout_sec or 3600) + 30
+        establish_timeout = min(self._EXEC_ESTABLISH_TIMEOUT_SEC, hard_limit)
         t = threading.Thread(target=_run, daemon=True)
         t.start()
-        t.join(timeout=hard_limit)
+
+        # Phase 1 — establishment. join() returns as soon as the command
+        # finishes (so short commands add no latency); if it's still running and
+        # the connection never came up, the connection is hung. Report it as a
+        # fast, retryable establishment failure rather than blocking until the
+        # long hard limit — by which point the caller's (verifier) timeout would
+        # have cancelled us and the retry would never run.
+        t.join(timeout=establish_timeout)
+        if t.is_alive() and not established:
+            stop_ping.set()
+            return ExecResult(
+                stdout="",
+                stderr=f"[establishment timeout after {establish_timeout}s — "
+                       f"connection never established]",
+                return_code=124), False, None
+
+        # Phase 2 — established (or finished); wait for completion up to the
+        # remaining hard limit.
+        if t.is_alive():
+            t.join(timeout=max(hard_limit - establish_timeout, 0))
         if t.is_alive():
             stop_ping.set()
-            # The worker is still alive (likely wedged in k8s_stream). It may yet
-            # establish the connection and run the command after we return, so we
-            # must NOT report "never established" — that would let the caller
-            # retry and double-execute a non-idempotent command. Force
-            # established=True so this attempt is treated as non-retryable.
+            # The worker is still alive (likely wedged after establishing). It
+            # may yet finish the command, so we must NOT report "never
+            # established" — that would let the caller retry and double-execute a
+            # non-idempotent command. Force established=True (non-retryable).
             return ExecResult(
                 stdout="",
                 stderr=f"[ws_exec hard timeout after {hard_limit}s — HAProxy connection dead]",

--- a/agent_eval/harbor/kubernetes.py
+++ b/agent_eval/harbor/kubernetes.py
@@ -512,8 +512,19 @@ class KubernetesEnvironment(BaseEnvironment):
         rc = getattr(result, "return_code", None)
         cmd = (command.strip().splitlines() or [""])[0][:160]
         if exc is None and rc in (None, 0):
-            self.logger.debug("exec ok: rc=0 dur=%.2fs attempts=%d cmd=%r",
-                              duration, attempts, cmd)
+            # Successful execs are quiet by default. AGENT_EVAL_EXEC_TRACE=1 logs
+            # every exec (at warning, so it is captured regardless of log level)
+            # to reconstruct the full per-step exec sequence when diagnosing why
+            # a verifier produced no reward.
+            if os.environ.get("AGENT_EVAL_EXEC_TRACE") == "1":
+                out = len(getattr(result, "stdout", "") or "")
+                err = len(getattr(result, "stderr", "") or "")
+                self.logger.warning(
+                    "exec trace: rc=0 dur=%.2fs attempts=%d out=%dB err=%dB cmd=%r",
+                    duration, attempts, out, err, cmd)
+            else:
+                self.logger.debug("exec ok: rc=0 dur=%.2fs attempts=%d cmd=%r",
+                                  duration, attempts, cmd)
             return
         detail = (f"{type(exc).__name__}: {exc}" if exc is not None
                   else (result.stderr or ""))
@@ -640,27 +651,56 @@ class KubernetesEnvironment(BaseEnvironment):
         qtmp = shlex.quote(tmp)
         await self._checked_exec(f"mkdir -p {tgt}", f"upload_dir mkdir -> {target_dir}")
         await self._write_b64_chunked(b64, tmp, f"upload_dir -> {target_dir}")
-        await self._checked_exec(
-            f"base64 -d {qtmp} | tar xzmf - --no-same-owner --no-same-permissions "
-            f"-C {tgt} 2>/dev/null; rm -f {qtmp}; true",
-            f"upload_dir extract -> {target_dir}")
+        # `set -o pipefail` + no trailing `; true` so a failed decode/extract
+        # surfaces (it used to be masked, silently producing a partial upload —
+        # e.g. an incomplete tests dir whose verifier then writes no reward).
+        # Best-effort: log and continue rather than abort the whole step.
+        extract = (f"set -o pipefail; base64 -d {qtmp} | "
+                   f"tar xzmf - --no-same-owner --no-same-permissions -C {tgt}")
+        try:
+            await self._checked_exec(extract, f"upload_dir extract -> {target_dir}")
+        except RuntimeError as e:
+            self.logger.warning("upload_dir extract failed (continuing): %s", self._esc(str(e), 300))
+        finally:
+            await self.exec(f"rm -f {qtmp}")
+
+    @staticmethod
+    def _esc(text: str | None, limit: int = 200) -> str:
+        return (text or "").encode("unicode_escape").decode("ascii")[:limit]
 
     async def download_file(self, source_path: str, target_path: Path | str) -> None:
         res = await self.exec(f"base64 -w0 {shlex.quote(source_path)}")
         if res.return_code != 0:
+            self.logger.warning("download_file %s: rc=%s stderr=%r",
+                                source_path, res.return_code, self._esc(res.stderr))
             raise RuntimeError(f"download_file {source_path}: {res.stderr}")
         Path(target_path).parent.mkdir(parents=True, exist_ok=True)
-        Path(target_path).write_bytes(base64.b64decode(res.stdout))
+        try:
+            Path(target_path).write_bytes(base64.b64decode(res.stdout))
+        except Exception as e:
+            self.logger.warning("download_file %s: decode failed (stdout=%dB): %s",
+                                source_path, len(res.stdout or ""), e)
+            raise
 
     async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
+        # `set -o pipefail` so a failing `tar` surfaces as a non-zero rc — without
+        # it the pipe's rc is base64's (0), masking a truncated/empty download and
+        # silently producing an empty target dir.
         res = await self.exec(
-            f"tar cf - -C {shlex.quote(source_dir)} . | base64 -w0")
+            f"set -o pipefail; tar cf - -C {shlex.quote(source_dir)} . | base64 -w0")
         if res.return_code != 0:
+            self.logger.warning("download_dir %s: rc=%s stderr=%r",
+                                source_dir, res.return_code, self._esc(res.stderr))
             raise RuntimeError(f"download_dir {source_dir}: {res.stderr}")
         Path(target_dir).mkdir(parents=True, exist_ok=True)
-        raw = base64.b64decode(res.stdout)
-        with tarfile.open(fileobj=io.BytesIO(raw), mode="r") as tf:
-            tf.extractall(target_dir, filter="data")
+        try:
+            raw = base64.b64decode(res.stdout)
+            with tarfile.open(fileobj=io.BytesIO(raw), mode="r") as tf:
+                tf.extractall(target_dir, filter="data")
+        except Exception as e:
+            self.logger.warning("download_dir %s: decode/extract failed (stdout=%dB): %s",
+                                source_dir, len(res.stdout or ""), e)
+            raise
 
     async def _checked_exec(self, command: str, what: str) -> None:
         res = await self.exec(command, timeout_sec=300)

--- a/agent_eval/harbor/kubernetes.py
+++ b/agent_eval/harbor/kubernetes.py
@@ -496,6 +496,32 @@ class KubernetesEnvironment(BaseEnvironment):
             stdout="", stderr="[no result from exec thread]", return_code=1)
         return result, is_established, None
 
+    def _log_exec(self, command: str, result: ExecResult, established: bool,
+                  exc: BaseException | None, duration: float, attempts: int) -> None:
+        """Record the outcome of an exec so failures are diagnosable.
+
+        Harbor calls ``exec`` for everything (agent, verifier, file transfer) and
+        only surfaces a generic "step failed" on error, so without this the
+        return code / stderr / establishment state of a failed exec is lost.
+        Successful execs log at debug; failures log at warning with the fields
+        that explain *why* (rc, established vs post-establishment drop, duration,
+        retry count). ``cmd`` is the first line truncated so a large upload chunk
+        doesn't flood the log; ``detail`` is escaped (untrusted container output,
+        CWE-117) and bounded (CWE-532).
+        """
+        rc = getattr(result, "return_code", None)
+        cmd = (command.strip().splitlines() or [""])[0][:160]
+        if exc is None and rc in (None, 0):
+            self.logger.debug("exec ok: rc=0 dur=%.2fs attempts=%d cmd=%r",
+                              duration, attempts, cmd)
+            return
+        detail = (f"{type(exc).__name__}: {exc}" if exc is not None
+                  else (result.stderr or ""))
+        detail = detail.encode("unicode_escape").decode("ascii")[:300]
+        self.logger.warning(
+            "exec FAILED: rc=%s established=%s dur=%.2fs attempts=%d cmd=%r detail=%r",
+            rc, established, duration, attempts, cmd, detail)
+
     def _ws_exec(self, command: str, timeout_sec: int | None) -> ExecResult:
         """WebSocket exec, retrying only pre-execution (establishment) failures.
 
@@ -506,9 +532,12 @@ class KubernetesEnvironment(BaseEnvironment):
         returned/raised as-is so a possibly-executed command is never re-run.
         """
         attempts = self._EXEC_ESTABLISH_RETRIES + 1
+        start = time.monotonic()
         for attempt in range(1, attempts + 1):
             result, established, exc = self._ws_exec_once(command, timeout_sec)
             if established:
+                self._log_exec(command, result, established, exc,
+                               time.monotonic() - start, attempt)
                 if exc is not None:
                     raise exc  # post-establishment failure — preserve old contract
                 return result
@@ -521,6 +550,8 @@ class KubernetesEnvironment(BaseEnvironment):
                 time.sleep(backoff)
                 continue
             # Exhausted retries with no establishment.
+            self._log_exec(command, result, established, exc,
+                           time.monotonic() - start, attempt)
             if exc is not None:
                 raise exc
             return result

--- a/agent_eval/harbor/results.py
+++ b/agent_eval/harbor/results.py
@@ -304,6 +304,14 @@ def _parse_multi_step_trial(trial_dir: Path, steps_dir: Path) -> dict | None:
             except (json.JSONDecodeError, OSError):
                 pass
 
+    # A trial with an infra-failed step is incomplete — averaging only the steps
+    # that did run would let a half-finished pipeline read as a high (even
+    # perfect) reward. Exclude it from the reward mean entirely (reward=None);
+    # the per-step judges still reflect what actually ran, and the infra failure
+    # is surfaced via infra_error_steps / INFRA-ERRORS.
+    if infra_error_steps:
+        mean_reward = None
+
     return {
         "case_id": _case_id_from_dir(trial_dir),
         "trial_dir": trial_dir.name,

--- a/tests/test_harbor_exec_retry.py
+++ b/tests/test_harbor_exec_retry.py
@@ -127,3 +127,43 @@ def test_establishment_failure_without_exception_returns_result(monkeypatch):
     res = env._ws_exec("test.sh", None)
     assert res.return_code == 124
     assert len(calls) == env._EXEC_ESTABLISH_RETRIES + 1
+
+
+def test_failed_exec_is_logged_with_diagnostics(monkeypatch, caplog):
+    # A post-establishment failure must be logged (rc, established, cmd, detail)
+    # so the reason is diagnosable rather than vanishing into "step failed".
+    env = _env()
+
+    def fake_once(cmd, timeout):
+        return ExecResult(stdout="", stderr="oom-killed", return_code=137), True, None
+
+    monkeypatch.setattr(env, "_ws_exec_once", fake_once)
+    with caplog.at_level(logging.WARNING, logger="test-exec-retry"):
+        res = env._ws_exec("cd /workspace && ./steps/auto-fix/tests/test.sh", None)
+    assert res.return_code == 137
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("exec FAILED" in m and "rc=137" in m and "established=True" in m
+               and "test.sh" in m for m in msgs), msgs
+
+
+def test_successful_exec_does_not_warn(monkeypatch, caplog):
+    env = _env()
+    monkeypatch.setattr(env, "_ws_exec_once",
+                        lambda c, t: (ExecResult(stdout="ok", stderr="", return_code=0), True, None))
+    with caplog.at_level(logging.WARNING, logger="test-exec-retry"):
+        env._ws_exec("ls", None)
+    assert not any("exec FAILED" in r.getMessage() for r in caplog.records)
+
+
+def test_sensitive_exec_stderr_is_sanitized(monkeypatch, caplog):
+    # stderr is untrusted container output: control chars / ANSI must be escaped
+    # and the detail bounded before it reaches the log.
+    env = _env()
+    payload = "secret\x1b[31m\nLEAKED: token=abc\t" + "x" * 500
+    monkeypatch.setattr(env, "_ws_exec_once",
+                        lambda c, t: (ExecResult(stdout="", stderr=payload, return_code=1), True, None))
+    with caplog.at_level(logging.WARNING, logger="test-exec-retry"):
+        env._ws_exec("./test.sh", None)
+    detail = next(r.getMessage() for r in caplog.records if "exec FAILED" in r.getMessage())
+    assert "\x1b" not in detail and "\n" not in detail.split("detail=")[-1]
+    assert "\\x1b" in detail  # escaped form retained

--- a/tests/test_harbor_exec_retry.py
+++ b/tests/test_harbor_exec_retry.py
@@ -11,7 +11,9 @@ own interpreter rather than the eval venv — skip cleanly where it is absent.
 
 import logging
 import sys
+import time
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -32,6 +34,33 @@ def _env():
     env = object.__new__(KubernetesEnvironment)
     env.logger = logging.getLogger("test-exec-retry")
     return env
+
+
+def test_establishment_hang_fails_fast_and_retryable(monkeypatch):
+    # A connection that hangs at establishment must fail fast as a *retryable*
+    # not-established result — not block until the long hard limit (by which
+    # point the caller's verifier timeout would have cancelled it). This is the
+    # real verifier-flake fix.
+    import agent_eval.harbor.kubernetes as K
+
+    env = _env()
+    env._pod = "p"
+    env._namespace = "ns"
+    env._core = MagicMock()
+    env._EXEC_ESTABLISH_TIMEOUT_SEC = 0.2  # tiny cap for the test
+
+    # Simulate a hung establishment: k8s_stream never returns.
+    monkeypatch.setattr(K, "k8s_stream", lambda *a, **k: time.sleep(60))
+
+    start = time.perf_counter()
+    result, established, exc = env._ws_exec_once("./tests/test.sh", None)
+    elapsed = time.perf_counter() - start
+
+    assert established is False          # retryable
+    assert exc is None
+    assert result.return_code == 124
+    assert "establishment timeout" in result.stderr
+    assert elapsed < 5                  # ~0.2s, NOT the 3600s hard limit
 
 
 def test_retries_establishment_failure_then_succeeds(monkeypatch):

--- a/tests/test_harbor_exec_retry.py
+++ b/tests/test_harbor_exec_retry.py
@@ -155,6 +155,29 @@ def test_successful_exec_does_not_warn(monkeypatch, caplog):
     assert not any("exec FAILED" in r.getMessage() for r in caplog.records)
 
 
+def test_exec_trace_logs_successful_execs(monkeypatch, caplog):
+    # AGENT_EVAL_EXEC_TRACE=1 logs every (successful) exec so the full per-step
+    # exec sequence can be reconstructed when diagnosing a missing reward.
+    env = _env()
+    monkeypatch.setenv("AGENT_EVAL_EXEC_TRACE", "1")
+    monkeypatch.setattr(env, "_ws_exec_once",
+                        lambda c, t: (ExecResult(stdout="ok", stderr="", return_code=0), True, None))
+    with caplog.at_level(logging.WARNING, logger="test-exec-retry"):
+        env._ws_exec("cd /workspace && ./tests/test.sh", None)
+    assert any("exec trace" in r.getMessage() and "test.sh" in r.getMessage()
+               for r in caplog.records)
+
+
+def test_no_trace_for_success_by_default(monkeypatch, caplog):
+    env = _env()
+    monkeypatch.delenv("AGENT_EVAL_EXEC_TRACE", raising=False)
+    monkeypatch.setattr(env, "_ws_exec_once",
+                        lambda c, t: (ExecResult(stdout="ok", stderr="", return_code=0), True, None))
+    with caplog.at_level(logging.WARNING, logger="test-exec-retry"):
+        env._ws_exec("ls", None)
+    assert not any("exec trace" in r.getMessage() for r in caplog.records)
+
+
 def test_sensitive_exec_stderr_is_sanitized(monkeypatch, caplog):
     # stderr is untrusted container output: control chars / ANSI must be escaped
     # and the detail bounded before it reaches the log.

--- a/tests/test_harbor_results.py
+++ b/tests/test_harbor_results.py
@@ -125,6 +125,30 @@ def test_multistep_infra_excluded_from_step_mean(tmp_path):
     assert parsed["n_infra_errors"] == 1
 
 
+def test_multistep_infra_step_excludes_trial_from_reward_mean(tmp_path):
+    # A case whose create ran (1.0) but auto-fix infra-failed must NOT contribute
+    # a perfect 1.0 from its surviving step — the trial is excluded from the
+    # reward mean entirely, so only fully-scored cases count.
+    job = tmp_path / "job"
+    job.mkdir()
+    healthy = job / "case-001__a"
+    healthy.mkdir()
+    _make_step(healthy, "create", reward=1.0)
+    _make_step(healthy, "submit", reward=1.0)
+    partial = job / "case-006__b"
+    partial.mkdir()
+    _make_step(partial, "create", reward=1.0)
+    _make_step(partial, "auto-fix")  # infra failure (no reward.json)
+
+    parsed = R.parse_job(job)
+    rb = next(t for t in parsed["trials"] if t["case_id"] == "case-006")
+    assert rb["infra_error_steps"] == ["auto-fix"]
+    assert rb["reward"] is None                  # not 1.0 from create-only
+    assert parsed["mean_reward"] == 1.0          # only the healthy case counts
+    assert parsed["n_completed"] == 2            # still counted as a case
+    assert parsed["n_infra_errors"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Trial that failed before producing any reward (e.g. pod never Ready) must be
 # surfaced as an errored trial, not silently dropped from the case total.

--- a/tests/test_harbor_upload.py
+++ b/tests/test_harbor_upload.py
@@ -28,7 +28,7 @@ pytest.importorskip("kubernetes")
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from agent_eval.harbor.kubernetes import KubernetesEnvironment
+from agent_eval.harbor.kubernetes import KubernetesEnvironment, ExecResult
 
 _MAX_ARG_STRLEN = 131072  # Linux per-argument cap
 
@@ -84,17 +84,25 @@ def test_upload_dir_gzips_and_chunks(tmp_path):
     async def fake_checked(cmd, what):
         cmds.append(cmd)
 
+    async def fake_exec(cmd, *a, **k):
+        cmds.append(cmd)
+        return ExecResult(stdout="", stderr="", return_code=0)
+
     env._write_b64_chunked = fake_chunked
     env._checked_exec = fake_checked
+    env.exec = fake_exec  # temp-file cleanup goes through exec()
     asyncio.run(env.upload_dir(src, "/workspace/logs"))
 
     # The blob handed to the chunked writer must be a gzip tar of the dir.
     raw = base64.b64decode(captured["b64"])
     with tarfile.open(fileobj=io.BytesIO(raw), mode="r:gz") as tf:
         assert sorted(tf.getnames()) == ["b.txt", "claude-code.txt"]
-    # Extraction decodes from the temp file and untars with gzip.
+    # Extraction decodes from the temp file and untars with gzip; the masking
+    # trailing `; true` is gone (failures must surface) and pipefail is set.
     extract = [c for c in cmds if "tar xz" in c]
     assert extract and "base64 -d" in extract[0]
+    assert "; true" not in extract[0] and "set -o pipefail" in extract[0]
+    assert any(c.startswith("rm -f") for c in cmds)  # tmp cleaned up
 
 
 def test_upload_file_chunks_and_decodes(tmp_path):


### PR DESCRIPTION
Diagnostics that **root-caused** the recurring "verifier produced no reward" flake, plus the fix and related hardening. All from the case-006/012 investigation.

### Root cause (found via the exec trace)
Harbor issues the verifier's test exec with **no timeout**, so our `_ws_exec` used the **3600s** hard limit. When that exec's WebSocket **hung at establishment** (HAProxy transient), it blocked — and our establishment-retry only triggers on a *returned* not-established result, which for a hang only happens after 3600s. Harbor's verifier-level `asyncio.wait_for` fired far sooner, cancelled `verify()`, and the step failed with **no reward and no logged error**. Confirmed: the trace stops exactly at `chmod +x test.sh`; running the identical command on the live pod works in 1.7s.

### Commits
1. **log every exec outcome** — success at debug, failure at warning (rc, established, duration, retries; cmd truncated, stderr sanitized).
2. **exclude infra-incomplete trials from the reward mean** — a case whose verifier infra-failed no longer contributes a partial/perfect reward; it's `None` (excluded) and surfaced via `INFRA-ERRORS`.
3. **full exec trace (`AGENT_EVAL_EXEC_TRACE=1`) + surface file-transfer failures** — trace every exec to reconstruct a step's sequence; drop `upload_dir`'s masking `; true` and add `set -o pipefail` to `download_dir/_file` so silent partial transfers surface.
4. **fail fast on hung exec establishment** — `_EXEC_ESTABLISH_TIMEOUT_SEC=30`: a hung establishment returns a fast retryable failure instead of blocking until the hard limit, so the retry runs inside the caller's timeout budget. Short commands add no latency; the long agent run is unaffected. **This is the actual flake fix.**

### Also surfaced (benign, noted for follow-up)
- `empty_dirs` `chmod` fails under OpenShift SCC (rc discarded by harbor).
- `upload_dir -> /workspace` can't overwrite a pre-existing `.claude/settings.json` (rc=2) — partial workspace upload, mostly benign.

Tests in `tests/test_harbor_exec_retry.py`, `tests/test_harbor_results.py`, `tests/test_harbor_upload.py` (incl. a hung-establishment fast-fail test verified against the real `_ws_exec_once`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)