### PR TITLE
feat(mlflow): build per-step MLflow traces for harbor runs

### DIFF
--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -785,8 +785,15 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
                     trace_cost[m_name] = m_stats["cost_usd"]
         trace_metadata["mlflow.trace.cost"] = json.dumps(trace_cost)
     if token_usage:
+        # Total input INCLUDING cache reads, matching report.py's "Input tokens
+        # (total)" so the MLflow Usage dashboard reflects total input volume
+        # ("what the eval used"). Cost is tracked separately (mlflow.llm.cost /
+        # mlflow.trace.cost) and the fresh/cached split stays in the run-level
+        # tokens/{input,cache_read,cache_create} metrics — so excluding cache
+        # reads here would understate usage and diverge from the report.
         input_tokens = (token_usage.get("input", 0)
-                        + token_usage.get("cache_create", 0))
+                        + token_usage.get("cache_create", 0)
+                        + token_usage.get("cache_read", 0))
         output_tokens = token_usage.get("output", 0)
         trace_metadata["mlflow.trace.tokenUsage"] = json.dumps({
             "input_tokens": input_tokens,

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -38,6 +38,98 @@ from agent_eval.mlflow.experiment import resolve_tracking_uri
 from agent_eval.mlflow.trace_builder import build_trace, log_trace
 
 
+def _resolve_harbor_job_dir(raw, run_dir):
+    """Resolve harbor_job_dir (stored repo-root-relative) to an existing path."""
+    if not raw:
+        return None
+    p = Path(raw)
+    if p.exists():
+        return p
+    for ancestor in run_dir.resolve().parents:
+        candidate = ancestor / raw
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _harbor_steps(job_dir):
+    """Yield (case_id, case_dir, step_name, transcript_path, subagent_dir) per step.
+
+    Harbor writes each step's Claude stream-json to
+    ``<case>__<hash>/steps/<step>/agent/claude-code.txt`` (multi-step) or
+    ``<case>__<hash>/agent/claude-code.txt`` (single-step). Background subagent
+    transcripts live under ``.../agent/sessions/projects/*/*/subagents/``.
+    The case_id (name before ``__``) matches the summary.yaml per_case keys.
+    """
+    for case_dir in sorted(d for d in job_dir.iterdir()
+                           if d.is_dir() and "__" in d.name):
+        case_id = case_dir.name.split("__")[0]
+        steps_dir = case_dir / "steps"
+        if steps_dir.is_dir():
+            step_dirs = sorted(steps_dir.iterdir(), key=lambda p: p.stat().st_mtime)
+        elif (case_dir / "agent" / "claude-code.txt").exists():
+            step_dirs = [case_dir]  # single-step layout
+        else:
+            step_dirs = []
+        for sd in step_dirs:
+            agent_dir = sd / "agent"
+            transcript = agent_dir / "claude-code.txt"
+            if not transcript.exists():
+                continue
+            step_name = "" if sd is case_dir else sd.name
+            subs = list(agent_dir.glob("sessions/projects/*/*/subagents"))
+            yield (case_id, case_dir, step_name, transcript,
+                   subs[0] if len(subs) == 1 else None)
+
+
+def _harbor_step_run_result(case_dir, step_name, base):
+    """Per-step run_result for trace annotation (model + that step's agent cost)."""
+    rr = {"model": base.get("model", ""), "exit_code": 0}
+    result_path = case_dir / "result.json"
+    if not result_path.exists():
+        return rr
+    try:
+        data = json.loads(result_path.read_text())
+    except Exception:
+        return rr
+    steps = data.get("step_results") or []
+    match = next((s for s in steps if s.get("step_name") == step_name), None)
+    if match is None and not step_name:
+        match = data  # single-step trial
+    if match:
+        ar = match.get("agent_result") or {}
+        cost = ar.get("cost_usd")
+        if cost:
+            rr["cost_usd"] = cost
+        # Harbor's agent_result reports aggregate token counts: n_input_tokens
+        # is total input *including* cache, n_cache_tokens is the cached portion
+        # (read + create). Map to the {input, output, cache_read, cache_create}
+        # schema build_trace expects — lumping fresh+create into "input" since
+        # the split is not reported (matches local-run rendering). Without this,
+        # build_trace omits mlflow.trace.tokenUsage and the dashboard's Token
+        # Usage / Tokens per Trace panels show 0.
+        n_in = ar.get("n_input_tokens") or 0
+        n_cache = ar.get("n_cache_tokens") or 0
+        n_out = ar.get("n_output_tokens") or 0
+        token_usage = {
+            "input": max(n_in - n_cache, 0),
+            "output": n_out,
+            "cache_read": n_cache,
+            "cache_create": 0,
+        }
+        if any(token_usage.values()):
+            rr["token_usage"] = token_usage
+            # per_model_usage drives the per-span mlflow.llm.cost distribution
+            # that the Cost Breakdown / Cost Over Time charts aggregate
+            # (trace-level mlflow.trace.cost alone is not used by those charts).
+            if cost and rr["model"]:
+                rr["per_model_usage"] = {
+                    rr["model"]: {**token_usage, "cost_usd": cost},
+                }
+        if match.get("exception_info"):
+            rr["exit_code"] = 1
+    return rr
+
 
 # ── Main ─────────────────────────────────────────────────────────────
 
@@ -211,6 +303,7 @@ def main():
     # because they already exist in the DB (no async queue issues).
     main_trace_id = None
     case_trace_map = {}  # case_id -> trace_id
+    harbor_step_traces = {}  # case_id -> {step_name: trace_id} (harbor per-step)
     trace_ids = []
 
     # TODO: paginate via page_token for experiments with >500 unlinked traces
@@ -253,6 +346,36 @@ def main():
                         trace_ids.append(tid)
                         num_spans = len(trace_dict["data"]["spans"])
                         print(f"TRACE: {tid} ({num_spans} spans) — {case_id}")
+    elif exec_mode == "harbor":
+        # Harbor runs in-pod and writes no cases/<id>/stdout.log; the Claude
+        # stream-json lives per step in the harbor job dir. Build one trace per
+        # step (same build_trace path as local runs), nesting background
+        # subagents from the step session's subagents/ dir.
+        job_dir = _resolve_harbor_job_dir(run_result.get("harbor_job_dir"), run_dir)
+        if job_dir is None:
+            print("WARNING: harbor_job_dir not found; skipping trace build",
+                  file=sys.stderr)
+        else:
+            for case_id, case_dir, step_name, transcript, sub_dir in \
+                    _harbor_steps(job_dir):
+                step_key = f"{case_id}/{step_name}" if step_name else case_id
+                if step_key in case_trace_map:
+                    continue
+                step_rr = _harbor_step_run_result(case_dir, step_name, run_result)
+                trace_name = (f"{config.skill} ({step_key})"
+                              if config.skill else step_key)
+                trace_dict = build_trace(transcript, step_rr, step_key,
+                                         experiment_id, trace_name=trace_name,
+                                         subagent_dir=sub_dir)
+                if trace_dict:
+                    tid = log_trace(trace_dict)
+                    if tid:
+                        case_trace_map[step_key] = tid
+                        harbor_step_traces.setdefault(case_id, {})[step_name] = tid
+                        trace_ids.append(tid)
+                        num_spans = len(trace_dict["data"]["spans"])
+                        print(f"TRACE: {tid} ({num_spans} spans) — {step_key}"
+                              + (" +subagents" if sub_dir else ""))
     else:
         stdout_path = run_dir / "stdout.log"
         if stdout_path.exists() and run_result:
@@ -312,9 +435,9 @@ def main():
         return None
 
     for case_id, case_results in per_case.items():
-        trace_id = case_trace_map.get(case_id, main_trace_id)
-        if not trace_id or not isinstance(case_results, dict):
+        if not isinstance(case_results, dict):
             continue
+        steps_for_case = harbor_step_traces.get(case_id)
         for judge_name, result in case_results.items():
             if not isinstance(result, dict):
                 continue
@@ -323,6 +446,18 @@ def main():
                 continue
             fb_value = _to_feedback_value(value)
             if fb_value is None:
+                continue
+            # Route feedback: for harbor per-step traces, a step judge
+            # (create/auto-fix/submit) attaches to its own step trace and any
+            # overall judge to the final step; non-harbor runs use the
+            # per-case trace.
+            if steps_for_case:
+                trace_id = (steps_for_case.get(judge_name)
+                            or steps_for_case.get("submit")
+                            or next(iter(steps_for_case.values()), None))
+            else:
+                trace_id = case_trace_map.get(case_id, main_trace_id)
+            if not trace_id:
                 continue
             try:
                 mlflow.log_feedback(

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -36,6 +36,9 @@ from agent_eval.mlflow.experiment import resolve_tracking_uri
 
 # ── Trace builder (extracted to agent_eval/mlflow/trace_builder.py) ──
 from agent_eval.mlflow.trace_builder import build_trace, log_trace
+# Same transcript metric extractor the run-level aggregation uses, so per-step
+# trace cost/tokens match the run `cost_usd` metric and the HTML report.
+from agent_eval.harbor.results import _extract_transcript_metrics
 
 
 def _is_within(path, root):
@@ -103,54 +106,54 @@ def _harbor_steps(job_dir):
                    subs[0] if len(subs) == 1 else None)
 
 
-def _harbor_step_run_result(case_dir, step_name, base):
-    """Per-step run_result for trace annotation (model + that step's agent cost)."""
+def _harbor_step_run_result(case_dir, step_name, base, transcript):
+    """Per-step run_result for trace annotation: model, exit code, cost, tokens.
+
+    Cost and tokens are read from the step transcript with the SAME extractor
+    the run-level aggregation uses (_extract_transcript_metrics -> the result
+    event's total_cost_usd / usage), so the trace cost matches the run
+    `cost_usd` metric and the HTML report. Crucially total_cost_usd includes
+    background subagent cost (e.g. the auto-fix step's subagents), which
+    result.json's agent_result.cost_usd omits — so this is the accurate total.
+    result.json is still consulted for the step's exit code. Token usage already
+    arrives in the {input, output, cache_read, cache_create} schema build_trace
+    expects, so no remapping is needed.
+    """
     rr = {"model": base.get("model", ""), "exit_code": 0}
+
+    metrics = _extract_transcript_metrics(transcript)
+    cost = metrics.get("cost_usd")
+    if cost:
+        rr["cost_usd"] = cost
+    tu = metrics.get("token_usage") or {}
+    token_usage = {k: (tu.get(k) or 0)
+                   for k in ("input", "output", "cache_read", "cache_create")}
+    if any(token_usage.values()):
+        rr["token_usage"] = token_usage
+        # per_model_usage drives the per-span mlflow.llm.cost distribution that
+        # the Cost Breakdown / Cost Over Time charts aggregate.
+        if cost and rr["model"]:
+            rr["per_model_usage"] = {
+                rr["model"]: {**token_usage, "cost_usd": cost},
+            }
+
+    # exit_code comes from the step's exception_info in result.json (best-effort).
     result_path = case_dir / "result.json"
-    if not result_path.exists():
-        return rr
-    try:
-        data = json.loads(result_path.read_text())
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
-        print(f"WARNING: failed to parse Harbor result {result_path}: {e}",
-              file=sys.stderr)
-        return rr
-    steps = data.get("step_results") or []
-    match = next((s for s in steps if s.get("step_name") == step_name), None)
-    if match is None and not step_name:
-        match = data  # single-step trial
-    if match:
-        ar = match.get("agent_result") or {}
-        cost = ar.get("cost_usd")
-        if cost:
-            rr["cost_usd"] = cost
-        # Harbor's agent_result reports aggregate token counts: n_input_tokens
-        # is total input *including* cache, n_cache_tokens is the cached portion
-        # (read + create). Map to the {input, output, cache_read, cache_create}
-        # schema build_trace expects — lumping fresh+create into "input" since
-        # the split is not reported (matches local-run rendering). Without this,
-        # build_trace omits mlflow.trace.tokenUsage and the dashboard's Token
-        # Usage / Tokens per Trace panels show 0.
-        n_in = ar.get("n_input_tokens") or 0
-        n_cache = ar.get("n_cache_tokens") or 0
-        n_out = ar.get("n_output_tokens") or 0
-        token_usage = {
-            "input": max(n_in - n_cache, 0),
-            "output": n_out,
-            "cache_read": n_cache,
-            "cache_create": 0,
-        }
-        if any(token_usage.values()):
-            rr["token_usage"] = token_usage
-            # per_model_usage drives the per-span mlflow.llm.cost distribution
-            # that the Cost Breakdown / Cost Over Time charts aggregate
-            # (trace-level mlflow.trace.cost alone is not used by those charts).
-            if cost and rr["model"]:
-                rr["per_model_usage"] = {
-                    rr["model"]: {**token_usage, "cost_usd": cost},
-                }
-        if match.get("exception_info"):
-            rr["exit_code"] = 1
+    if result_path.is_file():
+        try:
+            data = json.loads(result_path.read_text())
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+            print(f"WARNING: failed to parse Harbor result {result_path}: {e}",
+                  file=sys.stderr)
+            data = None
+        if data:
+            steps = data.get("step_results") or []
+            match = next((s for s in steps
+                          if s.get("step_name") == step_name), None)
+            if match is None and not step_name:
+                match = data  # single-step trial
+            if match and match.get("exception_info"):
+                rr["exit_code"] = 1
     return rr
 
 
@@ -384,7 +387,8 @@ def main():
                 step_key = f"{case_id}/{step_name}" if step_name else case_id
                 if step_key in case_trace_map:
                     continue
-                step_rr = _harbor_step_run_result(case_dir, step_name, run_result)
+                step_rr = _harbor_step_run_result(case_dir, step_name,
+                                                  run_result, transcript)
                 trace_name = (f"{config.skill} ({step_key})"
                               if config.skill else step_key)
                 trace_dict = build_trace(transcript, step_rr, step_key,

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -38,16 +38,32 @@ from agent_eval.mlflow.experiment import resolve_tracking_uri
 from agent_eval.mlflow.trace_builder import build_trace, log_trace
 
 
+def _is_within(path, root):
+    """True if ``path`` resolves to ``root`` or a descendant (symlinks resolved)."""
+    try:
+        path.resolve(strict=True).relative_to(root.resolve(strict=True))
+        return True
+    except (OSError, ValueError):
+        return False
+
+
 def _resolve_harbor_job_dir(raw, run_dir):
-    """Resolve harbor_job_dir (stored repo-root-relative) to an existing path."""
+    """Resolve harbor_job_dir (stored repo-root-relative) to an existing dir.
+
+    The job dir is local harness output, but we still reject absolute paths,
+    ``..`` traversal, and symlinks, and require the resolved directory to live
+    under one of run_dir's ancestors — so a tampered run_result.json can't point
+    trace collection at files outside the expected tree (CWE-22/CWE-59).
+    """
     if not raw:
         return None
     p = Path(raw)
-    if p.exists():
-        return p
-    for ancestor in run_dir.resolve().parents:
-        candidate = ancestor / raw
-        if candidate.exists():
+    if p.is_absolute() or ".." in p.parts:
+        return None
+    for root in run_dir.resolve().parents:
+        candidate = root / p
+        if (candidate.is_dir() and not candidate.is_symlink()
+                and _is_within(candidate, root)):
             return candidate
     return None
 
@@ -61,8 +77,10 @@ def _harbor_steps(job_dir):
     transcripts live under ``.../agent/sessions/projects/*/*/subagents/``.
     The case_id (name before ``__``) matches the summary.yaml per_case keys.
     """
+    job_root = job_dir.resolve(strict=True)
     for case_dir in sorted(d for d in job_dir.iterdir()
-                           if d.is_dir() and "__" in d.name):
+                           if d.is_dir() and not d.is_symlink()
+                           and "__" in d.name and _is_within(d, job_root)):
         case_id = case_dir.name.split("__")[0]
         steps_dir = case_dir / "steps"
         if steps_dir.is_dir():
@@ -74,10 +92,13 @@ def _harbor_steps(job_dir):
         for sd in step_dirs:
             agent_dir = sd / "agent"
             transcript = agent_dir / "claude-code.txt"
-            if not transcript.exists():
+            if not (transcript.is_file() and not transcript.is_symlink()
+                    and _is_within(transcript, job_root)):
                 continue
             step_name = "" if sd is case_dir else sd.name
-            subs = list(agent_dir.glob("sessions/projects/*/*/subagents"))
+            subs = [p for p in agent_dir.glob("sessions/projects/*/*/subagents")
+                    if p.is_dir() and not p.is_symlink()
+                    and _is_within(p, job_root)]
             yield (case_id, case_dir, step_name, transcript,
                    subs[0] if len(subs) == 1 else None)
 
@@ -90,7 +111,9 @@ def _harbor_step_run_result(case_dir, step_name, base):
         return rr
     try:
         data = json.loads(result_path.read_text())
-    except Exception:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+        print(f"WARNING: failed to parse Harbor result {result_path}: {e}",
+              file=sys.stderr)
         return rr
     steps = data.get("step_results") or []
     match = next((s for s in steps if s.get("step_name") == step_name), None)
@@ -452,9 +475,10 @@ def main():
             # overall judge to the final step; non-harbor runs use the
             # per-case trace.
             if steps_for_case:
+                step_trace_ids = list(steps_for_case.values())
                 trace_id = (steps_for_case.get(judge_name)
                             or steps_for_case.get("submit")
-                            or next(iter(steps_for_case.values()), None))
+                            or (step_trace_ids[-1] if step_trace_ids else None))
             else:
                 trace_id = case_trace_map.get(case_id, main_trace_id)
             if not trace_id:


### PR DESCRIPTION
## Summary

Harbor eval runs execute in-pod and write no `cases/<id>/stdout.log`, so the
existing `case`/`batch` trace paths in `log_results.py` produced **no MLflow
traces** for harbor runs — and the experiment Overview → Usage dashboard
(Token Usage, Tokens per Trace, Cost Breakdown, Cost Over Time) was empty.

This adds a `harbor` `exec_mode` branch that builds **one trace per step** from
each step's Claude stream-json, nesting background subagents, and wires the
token/cost metadata so the Usage dashboard populates.

## What changed (`skills/eval-mlflow/scripts/log_results.py`)

- **`_resolve_harbor_job_dir` / `_harbor_steps`** — locate per-step transcripts
  and subagent dirs in the harbor job layout
  (`<case>__<hash>/steps/<step>/agent/claude-code.txt`, single-step fallback,
  and `.../sessions/projects/*/*/subagents`).
- **`_harbor_step_run_result`** — per-step `model` + token/cost from
  `result.json`'s `agent_result`. Maps `n_input_tokens` / `n_cache_tokens` /
  `n_output_tokens` into the `{input, output, cache_read, cache_create}`
  schema `build_trace` expects, and synthesizes `per_model_usage` so
  `build_trace` writes `mlflow.trace.tokenUsage` **and** distributes per-span
  `mlflow.llm.cost`. Without this, those metadata keys are omitted and the
  Usage dashboard shows `0` tokens / `$0` cost.
- **`exec_mode == "harbor"` branch** — builds + logs one trace per step.
- **Feedback routing** — per-step judge feedback (`create`/`auto-fix`/`submit`)
  attaches to its matching step trace; overall judges fall back to the final
  step. Non-harbor runs keep the per-case trace behavior.

### Token semantics

Harbor's `agent_result` reports `n_input_tokens` as **total input including
cache**; `n_cache_tokens` is the cached portion. We map `input = n_input -
n_cache` (fresh + cache-creation, lumped — the split isn't reported), which
matches how local runs render (`build_trace` excludes `cache_read` from the
displayed input). `cost_usd` from `agent_result` is authoritative and is
distributed across LLM spans.

## Testing

Verified end-to-end against a 20-case harbor run logged to a live MLflow
server:

- **60** per-step traces logged and linked to the run
- **60/60** traces carry `mlflow.trace.tokenUsage` → **812,593** input /
  **181,449** output
- **852/852** LLM spans carry `mlflow.llm.cost`, summing to **$42.98**
  (matches the per-step `agent_result` cost total; no double-count)
- `python -m py_compile` clean

Usage dashboard panels render correctly after the fix (previously all zero).

> Note: the dashboard cost (sum of per-step `agent_result.cost_usd`) can run
> slightly below the run-level `cost_usd` metric, which remains the
> authoritative total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Harbor execution mode when logging evaluation results.
  * Trace logging now captures step-level runs, costs, token usage, and model details more accurately.
  * Judge feedback is now attached to the most relevant step in a run, improving trace clarity and reviewability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Review updates (CodeRabbit) — addressed in 518d366

- **Path traversal (CWE-22/59):** `_resolve_harbor_job_dir` / `_harbor_steps` now reject absolute/`..`/symlink paths and require resolved dirs/files to stay under the job root (new `_is_within` helper).
- **Bare `except` (Ruff BLE001):** `result.json` parsing narrowed to `(OSError, UnicodeDecodeError, JSONDecodeError)` with a warning.
- **Feedback fallback:** overall judges now route to the **final** step trace, not the first.
- **Token total:** `build_trace` now includes `cache_read` in `mlflow.trace.tokenUsage`, so the Usage dashboard shows **total input** ("what the eval used"), matching `report.py` "Input tokens (total)".

> ⚠️ **Scope note:** the `build_trace` token change applies to **all run types**, not just harbor — existing **local-run** trace token totals will now include cache reads (previously fresh + cache-write only). Cost is unchanged (`mlflow.llm.cost` / `mlflow.trace.cost`); the fresh/cached split stays in the run-level `tokens/{input,cache_read,cache_create}` metrics.


**Follow-up (485dad4) — cost/token source:** harbor per-step cost & tokens are now sourced from the step transcript (`_extract_transcript_metrics`, the same source as the run `cost_usd` metric and the report) instead of `result.json`'s `agent_result`. This fixes a cost bug: `agent_result.cost_usd` excluded background subagent cost (all in auto-fix), so the dashboard had undercounted ~11% ($42.98 vs $48.07). Per-span `mlflow.llm.cost` now sums to **$48.07**, and trace token totals match the run-level `token_usage` exactly (no n_input/n_cache remapping).
