### PR TITLE
feat(bootstrap): verify TLS against OS trust store when no CA bundle set

### DIFF
--- a/agent_eval/_bootstrap.py
+++ b/agent_eval/_bootstrap.py
@@ -136,13 +136,23 @@ def _inject_os_trust():
     importable (and after any os.execv in ``_activate``) — a no-op if truststore
     is absent, e.g. the in-pod harbor verifier that has no venv.
     """
-    if os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE"):
+    # Respect any explicit CA configuration — requests also falls back to
+    # CURL_CA_BUNDLE and OpenSSL honors SSL_CERT_FILE / SSL_CERT_DIR — so an
+    # operator-supplied trust store is never silently replaced by the OS store.
+    if any(os.environ.get(v) for v in
+           ("REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE",
+            "SSL_CERT_FILE", "SSL_CERT_DIR")):
         return
     try:
         import truststore
         truststore.inject_into_ssl()
-    except Exception:
-        pass
+    except ImportError:
+        pass  # truststore not installed — fall back to certifi
+    except Exception as e:
+        # Injection itself failed (unsupported platform / API change). Warn
+        # rather than silently fall back, so a real CA-chain problem is visible.
+        print(f"WARNING: truststore.inject_into_ssl() failed: {e}",
+              file=sys.stderr)
 
 
 _activate()

--- a/agent_eval/_bootstrap.py
+++ b/agent_eval/_bootstrap.py
@@ -122,4 +122,28 @@ def _activate():
         _patch_syspath(site_dirs)
 
 
+def _inject_os_trust():
+    """Verify TLS against the OS trust store instead of certifi's bundle.
+
+    This lets the harness reach endpoints fronted by an internal CA — notably a
+    Red Hat-issued MLflow tracking server — without anyone setting
+    ``REQUESTS_CA_BUNDLE``, because the OS store (macOS keychain, Linux system
+    certs) already trusts both public and internal roots.
+
+    Gated on the CA-bundle env vars: when one is set (CI, containers) we leave
+    verification untouched, since truststore makes the OS store authoritative and
+    would otherwise override that bundle. Best-effort and called after deps are
+    importable (and after any os.execv in ``_activate``) — a no-op if truststore
+    is absent, e.g. the in-pod harbor verifier that has no venv.
+    """
+    if os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE"):
+        return
+    try:
+        import truststore
+        truststore.inject_into_ssl()
+    except Exception:
+        pass
+
+
 _activate()
+_inject_os_trust()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ requires-python = ">=3.11"
 dependencies = [
     "pyyaml>=6.0",
     "jinja2>=3.1",
+    # Verify TLS against the OS trust store (see agent_eval/_bootstrap.py) so the
+    # harness reaches internal-CA endpoints (e.g. a Red Hat-issued MLflow server)
+    # without REQUESTS_CA_BUNDLE. Pure-Python, requires-python>=3.11 covers it.
+    "truststore>=0.9",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # Verify TLS against the OS trust store (see agent_eval/_bootstrap.py) so the
     # harness reaches internal-CA endpoints (e.g. a Red Hat-issued MLflow server)
     # without REQUESTS_CA_BUNDLE. Pure-Python, requires-python>=3.11 covers it.
-    "truststore>=0.9",
+    "truststore>=0.9,<1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

The harness's HTTPS clients (`mlflow`, `requests`) verify TLS against `certifi`,
which doesn't trust internal CAs. Reaching the Red Hat-issued MLflow tracking
server therefore required exporting `REQUESTS_CA_BUNDLE` pointed at the RH root —
and that's a footgun: an **RH-root-only** bundle breaks any *public* HTTPS in the
same process (pip/PyPI, S3), because public certs can't chain to it.

This injects [`truststore`](https://truststore.readthedocs.io) in `_bootstrap`
so Python verifies against the **OS trust store** (macOS keychain / Linux system
certs), which already trusts **both** public and internal roots — so no CA env
var is needed for internal-CA endpoints, and public HTTPS keeps working.

## Changes

- `pyproject.toml`: add `truststore>=0.9` to core dependencies (pure-Python;
  `requires-python>=3.11` already satisfies its 3.10+ floor).
- `agent_eval/_bootstrap.py`: add `_inject_os_trust()`, called after `_activate()`
  (so it runs in the final interpreter, including after the `os.execv` ABI-mismatch
  re-exec, where `_activate` short-circuits on the sentinel).

## Gating — no conflict with CI / explicit bundles

Injection is **skipped when `REQUESTS_CA_BUNDLE` or `SSL_CERT_FILE` is set**:

| Environment | Behavior |
|---|---|
| Local dev (no CA env var) | truststore injected → OS keychain used → no env var needed |
| CI / containers (`REQUESTS_CA_BUNDLE` set) | injection skipped → explicit bundle honored, **unchanged** |
| No venv (in-pod harbor verifier) / truststore absent | guarded `try/except` → no-op |

This gate matters because truststore makes the OS store **authoritative** — I
confirmed that with truststore active, an RH-root-only bundle still verifies a
*public* host and a certifi-only bundle still verifies the *RH* host (i.e. it can
override the provided bundle). Skipping injection when a bundle is explicitly set
guarantees CI is byte-for-byte unchanged.

## Testing

- `truststore.inject_into_ssl()` connects to the RH MLflow server (**TLS OK,
  HTTP 403**) where plain `certifi` **fails** — verified in a clean venv.
- `python -m py_compile agent_eval/_bootstrap.py` clean.
- Import smoke test passes with the env var both set (skip path) and unset
  (guarded no-op while truststore not yet installed).

## Notes / limitations

- truststore only helps where the **OS trust store contains the internal root**
  (developer laptops via IT-provisioned keychain ✓). Bare CI runners / containers
  still need the CA provisioned (`update-ca-trust`) or the `REQUESTS_CA_BUNDLE`
  fallback — which this change preserves.
- The RH MLflow host is a genuine internal-CA endpoint (cert chains to the Red Hat
  IT Internal Root CA); public endpoints (PyPI, S3) are **not** intercepted, so a
  single RH-only bundle can't serve both — which is the motivation for using the
  OS store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS certificate verification to automatically use the operating system trust store when no custom certificate bundle settings are provided, improving compatibility across more environments.
  * Uses a best-effort approach: if the OS trust-store helper isn’t available, it falls back safely; unexpected issues emit a warning.

* **Chores**
  * Added a new dependency to enable OS-based certificate verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->