### PR TITLE
Add OpenCode smoke test with OTel tracing to MLflow

### DIFF
--- a/eval/opencode-smoke/cases/case-001/annotations.yaml
+++ b/eval/opencode-smoke/cases/case-001/annotations.yaml
@@ -1,0 +1,2 @@
+expected_file: hello.txt
+expected_content: "Hello from OpenCode smoke test"

--- a/eval/opencode-smoke/cases/case-001/input.yaml
+++ b/eval/opencode-smoke/cases/case-001/input.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  Create a file called hello.txt with exactly the content "Hello from OpenCode smoke test" (no quotes, no trailing newline). Do not create any other files.

--- a/eval/opencode-smoke/eval.yaml
+++ b/eval/opencode-smoke/eval.yaml
@@ -16,7 +16,6 @@ execution:
     OPENCODE_OTLP_PROTOCOL: http/json
     OPENCODE_OTLP_HEADERS: "$OPENCODE_OTLP_HEADERS"
     OTEL_BSP_SCHEDULE_DELAY: "100"
-    NODE_TLS_REJECT_UNAUTHORIZED: "0"
 
 runner:
   type: cli
@@ -43,10 +42,9 @@ mlflow:
 dataset:
   path: cases
   schema: |
-    Each case directory contains input.yaml with:
-    - prompt: the task for opencode to execute
-    - expected_file: filename that should be created
-    - expected_content: text that should appear in the file
+    Each case directory contains:
+    - input.yaml: prompt (the task for opencode to execute)
+    - annotations.yaml: expected_file, expected_content (used by judges)
 
 outputs:
   - path: output

--- a/eval/opencode-smoke/eval.yaml
+++ b/eval/opencode-smoke/eval.yaml
@@ -1,0 +1,93 @@
+name: opencode-smoke
+description: Smoke test for OpenCode CLI agent — creates a file and verifies content
+skill: opencode-smoke
+
+execution:
+  mode: case
+  arguments: "{prompt}"
+  timeout: 120
+  max_budget_usd: 1.0
+  env:
+    GOOGLE_CLOUD_PROJECT: "$GOOGLE_CLOUD_PROJECT"
+    VERTEX_LOCATION: us-east5
+    EVAL_PROJECT_ROOT: "$PWD"
+    OPENCODE_ENABLE_TELEMETRY: "1"
+    OPENCODE_OTLP_ENDPOINT: "$OPENCODE_OTLP_ENDPOINT"
+    OPENCODE_OTLP_PROTOCOL: http/json
+    OPENCODE_OTLP_HEADERS: "$OPENCODE_OTLP_HEADERS"
+    OTEL_BSP_SCHEDULE_DELAY: "100"
+    NODE_TLS_REJECT_UNAUTHORIZED: "0"
+
+runner:
+  type: cli
+  command:
+    - bash
+    - -c
+    - exec "$EVAL_PROJECT_ROOT/eval/opencode-smoke/scripts/run-opencode.sh" "$@"
+    - --
+    - "{args}"
+    - "{workspace}"
+    - "{output_dir}"
+    - "{model}"
+
+models:
+  skill: google-vertex/claude-haiku-4-5@20251001
+
+mlflow:
+  experiment: jeder-opencode
+  tracking_uri: https://mlflow.apps.int.spoke.prod.us-west-2.aws.paas.redhat.com
+  tags:
+    test_type: smoke
+    agent: opencode
+
+dataset:
+  path: cases
+  schema: |
+    Each case directory contains input.yaml with:
+    - prompt: the task for opencode to execute
+    - expected_file: filename that should be created
+    - expected_content: text that should appear in the file
+
+outputs:
+  - path: output
+    schema: Files created by opencode during execution
+
+traces:
+  stdout: true
+  stderr: true
+  events: false
+  metrics: true
+
+judges:
+  - name: exit_success
+    description: OpenCode exited successfully
+    check: |
+      ec = outputs.get("exit_code", -1)
+      if ec == 0:
+        return True, "Exit code 0"
+      return False, f"Exit code {ec}"
+
+  - name: file_created
+    description: Expected file exists with correct content
+    check: |
+      ann = outputs.get("annotations", {})
+      expected_file = ann.get("expected_file", "")
+      expected_content = ann.get("expected_content", "")
+      if not expected_file:
+        return False, "No expected_file in annotations"
+      files = outputs.get("files", {})
+      for path, content in files.items():
+        if expected_file in path and isinstance(content, str):
+          if expected_content and expected_content in content:
+            return True, f"Found {expected_file} with expected content"
+          elif not expected_content:
+            return True, f"Found {expected_file}"
+          else:
+            return False, f"Found {expected_file} but content mismatch: {content[:200]}"
+      return False, f"File {expected_file} not found in outputs: {list(files.keys())[:10]}"
+
+thresholds:
+  exit_success:
+    min_pass_rate: 1.0
+  file_created:
+    min_pass_rate: 1.0

--- a/eval/opencode-smoke/scripts/run-opencode.sh
+++ b/eval/opencode-smoke/scripts/run-opencode.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Wrapper: run opencode in the workspace, copy new files to output_dir,
+# extract metrics from JSON event stream.
+#
+# Usage: run-opencode.sh <prompt> <workspace> <output_dir> [model]
+set -euo pipefail
+
+PROMPT="$1"
+WORKSPACE="$2"
+OUTPUT_DIR="$3"
+MODEL="${4:-google-vertex/claude-haiku-4-5@20251001}"
+
+OPENCODE="${OPENCODE_BIN:-$(command -v opencode 2>/dev/null || echo "$HOME/.opencode/bin/opencode")}"
+
+mkdir -p "$WORKSPACE" "$OUTPUT_DIR"
+cd "$WORKSPACE"
+
+# Snapshot pre-existing files
+PRE_LIST=$(mktemp)
+find . -maxdepth 3 -type f \
+  -not -path './.git/*' -not -path './.opencode/*' \
+  -not -path './output/*' -not -path './.claude/*' \
+  > "$PRE_LIST" 2>/dev/null || true
+
+# Run opencode — capture JSON events to a temp file, stream to stdout for harness
+EVENT_LOG=$(mktemp)
+set +e
+"$OPENCODE" run "$PROMPT" \
+  --format json \
+  --dir "$WORKSPACE" \
+  --model "$MODEL" \
+  --auto \
+  2>&1 | tee "$EVENT_LOG"
+EXIT_CODE=${PIPESTATUS[0]}
+set -e
+
+# Snapshot post-run files
+POST_LIST=$(mktemp)
+find . -maxdepth 3 -type f \
+  -not -path './.git/*' -not -path './.opencode/*' \
+  -not -path './output/*' -not -path './.claude/*' \
+  > "$POST_LIST" 2>/dev/null || true
+
+# Copy new files to output_dir (set difference via comm)
+comm -13 <(sort "$PRE_LIST") <(sort "$POST_LIST") | while IFS= read -r f; do
+  target_dir="$OUTPUT_DIR/$(dirname "$f")"
+  mkdir -p "$target_dir"
+  cp "$f" "$OUTPUT_DIR/$f" 2>/dev/null || true
+done
+
+# Extract metrics from step_finish events in the JSON stream
+_EVENT_LOG="$EVENT_LOG" _OUTPUT_DIR="$OUTPUT_DIR" _MODEL="$MODEL" \
+python3 -c "
+import json, os
+
+total_input = 0
+total_output = 0
+cache_read = 0
+cache_write = 0
+total_cost = 0.0
+num_turns = 0
+
+for line in open(os.environ['_EVENT_LOG']):
+    line = line.strip()
+    if not line or not line.startswith('{'):
+        continue
+    try:
+        evt = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if evt.get('type') == 'step_finish':
+        part = evt.get('part', {})
+        tokens = part.get('tokens', {})
+        total_input += tokens.get('input', 0)
+        total_output += tokens.get('output', 0)
+        cache_read += tokens.get('cache', {}).get('read', 0)
+        cache_write += tokens.get('cache', {}).get('write', 0)
+        total_cost += part.get('cost', 0.0)
+        num_turns += 1
+
+metrics = {
+    'token_usage': {
+        'input': total_input + cache_read,
+        'output': total_output,
+        'cache_read': cache_read,
+        'cache_write': cache_write,
+    },
+    'cost_usd': round(total_cost, 6) if total_cost else None,
+    'num_turns': num_turns or None,
+    'model': os.environ['_MODEL'],
+}
+with open(os.path.join(os.environ['_OUTPUT_DIR'], 'metrics.json'), 'w') as f:
+    json.dump(metrics, f, indent=2)
+" 2>/dev/null || true
+
+rm -f "$PRE_LIST" "$POST_LIST" "$EVENT_LOG"
+exit $EXIT_CODE

--- a/eval/opencode-smoke/scripts/run-opencode.sh
+++ b/eval/opencode-smoke/scripts/run-opencode.sh
@@ -15,15 +15,18 @@ OPENCODE="${OPENCODE_BIN:-$(command -v opencode 2>/dev/null || echo "$HOME/.open
 mkdir -p "$WORKSPACE" "$OUTPUT_DIR"
 cd "$WORKSPACE"
 
-# Snapshot pre-existing files
-PRE_LIST=$(mktemp)
+# Snapshot pre-existing files with checksums to detect both new and modified files
+PRE_CHECKSUMS=$(mktemp)
+EVENT_LOG=$(mktemp)
+POST_CHECKSUMS=$(mktemp)
+trap 'rm -f "$PRE_CHECKSUMS" "$POST_CHECKSUMS" "$EVENT_LOG"' EXIT
+
 find . -maxdepth 3 -type f \
   -not -path './.git/*' -not -path './.opencode/*' \
   -not -path './output/*' -not -path './.claude/*' \
-  > "$PRE_LIST" 2>/dev/null || true
+  -exec md5sum {} + 2>/dev/null | sort > "$PRE_CHECKSUMS" || true
 
 # Run opencode — capture JSON events to a temp file, stream to stdout for harness
-EVENT_LOG=$(mktemp)
 set +e
 "$OPENCODE" run "$PROMPT" \
   --format json \
@@ -34,15 +37,14 @@ set +e
 EXIT_CODE=${PIPESTATUS[0]}
 set -e
 
-# Snapshot post-run files
-POST_LIST=$(mktemp)
+# Snapshot post-run files with checksums
 find . -maxdepth 3 -type f \
   -not -path './.git/*' -not -path './.opencode/*' \
   -not -path './output/*' -not -path './.claude/*' \
-  > "$POST_LIST" 2>/dev/null || true
+  -exec md5sum {} + 2>/dev/null | sort > "$POST_CHECKSUMS" || true
 
-# Copy new files to output_dir (set difference via comm)
-comm -13 <(sort "$PRE_LIST") <(sort "$POST_LIST") | while IFS= read -r f; do
+# Copy new and modified files to output_dir
+comm -13 "$PRE_CHECKSUMS" "$POST_CHECKSUMS" | awk '{print $2}' | while IFS= read -r f; do
   target_dir="$OUTPUT_DIR/$(dirname "$f")"
   mkdir -p "$target_dir"
   cp "$f" "$OUTPUT_DIR/$f" 2>/dev/null || true
@@ -85,13 +87,12 @@ metrics = {
         'cache_read': cache_read,
         'cache_write': cache_write,
     },
-    'cost_usd': round(total_cost, 6) if total_cost else None,
-    'num_turns': num_turns or None,
+    'cost_usd': round(total_cost, 6) if num_turns > 0 else None,
+    'num_turns': num_turns if num_turns > 0 else None,
     'model': os.environ['_MODEL'],
 }
 with open(os.path.join(os.environ['_OUTPUT_DIR'], 'metrics.json'), 'w') as f:
     json.dump(metrics, f, indent=2)
 " 2>/dev/null || true
 
-rm -f "$PRE_LIST" "$POST_LIST" "$EVENT_LOG"
 exit $EXIT_CODE


### PR DESCRIPTION
Adds an eval config that runs OpenCode headlessly via the CLI runner and pushes results + OTel traces to MLflow.

## What's included

- **`eval/opencode-smoke/eval.yaml`** — CLI runner config targeting `jeder-opencode` experiment, Haiku via Vertex AI
- **`eval/opencode-smoke/cases/case-001/`** — trivial "create hello.txt" test case with annotations
- **`eval/opencode-smoke/scripts/run-opencode.sh`** — wrapper that runs opencode, copies artifacts to output dir, extracts token/cost metrics from JSON event stream

## Key details

- **Runner**: `cli` type wrapping `opencode run --format json --auto`
- **Model**: `google-vertex/claude-haiku-4-5@20251001` (Claude via Vertex AI)
- **Judges**: 2 deterministic check judges (exit_success, file_created) — no LLM spend for scoring
- **OTel tracing**: via [`@devtheops/opencode-plugin-otel`](https://github.com/DEVtheOPS/opencode-plugin-otel) — session, LLM, and tool spans export to MLflow's OTLP endpoint
- **Metrics**: token usage and cost extracted from opencode's `step_finish` JSON events into `metrics.json`

## Tested

- Smoke test passes (both judges 100%)
- Results logged to MLflow (params, metrics, artifacts)
- OTel traces land in MLflow with tool and LLM spans
- Requires `OTEL_BSP_SCHEDULE_DELAY=100` to flush spans before opencode exits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new smoke-test evaluation for creating a text file from a prompt.
  * Captures the generated file and checks that it contains the expected exact content.
  * Tracks run metrics such as token usage and cost for each execution.
  * Configured the evaluation to use a specific model setup with runtime limits and pass/fail checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->