### PR TITLE
feat(mlflow): break out cache tokens in trace token usage

### DIFF
--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -785,21 +785,26 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
                     trace_cost[m_name] = m_stats["cost_usd"]
         trace_metadata["mlflow.trace.cost"] = json.dumps(trace_cost)
     if token_usage:
-        # Total input INCLUDING cache reads, matching report.py's "Input tokens
-        # (total)" so the MLflow Usage dashboard reflects total input volume
-        # ("what the eval used"). Cost is tracked separately (mlflow.llm.cost /
-        # mlflow.trace.cost) and the fresh/cached split stays in the run-level
-        # tokens/{input,cache_read,cache_create} metrics — so excluding cache
-        # reads here would understate usage and diverge from the report.
-        input_tokens = (token_usage.get("input", 0)
-                        + token_usage.get("cache_create", 0)
-                        + token_usage.get("cache_read", 0))
+        # Follow MLflow's anthropic / claude_code token-usage convention so the
+        # Usage dashboard renders Input / Output / Cache Read / Cache Write as
+        # distinct lines: input_tokens is the NON-cached (fresh) input, cache
+        # tokens are separate optional keys, and total_tokens = input + output
+        # (cache excluded). The cache lines carry the bulk of the volume; cost
+        # stays separate via mlflow.llm.cost / mlflow.trace.cost.
+        input_tokens = token_usage.get("input", 0)
         output_tokens = token_usage.get("output", 0)
-        trace_metadata["mlflow.trace.tokenUsage"] = json.dumps({
+        usage = {
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "total_tokens": input_tokens + output_tokens,
-        })
+        }
+        cache_read = token_usage.get("cache_read", 0)
+        cache_create = token_usage.get("cache_create", 0)
+        if cache_read:
+            usage["cache_read_input_tokens"] = cache_read
+        if cache_create:
+            usage["cache_creation_input_tokens"] = cache_create
+        trace_metadata["mlflow.trace.tokenUsage"] = json.dumps(usage)
     if session_id:
         trace_metadata["mlflow.trace.session"] = session_id
 


### PR DESCRIPTION
## Summary

Populate the MLflow experiment **Usage** dashboard's **Cache Read** and **Cache Write** lines, which were empty because the trace token usage only carried `input_tokens` / `output_tokens` (with cache folded into input by #141).

MLflow 3.12's `TokenUsageKey` schema supports the cache keys, and `mlflow/claude_code/tracing.py` documents the exact convention (matching `mlflow.anthropic.autolog`):
- `input_tokens` = **non-cached** (fresh) input
- `cache_read_input_tokens` → **Cache Read**, `cache_creation_input_tokens` → **Cache Write** (separate optional keys)
- `total_tokens = input_tokens + output_tokens` (**cache excluded**)

## Change

`agent_eval/mlflow/trace_builder.py` — emit the disjoint breakdown in `mlflow.trace.tokenUsage`:

```python
input_tokens  = token_usage.get("input", 0)      # fresh
output_tokens = token_usage.get("output", 0)
usage = {"input_tokens": input_tokens, "output_tokens": output_tokens,
         "total_tokens": input_tokens + output_tokens}
if token_usage.get("cache_read"):   usage["cache_read_input_tokens"]     = ...
if token_usage.get("cache_create"): usage["cache_creation_input_tokens"] = ...
```

This **refines #141**: that PR folded `cache_read + cache_create` into `input_tokens` as a stopgap (when only input/output were thought to be supported). With the cache keys confirmed, the disjoint breakdown is correct — the four lines show total volume *and* separate the cost-driving fresh + cache-write tokens from cheap cache reads.

## Behavior change to note

The headline **Token Usage** total now follows MLflow's convention — `input + output` (**cache excluded**). The cache volume appears in its own Cache Read / Cache Write lines rather than being summed into input/total.

## Testing

Built traces for all 60 steps of the 20-case harbor run; aggregated trace token usage matches the run-level `token_usage` exactly:

| key | trace aggregate | run-level |
|---|---|---|
| input_tokens (fresh) | 948 | 948 |
| output_tokens | 172,588 | 172,588 |
| cache_read_input_tokens | 33,721,364 | 33,721,364 |
| cache_creation_input_tokens | 786,736 | 786,736 |

`python -m py_compile` clean. Existing runs need a re-log to surface the new lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated trace token usage reporting to align with MLflow and Claude-style conventions.
  * Input tokens now reflect only non-cached input usage, while cache read and cache creation counts are reported separately when available.
  * Total token counts now use input plus output tokens, improving accuracy and consistency in usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->