### PR TITLE
[wip] feat: multi-step workflow evaluation

### DIFF
--- a/agent_eval/agent/base.py
+++ b/agent_eval/agent/base.py
@@ -63,6 +63,8 @@ class EvalRunner(ABC):
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
         extra_env: Optional[dict] = None,
+        continue_session: bool = False,
+        skip_cleanup: bool = False,
     ) -> RunResult:
         """Invoke a skill in an isolated workspace.
 
@@ -79,7 +81,14 @@ class EvalRunner(ABC):
             timeout_s: Timeout in seconds.
             extra_env: Additional env vars to inject (e.g. from hook outputs).
                 Merged after execution.env, so hook env overrides static config.
+            continue_session: If True, continue the most recent session in the
+                workspace instead of starting a fresh one (Claude Code --continue).
+            skip_cleanup: If True, do not clean up the session directory after
+                the run. Used for workflow steps that need session continuation.
 
         Returns:
             RunResult with exit code, output, timing, and optional usage stats.
         """
+
+    def cleanup_session(self, workspace: Path) -> None:
+        """Clean up session data for a workspace. Called at workflow end."""

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -105,6 +105,8 @@ class ClaudeCodeRunner(EvalRunner):
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
         extra_env: Optional[dict] = None,
+        continue_session: bool = False,
+        skip_cleanup: bool = False,
     ) -> RunResult:
         cmd = [
             "claude",
@@ -131,6 +133,9 @@ class ClaudeCodeRunner(EvalRunner):
         effective_prompt = system_prompt or self._system_prompt
         if effective_prompt:
             cmd.extend(["--append-system-prompt", effective_prompt])
+
+        if continue_session:
+            cmd.append("--continue")
 
         # Permissions: allow/deny tool patterns
         deny = self._permissions.get("deny", [])
@@ -264,10 +269,8 @@ class ClaudeCodeRunner(EvalRunner):
         duration = time.monotonic() - start
         stdout_text = "\n".join(stdout_lines)
 
-        # Clean up session directory now that SubagentStop hooks have fired
-        # and copied transcripts.  Without this, session files accumulate
-        # in ~/.claude/projects/ for every eval run.
-        self._cleanup_session(workspace)
+        if not skip_cleanup:
+            self._cleanup_session(workspace)
 
         # Extract usage from collected stream-json lines
         raw_output = result_obj
@@ -313,6 +316,10 @@ class ClaudeCodeRunner(EvalRunner):
             permission_denials=denial_list,
             raw_output=raw_output,
         )
+
+    def cleanup_session(self, workspace: Path) -> None:
+        """Public interface for workflow-end session cleanup."""
+        self._cleanup_session(workspace)
 
     @staticmethod
     def _cleanup_session(workspace: Path) -> None:

--- a/agent_eval/agent/cli_runner.py
+++ b/agent_eval/agent/cli_runner.py
@@ -88,6 +88,8 @@ class CliRunner(EvalRunner):
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
         extra_env: Optional[dict] = None,
+        continue_session: bool = False,
+        skip_cleanup: bool = False,
     ) -> RunResult:
         workspace = workspace.resolve()
         output_dir = workspace / "output"

--- a/agent_eval/agent/responses_api.py
+++ b/agent_eval/agent/responses_api.py
@@ -267,6 +267,10 @@ class ResponsesAPIRunner(EvalRunner):
         continue_session: bool = False,
         skip_cleanup: bool = False,
     ) -> RunResult:
+        if continue_session:
+            raise NotImplementedError(
+                "ResponsesAPIRunner does not support continue_session. "
+                "Use ClaudeCodeRunner for workflow session continuation.")
         client = None
         effective_model = model or self._default_model
         if not effective_model:
@@ -360,5 +364,5 @@ class ResponsesAPIRunner(EvalRunner):
                 duration_s=duration,
             )
         finally:
-            if container_id and client is not None:
+            if container_id and client is not None and not skip_cleanup:
                 self._delete_container(client, container_id)

--- a/agent_eval/agent/responses_api.py
+++ b/agent_eval/agent/responses_api.py
@@ -264,6 +264,8 @@ class ResponsesAPIRunner(EvalRunner):
         max_budget_usd: float = 5.0,
         timeout_s: int = 600,
         extra_env: Optional[dict] = None,
+        continue_session: bool = False,
+        skip_cleanup: bool = False,
     ) -> RunResult:
         client = None
         effective_model = model or self._default_model

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -340,6 +340,45 @@ class JudgeConfig:
 
 
 @dataclass
+class StepValidateConfig:
+    """Validation-retry semantics for a validate step."""
+    retry_step: str = ""
+    max_retries: int = 3
+    retry_prompt: str = ""
+
+
+@dataclass
+class WorkflowStepConfig:
+    """A single step in a multi-step workflow."""
+    id: str = ""
+    type: str = ""  # "skill" | "script" | "validate"
+    description: str = ""
+
+    # Skill step fields
+    skill: str = ""
+    arguments: str = ""
+    max_budget_usd: Optional[float] = None
+    continue_session: bool = False
+
+    # Script / validate step fields
+    command: str = ""
+
+    # Validate step fields
+    validate: Optional[StepValidateConfig] = None
+
+    # Common fields
+    timeout: Optional[int] = None
+    condition: str = ""
+    on_failure: str = "abort"  # "abort" | "continue"
+
+
+@dataclass
+class WorkflowConfig:
+    """Multi-step workflow definition."""
+    steps: list = field(default_factory=list)
+
+
+@dataclass
 class RewardConfig:
     """Reward composition from judge results for RL training.
 
@@ -418,6 +457,9 @@ class EvalConfig:
 
     # Judges (inline checks, LLM, pairwise, external code)
     judges: list = field(default_factory=list)
+
+    # Multi-step workflow (mutually exclusive with skill)
+    workflow: Optional[WorkflowConfig] = None
 
     # Reward composition for RL training (optional)
     reward: Optional[RewardConfig] = None
@@ -758,6 +800,97 @@ class EvalConfig:
                     stacklevel=2,
                 )
 
+        # Workflow
+        workflow_raw = raw.get("workflow")
+        if workflow_raw is not None:
+            if config.skill:
+                raise ValueError(
+                    "workflow: and skill: are mutually exclusive")
+            if not isinstance(workflow_raw, dict):
+                raise ValueError("workflow must be a mapping")
+            steps_raw = workflow_raw.get("steps") or []
+            if not isinstance(steps_raw, list) or not steps_raw:
+                raise ValueError("workflow.steps must be a non-empty list")
+            step_ids: set[str] = set()
+            steps: list[WorkflowStepConfig] = []
+            for i, s in enumerate(steps_raw):
+                if not isinstance(s, dict):
+                    raise ValueError(
+                        f"workflow.steps[{i}] must be a mapping")
+                step_id = s.get("id", "")
+                if not step_id:
+                    raise ValueError(
+                        f"workflow.steps[{i}]: 'id' is required")
+                if step_id in step_ids:
+                    raise ValueError(
+                        f"workflow.steps[{i}]: duplicate step id "
+                        f"'{step_id}'")
+                step_ids.add(step_id)
+                step_type = s.get("type", "")
+                if step_type not in ("skill", "script", "validate"):
+                    raise ValueError(
+                        f"workflow.steps[{i}] ('{step_id}'): type must "
+                        f"be 'skill', 'script', or 'validate'")
+                on_failure_val = s.get("on_failure", "abort")
+                if on_failure_val not in ("abort", "continue"):
+                    raise ValueError(
+                        f"workflow.steps[{i}] ('{step_id}'): on_failure "
+                        f"must be 'abort' or 'continue'")
+                validate_cfg = None
+                if step_type == "validate":
+                    if not s.get("command"):
+                        raise ValueError(
+                            f"workflow.steps[{i}] ('{step_id}'): "
+                            f"validate steps require 'command'")
+                    retry_step = s.get("retry_step", "")
+                    if not retry_step:
+                        raise ValueError(
+                            f"workflow.steps[{i}] ('{step_id}'): "
+                            f"validate steps require 'retry_step'")
+                    if retry_step not in step_ids:
+                        raise ValueError(
+                            f"workflow.steps[{i}] ('{step_id}'): "
+                            f"retry_step '{retry_step}' not found in "
+                            f"earlier steps")
+                    prior_types = {
+                        st.id: st.type for st in steps
+                    }
+                    if prior_types.get(retry_step) != "skill":
+                        raise ValueError(
+                            f"workflow.steps[{i}] ('{step_id}'): "
+                            f"retry_step '{retry_step}' must reference "
+                            f"a skill step")
+                    validate_cfg = StepValidateConfig(
+                        retry_step=retry_step,
+                        max_retries=int(s.get("max_retries", 3)),
+                        retry_prompt=s.get("retry_prompt", ""),
+                    )
+                elif step_type == "skill":
+                    if not s.get("skill"):
+                        raise ValueError(
+                            f"workflow.steps[{i}] ('{step_id}'): "
+                            f"skill steps require 'skill'")
+                elif step_type == "script":
+                    if not s.get("command"):
+                        raise ValueError(
+                            f"workflow.steps[{i}] ('{step_id}'): "
+                            f"script steps require 'command'")
+                steps.append(WorkflowStepConfig(
+                    id=step_id,
+                    type=step_type,
+                    description=s.get("description", ""),
+                    skill=s.get("skill", ""),
+                    arguments=s.get("arguments", ""),
+                    max_budget_usd=s.get("max_budget_usd"),
+                    continue_session=bool(s.get("continue_session", False)),
+                    command=s.get("command", ""),
+                    validate=validate_cfg,
+                    timeout=s.get("timeout"),
+                    condition=s.get("condition", ""),
+                    on_failure=on_failure_val,
+                ))
+            config.workflow = WorkflowConfig(steps=steps)
+
         if config.skill:
             try:
                 _validate_path_segment(config.skill, f"skill name in {path}")
@@ -765,6 +898,11 @@ class EvalConfig:
                 raise ValueError(str(e)) from e
 
         return config
+
+    @property
+    def is_workflow(self) -> bool:
+        """True when this config defines a multi-step workflow."""
+        return self.workflow is not None and len(self.workflow.steps) > 0
 
     @property
     def project_root(self) -> Path:
@@ -802,9 +940,14 @@ def discover_configs(project_root: Path) -> list[DiscoveryResult]:
         except Exception as exc:
             print(f"Warning: skipping {yaml_path}: {exc}", file=sys.stderr)
             return
-        if not isinstance(raw, dict) or not raw.get("skill"):
+        if not isinstance(raw, dict):
             return
-        eval_name = raw["skill"]
+        has_skill = bool(raw.get("skill"))
+        has_workflow = (isinstance(raw.get("workflow"), dict)
+                        and raw["workflow"].get("steps"))
+        if not has_skill and not has_workflow:
+            return
+        eval_name = raw.get("name") or raw.get("skill", "")
         if not _is_valid_eval_name(eval_name):
             print(f"Warning: skipping {yaml_path}: invalid eval name {eval_name!r}",
                   file=sys.stderr)

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -821,6 +821,12 @@ class EvalConfig:
                 if not step_id:
                     raise ValueError(
                         f"workflow.steps[{i}]: 'id' is required")
+                import re as _re
+                if not _re.fullmatch(r'[a-zA-Z0-9][a-zA-Z0-9_-]*', step_id):
+                    raise ValueError(
+                        f"workflow.steps[{i}]: step id '{step_id}' "
+                        f"must start with alphanumeric and contain "
+                        f"only [a-zA-Z0-9_-]")
                 if step_id in step_ids:
                     raise ValueError(
                         f"workflow.steps[{i}]: duplicate step id "
@@ -860,9 +866,14 @@ class EvalConfig:
                             f"workflow.steps[{i}] ('{step_id}'): "
                             f"retry_step '{retry_step}' must reference "
                             f"a skill step")
+                    max_retries_raw = s.get("max_retries", 3)
+                    if not isinstance(max_retries_raw, int) or max_retries_raw < 0:
+                        raise ValueError(
+                            f"workflow.steps[{i}] ('{step_id}'): "
+                            f"max_retries must be a non-negative integer")
                     validate_cfg = StepValidateConfig(
                         retry_step=retry_step,
-                        max_retries=int(s.get("max_retries", 3)),
+                        max_retries=max_retries_raw,
                         retry_prompt=s.get("retry_prompt", ""),
                     )
                 elif step_type == "skill":

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -34,7 +34,8 @@ from agent_eval.events import (
 _HARNESS_PATHS = {
     ".claude", ".git", ".work", "subagents", "hooks",
     "stdout.log", "stderr.log",
-    "run_result.json", "batch.yaml", "case_order.yaml",
+    "run_result.json", "workflow_result.json",
+    "batch.yaml", "case_order.yaml",
 }
 
 

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -21,6 +21,7 @@ Usage:
 import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
 import argparse
+import ast
 import json
 import os
 import shutil
@@ -471,30 +472,80 @@ def _step_env(step_results):
     return env
 
 
-def _eval_step_condition(condition, step_results):
-    """Evaluate a step condition against accumulated results."""
-    class _StepProxy:
-        def __init__(self, data):
-            self._data = data
-        def __getattr__(self, key):
-            return self._data.get(key, _StepProxy({}))
-        def __bool__(self):
-            return bool(self._data)
+_STEP_FIELDS = frozenset({
+    "exit_code", "duration_s", "cost_usd", "timed_out", "skipped", "retries",
+})
 
-    steps_ns = {}
+_SAFE_AST_NODES = (
+    ast.Expression, ast.BoolOp, ast.And, ast.Or, ast.UnaryOp, ast.Not,
+    ast.Compare, ast.Eq, ast.NotEq, ast.Lt, ast.LtE, ast.Gt, ast.GtE,
+    ast.Is, ast.IsNot, ast.Attribute, ast.Name, ast.Constant, ast.Load,
+)
+
+
+def _eval_step_condition(condition, step_results):
+    """Evaluate a step condition safely using AST whitelisting.
+
+    Only allows: steps.<id>.<field>, boolean operators (and/or/not),
+    comparisons (==, !=, <, >, <=, >=), and constants.
+    """
+    try:
+        tree = ast.parse(condition, mode="eval")
+    except SyntaxError:
+        return False
+
+    for node in ast.walk(tree):
+        if not isinstance(node, _SAFE_AST_NODES):
+            return False
+
+    steps_data = {}
     for step_id, sr in step_results.items():
-        steps_ns[step_id] = _StepProxy({
+        steps_data[step_id] = {
             "exit_code": sr.exit_code,
             "duration_s": sr.duration_s,
             "cost_usd": sr.cost_usd,
             "timed_out": sr.timed_out,
             "skipped": sr.skipped,
             "retries": sr.retries,
-        })
+        }
+
+    class _StepAccessor:
+        def __init__(self, data):
+            self._data = data
+        def __getattr__(self, key):
+            if key.startswith("_"):
+                raise AttributeError(key)
+            val = self._data.get(key)
+            if val is None:
+                return _Missing()
+            if isinstance(val, dict):
+                return _StepAccessor(val)
+            return val
+
+    class _Missing:
+        def __bool__(self):
+            return False
+        def __eq__(self, other):
+            return False
+        def __ne__(self, other):
+            return True
+        def __lt__(self, other):
+            return False
+        def __gt__(self, other):
+            return False
+        def __le__(self, other):
+            return False
+        def __ge__(self, other):
+            return False
+        def __getattr__(self, key):
+            if key.startswith("_"):
+                raise AttributeError(key)
+            return _Missing()
 
     try:
-        return bool(eval(condition, {"__builtins__": {}},
-                         {"steps": _StepProxy(steps_ns)}))
+        code = compile(tree, "<condition>", "eval")
+        return bool(eval(code, {"__builtins__": {}},  # noqa: S307
+                         {"steps": _StepAccessor(steps_data)}))
     except Exception:
         return False
 
@@ -505,17 +556,15 @@ def _run_script_step(step, case_ws, step_results, case_data=None):
 
     env = {**os.environ, **_step_env(step_results)}
 
-    command = step.command
     if case_data and isinstance(case_data, dict):
-        try:
-            command = _resolve_arguments(command, case_data)
-        except (ValueError, KeyError):
-            pass
+        for key, value in case_data.items():
+            if isinstance(key, str) and value is not None:
+                env[f"CASE_{key.upper().replace('-', '_')}"] = str(value)
 
     start = time.monotonic()
     try:
         proc = _sp.run(
-            ["bash", "-c", command],
+            ["bash", "-c", step.command],
             cwd=str(case_ws),
             env=env,
             capture_output=True,

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -26,7 +26,9 @@ import os
 import shutil
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 from agent_eval.agent import RUNNERS
 from agent_eval.hooks import (
@@ -50,7 +52,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--workspace", required=True)
-    parser.add_argument("--skill", required=True)
+    parser.add_argument("--skill", default="")
     parser.add_argument("--skill-args", default=None,
                         help="Skill arguments (default: from eval.yaml execution.arguments)")
     parser.add_argument("--model", default=None,
@@ -146,7 +148,7 @@ def main():
     eval_params = _build_eval_params(args, config, skill_args, max_budget, timeout_s, effort)
 
     # ── Per-case execution ───────────────────────────────────────
-    if config.execution.mode == "case":
+    if config.is_workflow or config.execution.mode == "case":
         parallelism = (args.parallelism if args.parallelism is not None
                        else config.execution.parallelism)
         _execute_per_case(args, config, runner, runner_cls,
@@ -435,6 +437,472 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
     return case_id, case_result
 
 
+# ── Workflow execution ────────────────────────────────────────
+
+@dataclass
+class StepResult:
+    """Result of a single workflow step."""
+    step_id: str
+    step_type: str
+    exit_code: int
+    duration_s: float
+    cost_usd: Optional[float] = None
+    token_usage: Optional[dict] = None
+    num_turns: Optional[int] = None
+    timed_out: bool = False
+    stdout: str = ""
+    stderr: str = ""
+    retries: int = 0
+    skipped: bool = False
+
+
+def _step_env(step_results):
+    """Build env vars from accumulated step results."""
+    env = {}
+    for step_id, sr in step_results.items():
+        prefix = f"STEP_{step_id.upper().replace('-', '_')}"
+        env[f"{prefix}_EXIT_CODE"] = str(sr.exit_code)
+        env[f"{prefix}_DURATION_S"] = str(round(sr.duration_s, 1))
+        env[f"{prefix}_TIMED_OUT"] = "1" if sr.timed_out else "0"
+        if sr.cost_usd is not None:
+            env[f"{prefix}_COST_USD"] = str(round(sr.cost_usd, 4))
+        if sr.stderr:
+            env[f"{prefix}_STDERR"] = sr.stderr[:4096]
+    return env
+
+
+def _eval_step_condition(condition, step_results):
+    """Evaluate a step condition against accumulated results."""
+    class _StepProxy:
+        def __init__(self, data):
+            self._data = data
+        def __getattr__(self, key):
+            return self._data.get(key, _StepProxy({}))
+        def __bool__(self):
+            return bool(self._data)
+
+    steps_ns = {}
+    for step_id, sr in step_results.items():
+        steps_ns[step_id] = _StepProxy({
+            "exit_code": sr.exit_code,
+            "duration_s": sr.duration_s,
+            "cost_usd": sr.cost_usd,
+            "timed_out": sr.timed_out,
+            "skipped": sr.skipped,
+            "retries": sr.retries,
+        })
+
+    try:
+        return bool(eval(condition, {"__builtins__": {}},
+                         {"steps": _StepProxy(steps_ns)}))
+    except Exception:
+        return False
+
+
+def _run_script_step(step, case_ws, step_results, case_data=None):
+    """Run a script or validate step in the case workspace."""
+    import subprocess as _sp
+
+    env = {**os.environ, **_step_env(step_results)}
+
+    command = step.command
+    if case_data and isinstance(case_data, dict):
+        try:
+            command = _resolve_arguments(command, case_data)
+        except (ValueError, KeyError):
+            pass
+
+    start = time.monotonic()
+    try:
+        proc = _sp.run(
+            ["bash", "-c", command],
+            cwd=str(case_ws),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=step.timeout or 120,
+        )
+        return StepResult(
+            step_id=step.id,
+            step_type=step.type,
+            exit_code=proc.returncode,
+            duration_s=time.monotonic() - start,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+        )
+    except _sp.TimeoutExpired:
+        return StepResult(
+            step_id=step.id,
+            step_type=step.type,
+            exit_code=-1,
+            duration_s=time.monotonic() - start,
+            timed_out=True,
+            stderr=f"Script timed out after {step.timeout or 120}s",
+        )
+    except Exception as exc:
+        return StepResult(
+            step_id=step.id,
+            step_type=step.type,
+            exit_code=-1,
+            duration_s=time.monotonic() - start,
+            stderr=str(exc),
+        )
+
+
+def _resolve_step_args(template, step_results, case_data=None):
+    """Resolve argument templates that may reference step results."""
+    import re as _re
+
+    def _replace_step_ref(m):
+        ref = m.group(1)
+        if "." in ref:
+            parts = ref.split(".", 1)
+            step_id, field = parts[0], parts[1]
+            sr = step_results.get(step_id)
+            if sr:
+                return str(getattr(sr, field, ""))
+        return m.group(0)
+
+    result = _re.sub(r'\{([\w-]+\.[\w]+)\}', _replace_step_ref, template)
+
+    if case_data and isinstance(case_data, dict):
+        try:
+            result = _resolve_arguments(result, case_data)
+        except (ValueError, KeyError):
+            pass
+
+    return result
+
+
+def _run_workflow_case(runner, config, case_id, case_ws, output_dir,
+                       model, system_prompt, max_budget, timeout_s,
+                       mlflow_experiment=None, mlflow_tracking_uri=None,
+                       total_cases=1, index=1, hook_env=None,
+                       global_hook_outputs=None):
+    """Execute a multi-step workflow for a single case."""
+    import yaml as _yaml
+
+    if not case_ws.exists():
+        print(f"  [{index}/{total_cases}] {case_id}: SKIP (workspace missing)",
+              file=sys.stderr)
+        return case_id, None
+
+    input_path = case_ws / "input.yaml"
+    case_data = {}
+    if input_path.exists():
+        case_data = _yaml.safe_load(input_path.read_text()) or {}
+        if not isinstance(case_data, dict):
+            case_data = {}
+
+    if mlflow_experiment:
+        from agent_eval.mlflow.experiment import inject_tracing_env
+        inject_tracing_env(str(case_ws), project_root=Path.cwd(),
+                           tracking_uri=mlflow_tracking_uri,
+                           experiment_name=mlflow_experiment)
+
+    case_settings = case_ws / ".claude" / "settings.json"
+    settings_path = case_settings if case_settings.exists() else None
+
+    steps = config.workflow.steps
+    step_results = {}
+    total_retries = 0
+    has_skill_steps = any(s.type == "skill" for s in steps)
+
+    print(f"  [{index}/{total_cases}] {case_id}: workflow ({len(steps)} steps)",
+          file=sys.stderr)
+
+    # Per-case hooks
+    case_hook_env = None
+    merged_env = {}
+    if config and config.hooks and hook_env:
+        dataset_path = config.dataset.path
+        case_source_dir = (str(config.resolve_path(dataset_path) / case_id)
+                           if dataset_path else "")
+        case_hook_env = {
+            **hook_env,
+            "CASE_ID": case_id,
+            "CASE_WORKSPACE": str(case_ws.resolve()),
+            "CASE_SOURCE_DIR": case_source_dir,
+            "CASE_INPUT": str((case_ws / "input.yaml").resolve()),
+        }
+        log_dir = output_dir / "hooks"
+        if config.hooks.before_each:
+            run_hooks(config.hooks.before_each, env=case_hook_env,
+                      cwd=case_ws, log_dir=log_dir,
+                      phase_name="before_each", case_id=case_id)
+        case_outputs = collect_hook_outputs(case_ws)
+        global_env = (global_hook_outputs or {}).get("env", {})
+        case_env = case_outputs.get("env", {})
+        merged_env = {**global_env, **case_env}
+
+    try:
+        for step in steps:
+            # Evaluate condition
+            if step.condition:
+                if not _eval_step_condition(step.condition, step_results):
+                    step_results[step.id] = StepResult(
+                        step_id=step.id, step_type=step.type,
+                        exit_code=0, duration_s=0, skipped=True)
+                    print(f"    step '{step.id}': SKIPPED (condition false)",
+                          file=sys.stderr)
+                    continue
+
+            if step.type == "skill":
+                step_timeout = (step.timeout if step.timeout is not None
+                                else timeout_s)
+                step_budget = (step.max_budget_usd if step.max_budget_usd is not None
+                               else max_budget)
+                step_args = _resolve_step_args(
+                    step.arguments, step_results, case_data)
+
+                # All skill steps in a workflow skip cleanup so session can
+                # be continued; cleanup happens at the end.
+                is_last_skill = step is [
+                    s for s in steps if s.type == "skill"
+                ][-1] if has_skill_steps else True
+
+                print(f"    step '{step.id}': /{step.skill} {step_args}",
+                      file=sys.stderr)
+
+                try:
+                    result = runner.run_skill(
+                        skill_name=step.skill,
+                        args=step_args,
+                        workspace=case_ws,
+                        model=model,
+                        settings_path=settings_path,
+                        system_prompt=system_prompt,
+                        max_budget_usd=step_budget,
+                        timeout_s=step_timeout,
+                        extra_env=merged_env or None,
+                        continue_session=step.continue_session,
+                        skip_cleanup=not is_last_skill,
+                    )
+                    sr = StepResult(
+                        step_id=step.id,
+                        step_type="skill",
+                        exit_code=result.exit_code,
+                        duration_s=result.duration_s,
+                        cost_usd=result.cost_usd,
+                        token_usage=result.token_usage,
+                        num_turns=result.num_turns,
+                        timed_out=(result.exit_code == -1
+                                   and "Timed out" in (result.stderr or "")),
+                        stdout=result.stdout,
+                        stderr=result.stderr,
+                    )
+                except Exception as exc:
+                    sr = StepResult(
+                        step_id=step.id, step_type="skill",
+                        exit_code=-1, duration_s=0,
+                        stderr=str(exc))
+
+                step_results[step.id] = sr
+                status = ("TIMEOUT" if sr.timed_out
+                          else "OK" if sr.exit_code == 0
+                          else f"FAIL({sr.exit_code})")
+                print(f"      → {status} | {sr.duration_s:.0f}s | "
+                      f"${sr.cost_usd or 0:.2f}", file=sys.stderr)
+
+                if (sr.exit_code != 0 and not sr.timed_out
+                        and step.on_failure == "abort"):
+                    print(f"    workflow aborted at step '{step.id}'",
+                          file=sys.stderr)
+                    break
+
+            elif step.type == "script":
+                print(f"    step '{step.id}': script", file=sys.stderr)
+                sr = _run_script_step(step, case_ws, step_results, case_data)
+                step_results[step.id] = sr
+                status = "OK" if sr.exit_code == 0 else f"FAIL({sr.exit_code})"
+                print(f"      → {status} | {sr.duration_s:.1f}s",
+                      file=sys.stderr)
+
+                if sr.exit_code != 0 and step.on_failure == "abort":
+                    print(f"    workflow aborted at step '{step.id}'",
+                          file=sys.stderr)
+                    break
+
+            elif step.type == "validate":
+                print(f"    step '{step.id}': validate", file=sys.stderr)
+                sr = _run_script_step(step, case_ws, step_results, case_data)
+                step_results[step.id] = sr
+
+                if sr.exit_code != 0 and step.validate:
+                    retry_step_cfg = next(
+                        (s for s in steps if s.id == step.validate.retry_step),
+                        None)
+                    if retry_step_cfg:
+                        for attempt in range(1, step.validate.max_retries + 1):
+                            total_retries += 1
+                            retry_args = _resolve_step_args(
+                                step.validate.retry_prompt or retry_step_cfg.arguments,
+                                step_results, case_data)
+
+                            print(f"      retry {attempt}/{step.validate.max_retries}: "
+                                  f"re-invoking '{retry_step_cfg.id}'",
+                                  file=sys.stderr)
+
+                            retry_timeout = (retry_step_cfg.timeout
+                                             if retry_step_cfg.timeout is not None
+                                             else timeout_s)
+                            retry_budget = (retry_step_cfg.max_budget_usd
+                                            if retry_step_cfg.max_budget_usd is not None
+                                            else max_budget)
+                            try:
+                                retry_result = runner.run_skill(
+                                    skill_name=retry_step_cfg.skill,
+                                    args=retry_args,
+                                    workspace=case_ws,
+                                    model=model,
+                                    settings_path=settings_path,
+                                    system_prompt=system_prompt,
+                                    max_budget_usd=retry_budget,
+                                    timeout_s=retry_timeout,
+                                    extra_env=merged_env or None,
+                                    continue_session=True,
+                                    skip_cleanup=True,
+                                )
+                                step_results[retry_step_cfg.id] = StepResult(
+                                    step_id=retry_step_cfg.id,
+                                    step_type="skill",
+                                    exit_code=retry_result.exit_code,
+                                    duration_s=retry_result.duration_s,
+                                    cost_usd=retry_result.cost_usd,
+                                    token_usage=retry_result.token_usage,
+                                    num_turns=retry_result.num_turns,
+                                    stdout=retry_result.stdout,
+                                    stderr=retry_result.stderr,
+                                )
+                            except Exception as exc:
+                                print(f"      retry error: {exc}",
+                                      file=sys.stderr)
+
+                            # Re-run validation
+                            sr = _run_script_step(
+                                step, case_ws, step_results, case_data)
+                            step_results[step.id] = sr
+                            sr.retries = attempt
+
+                            if sr.exit_code == 0:
+                                print(f"      → validated after {attempt} "
+                                      f"retries", file=sys.stderr)
+                                break
+                        else:
+                            print(f"      → validation failed after "
+                                  f"{step.validate.max_retries} retries",
+                                  file=sys.stderr)
+                else:
+                    status = "OK" if sr.exit_code == 0 else f"FAIL({sr.exit_code})"
+                    print(f"      → {status}", file=sys.stderr)
+
+    finally:
+        # After_each hooks
+        if config and config.hooks and config.hooks.after_each and case_hook_env:
+            log_dir = output_dir / "hooks"
+            run_hooks_safe(config.hooks.after_each, env=case_hook_env,
+                           cwd=case_ws, log_dir=log_dir,
+                           phase_name="after_each", case_id=case_id)
+        # Final session cleanup
+        if has_skill_steps:
+            runner.cleanup_session(case_ws)
+
+    # Write workflow_result.json
+    case_output = output_dir / "cases" / case_id
+    case_output.mkdir(parents=True, exist_ok=True)
+
+    wf_steps = {}
+    for sid, sr in step_results.items():
+        entry = {
+            "exit_code": sr.exit_code,
+            "duration_s": round(sr.duration_s, 1),
+            "type": sr.step_type,
+            "skipped": sr.skipped,
+        }
+        if sr.timed_out:
+            entry["timed_out"] = True
+        if sr.cost_usd is not None:
+            entry["cost_usd"] = round(sr.cost_usd, 4)
+        if sr.num_turns is not None:
+            entry["num_turns"] = sr.num_turns
+        if sr.retries > 0:
+            entry["retries"] = sr.retries
+        wf_steps[sid] = entry
+
+    total_duration = sum(sr.duration_s for sr in step_results.values())
+    total_cost = sum(sr.cost_usd or 0 for sr in step_results.values())
+
+    workflow_result = {
+        "steps": wf_steps,
+        "total_retries": total_retries,
+        "total_duration_s": round(total_duration, 1),
+        "total_cost_usd": round(total_cost, 4),
+    }
+    with open(case_output / "workflow_result.json", "w") as f:
+        json.dump(workflow_result, f, indent=2)
+        f.write("\n")
+
+    # Also write run_result.json for compatibility with collect/score
+    agg_tokens = {}
+    for sr in step_results.values():
+        if sr.token_usage:
+            for k, v in sr.token_usage.items():
+                if isinstance(v, (int, float)):
+                    agg_tokens[k] = agg_tokens.get(k, 0) + v
+
+    worst_exit = max((sr.exit_code for sr in step_results.values()
+                      if not sr.skipped), default=0)
+
+    case_result = {
+        "exit_code": worst_exit,
+        "duration_s": round(total_duration, 1),
+        "token_usage": agg_tokens or None,
+        "cost_usd": round(total_cost, 4),
+        "num_turns": sum(sr.num_turns or 0 for sr in step_results.values()) or None,
+    }
+    with open(case_output / "run_result.json", "w") as f:
+        json.dump(case_result, f, indent=2)
+        f.write("\n")
+
+    # Save stdout/stderr from all skill steps
+    all_stdout = []
+    all_stderr = []
+    for sr in step_results.values():
+        if sr.stdout:
+            all_stdout.append(f"--- step: {sr.step_id} ---\n{sr.stdout}")
+        if sr.stderr:
+            all_stderr.append(f"--- step: {sr.step_id} ---\n{sr.stderr}")
+    if all_stdout:
+        (case_output / "stdout.log").write_text("\n".join(all_stdout))
+    if all_stderr:
+        (case_output / "stderr.log").write_text("\n".join(all_stderr))
+
+    # Copy input.yaml
+    if input_path.exists() and not input_path.is_symlink():
+        shutil.copy2(input_path, case_output / "input.yaml")
+
+    # Copy subagent transcripts
+    ws_subagents = case_ws / "subagents"
+    if ws_subagents.exists() and ws_subagents.is_dir():
+        out_subagents = case_output / "subagents"
+        out_subagents.mkdir(exist_ok=True)
+        for f in ws_subagents.iterdir():
+            if f.is_file() and not f.is_symlink() and f.suffix == ".jsonl":
+                shutil.copy2(f, out_subagents / f.name)
+
+    # Save hook outputs
+    merged_hook_data = {}
+    if global_hook_outputs:
+        merged_hook_data = global_hook_outputs.get("data", {})
+    save_hook_data(case_output, merged_hook_data)
+
+    status = "OK" if worst_exit == 0 else f"FAIL (exit {worst_exit})"
+    print(f"    → {case_id}: {status} | {total_duration:.0f}s | "
+          f"${total_cost:.2f} | retries={total_retries}", file=sys.stderr)
+
+    return case_id, case_result
+
+
 def _execute_per_case(args, config, runner, runner_cls,
                       output_dir, max_budget, timeout_s,
                       model, mlflow_experiment, system_prompt="",
@@ -457,8 +925,13 @@ def _execute_per_case(args, config, runner, runner_cls,
 
     effective_parallelism = min(parallelism, len(case_order)) if parallelism and parallelism > 1 else 1
     parallel_label = f", parallelism={effective_parallelism}" if effective_parallelism > 1 else ""
-    print(f"Executing: /{args.skill} (per-case, {len(case_order)} cases{parallel_label})",
-          file=sys.stderr)
+    if config.is_workflow:
+        step_count = len(config.workflow.steps)
+        print(f"Executing: workflow ({step_count} steps, {len(case_order)} cases{parallel_label})",
+              file=sys.stderr)
+    else:
+        print(f"Executing: /{args.skill} (per-case, {len(case_order)} cases{parallel_label})",
+              file=sys.stderr)
     print(f"Agent: {runner.name} | Model: {model}", file=sys.stderr)
 
     # Build hook environment
@@ -519,13 +992,23 @@ def _execute_per_case(args, config, runner, runner_cls,
             for i, entry in enumerate(case_order, 1):
                 case_id = entry["case_id"] if isinstance(entry, dict) else entry
                 case_ws = workspace / "cases" / case_id
-                case_id, result = _run_single_case(
-                    runner, args.skill, case_id, case_ws, output_dir,
-                    skill_args_template, model, mlflow_experiment,
-                    config.mlflow.tracking_uri, system_prompt,
-                    max_budget, timeout_s, len(case_order), i,
-                    config=config, hook_env=hook_env,
-                    global_hook_outputs=global_hook_outputs)
+                if config.is_workflow:
+                    case_id, result = _run_workflow_case(
+                        runner, config, case_id, case_ws, output_dir,
+                        model, system_prompt, max_budget, timeout_s,
+                        mlflow_experiment=mlflow_experiment,
+                        mlflow_tracking_uri=config.mlflow.tracking_uri,
+                        total_cases=len(case_order), index=i,
+                        hook_env=hook_env,
+                        global_hook_outputs=global_hook_outputs)
+                else:
+                    case_id, result = _run_single_case(
+                        runner, args.skill, case_id, case_ws, output_dir,
+                        skill_args_template, model, mlflow_experiment,
+                        config.mlflow.tracking_uri, system_prompt,
+                        max_budget, timeout_s, len(case_order), i,
+                        config=config, hook_env=hook_env,
+                        global_hook_outputs=global_hook_outputs)
                 if result is not None:
                     case_results[case_id] = result
     finally:

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -2377,7 +2377,7 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
                         html += (f'<p>Total retries: <strong>{total_retries}'
                                  f'</strong></p>\n')
                     html += '</details>\n'
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError, AttributeError, TypeError):
                 pass
 
         # Input data

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -2342,6 +2342,44 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
             html += (f'<div class="feedback-box"><strong>Human feedback:</strong> '
                      f'{_esc(str(case_feedback))}</div>\n')
 
+        # Workflow steps
+        wf_path = case_dir / "workflow_result.json"
+        if wf_path.exists():
+            try:
+                with open(wf_path) as _wf:
+                    wf = json.load(_wf)
+                wf_steps = wf.get("steps", {})
+                if wf_steps:
+                    html += '<details open><summary>Workflow Steps</summary>\n'
+                    html += ('<table><tr><th>Step</th><th>Type</th>'
+                             '<th>Duration</th><th>Cost</th>'
+                             '<th>Retries</th><th>Status</th></tr>\n')
+                    for sid, sdata in wf_steps.items():
+                        if sdata.get("skipped"):
+                            s_status = '<span class="skip">SKIP</span>'
+                        elif sdata.get("timed_out"):
+                            s_status = '<span class="fail">TIMEOUT</span>'
+                        elif sdata.get("exit_code", 0) == 0:
+                            s_status = '<span class="pass">OK</span>'
+                        else:
+                            s_status = f'<span class="fail">FAIL({sdata.get("exit_code")})</span>'
+                        s_dur = f'{sdata.get("duration_s", 0):.1f}s'
+                        s_cost = (f'${sdata["cost_usd"]:.2f}'
+                                  if sdata.get("cost_usd") else '-')
+                        s_retries = str(sdata.get("retries", 0))
+                        html += (f'<tr><td>{_esc(sid)}</td>'
+                                 f'<td>{_esc(sdata.get("type", ""))}</td>'
+                                 f'<td>{s_dur}</td><td>{s_cost}</td>'
+                                 f'<td>{s_retries}</td><td>{s_status}</td></tr>\n')
+                    html += '</table>\n'
+                    total_retries = wf.get("total_retries", 0)
+                    if total_retries:
+                        html += (f'<p>Total retries: <strong>{total_retries}'
+                                 f'</strong></p>\n')
+                    html += '</details>\n'
+            except (json.JSONDecodeError, OSError):
+                pass
+
         # Input data
         if dataset_path:
             input_text = _read_case_input(dataset_path, case_id)
@@ -2361,7 +2399,8 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
         # Execution logs at the case root — not skill output, exclude from
         # the report.  Only exclude root-level files, not nested ones with the
         # same name (a skill could legitimately produce artifacts/stdout.log).
-        _EXEC_LOG_PATHS = {"stdout.log", "stderr.log", "run_result.json", "input.yaml"}
+        _EXEC_LOG_PATHS = {"stdout.log", "stderr.log", "run_result.json",
+                          "workflow_result.json", "input.yaml"}
         if case_dir.exists():
             def _file_sort_key(f):
                 """Sort visual artifacts first: images, then diagrams, then the rest."""

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -570,7 +570,23 @@ def _render_jinja2_template(template_text, arguments, outputs):
         evidence_text = _extract_verifiable_evidence(out)
         out["evidence"] = evidence_text
 
-    workflow = out.get("workflow", {})
+    workflow_raw = out.get("workflow", {})
+    _safe_step_keys = {
+        "exit_code", "duration_s", "cost_usd", "timed_out",
+        "skipped", "retries", "type",
+    }
+    workflow = {}
+    if isinstance(workflow_raw, dict):
+        for k, v in workflow_raw.items():
+            if k == "steps" and isinstance(v, dict):
+                workflow["steps"] = {
+                    sid: {sk: sv for sk, sv in sdata.items()
+                          if sk in _safe_step_keys}
+                    for sid, sdata in v.items()
+                    if isinstance(sdata, dict)
+                }
+            elif k in ("total_retries", "total_duration_s", "total_cost_usd"):
+                workflow[k] = v
 
     return template.render(
         arguments=arguments or {},

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -439,6 +439,15 @@ def load_case_record(case_dir, config, run_id=None, runs_dir=None):
         except (yaml.YAMLError, OSError):
             record["hook_outputs"] = {}
 
+    # --- Workflow metadata (from workflow_result.json) ---
+    wf_path = case_dir / "workflow_result.json"
+    if wf_path.exists():
+        try:
+            with open(wf_path) as f:
+                record["workflow"] = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+
     return record
 
 
@@ -561,6 +570,8 @@ def _render_jinja2_template(template_text, arguments, outputs):
         evidence_text = _extract_verifiable_evidence(out)
         out["evidence"] = evidence_text
 
+    workflow = out.get("workflow", {})
+
     return template.render(
         arguments=arguments or {},
         outputs=out,
@@ -568,6 +579,7 @@ def _render_jinja2_template(template_text, arguments, outputs):
         conversation=conversation,
         inputs=inputs_text,
         evidence=evidence_text,
+        workflow=workflow,
     )
 
 

--- a/specs/009-multi-step-workflows/design.md
+++ b/specs/009-multi-step-workflows/design.md
@@ -1,0 +1,191 @@
+# 009: Multi-Step Workflow Evaluation
+
+**Status:** Implemented  
+**Date:** 2026-07-08
+
+## Problem
+
+The eval harness evaluates a single skill per case. Real-world agent deployments
+are multi-step pipelines where skill invocations are interleaved with
+deterministic scripts, conditional logic, and validation loops with retry
+(backpressure). This gap means critical failure modes — especially the
+"validate output, retry if invalid" loop — are untestable.
+
+### Motivating Example
+
+The OpenShift payload agent workflow (~635-line bash script) has these phases:
+
+1. Resolve a payload tag (deterministic API calls)
+2. Run `/ci:payload-analysis` with a 1hr timeout
+3. If timeout: re-invoke Claude with a "wrap up" nudge (session continuation)
+4. Validate structured outputs; re-invoke Claude up to 3x if invalid (backpressure)
+5. Generate Slack summary (separate skill)
+
+Step 4 is the highest-value evaluation target — it tests whether the agent can
+self-correct under structured feedback — and was completely untestable before
+this change.
+
+## Design
+
+### eval.yaml Schema
+
+`workflow:` is a new top-level key, mutually exclusive with `skill:`. It
+replaces the single-skill execution with a linear step sequence.
+
+```yaml
+name: payload-agent
+
+workflow:
+  steps:
+    - id: snapshot
+      type: script
+      command: python3 scripts/payload_snapshot.py {payload_tag}
+      timeout: 120
+
+    - id: analysis
+      type: skill
+      skill: ci:payload-analysis
+      arguments: "{payload_tag} --snapshot-dir snapshot"
+      timeout: 3600
+
+    - id: nudge
+      type: skill
+      skill: ci:payload-analysis
+      arguments: "Wrap up now and generate report artifacts."
+      continue_session: true
+      timeout: 600
+      condition: "steps.analysis.timed_out"
+
+    - id: validate
+      type: validate
+      command: python3 scripts/validate_output.py
+      retry_step: analysis
+      retry_prompt: |
+        Output invalid: {validate.stderr}
+        Regenerate the required files now.
+      max_retries: 3
+
+    - id: slack-summary
+      type: skill
+      skill: ci:slack-summary
+      arguments: "--input artifacts/payload-analysis.yaml"
+```
+
+### Step Types
+
+Three types — the minimal set that covers the observed patterns:
+
+| Type       | Behavior |
+|------------|----------|
+| `skill`    | Invokes a skill via the existing runner (`run_skill()`) |
+| `script`   | Runs a shell command via `subprocess` |
+| `validate` | Runs a shell command; on non-zero exit, re-invokes `retry_step` up to `max_retries` times |
+
+### Key Decisions and Rationale
+
+**1. Linear steps with conditions, not a DAG.**
+
+DAGs add complexity (cycle detection, join semantics, visualization) without
+covering additional real-world patterns. The `condition` field on any step
+provides skip-if-not-needed logic, which handles all observed branching patterns
+(timeout nudge, optional post-processing). If DAG workflows emerge later, this
+design extends naturally — add a `depends_on` field and topological sort.
+
+**2. `validate` is a distinct step type, not a generic retry wrapper.**
+
+The backpressure pattern (validate → retry skill → re-validate) is specific
+enough to warrant first-class support. Making it a step type keeps the eval.yaml
+declarative and avoids users needing to implement retry loops in custom scripts.
+The `retry_step` field must reference a `skill` step — you can only retry an
+agent, not a deterministic script.
+
+**3. Session continuation via `continue_session: true`.**
+
+The nudge and validation-retry patterns require continuing the same Claude
+conversation. This maps directly to `claude --continue`. Implementation required
+deferring session cleanup (`_cleanup_session()`) between workflow steps and only
+cleaning up at workflow end. The `skip_cleanup` parameter on `run_skill()` is
+the mechanism.
+
+**4. Inter-step data flow via shared workspace + env vars.**
+
+Steps share the case workspace filesystem. Each completed step also injects
+environment variables (`STEP_<ID>_EXIT_CODE`, `STEP_<ID>_DURATION_S`,
+`STEP_<ID>_TIMED_OUT`, etc.) into subsequent steps. Argument templates support
+`{step_id.field}` for referencing prior step results (e.g., `{validate.stderr}`
+in retry prompts).
+
+This avoids a separate data-passing mechanism — the filesystem is already the
+primary data channel between skills.
+
+**5. `on_failure: abort | continue`.**
+
+Steps default to `abort` (stop the workflow on failure). `continue` lets
+non-critical steps fail without blocking downstream steps. This is simpler than
+error-handler steps and covers the common patterns.
+
+### Workflow Result Artifacts
+
+Each case produces `workflow_result.json` alongside `run_result.json`:
+
+```json
+{
+  "steps": {
+    "snapshot": {"exit_code": 0, "duration_s": 12.3, "type": "script", "skipped": false},
+    "analysis": {"exit_code": 0, "duration_s": 845, "type": "skill", "cost_usd": 2.10},
+    "validate": {"exit_code": 0, "duration_s": 18.5, "type": "validate", "retries": 1}
+  },
+  "total_retries": 1,
+  "total_duration_s": 920.8,
+  "total_cost_usd": 2.40
+}
+```
+
+### Judging Workflow Metadata
+
+Judges can access workflow data:
+
+- **Inline checks:** `outputs.get("workflow", {})` — e.g., assert retry count
+- **LLM judges:** `{{ workflow }}` Jinja2 variable — e.g., "the workflow needed
+  {{ workflow.total_retries }} validation retries"
+- **Builtin/external judges:** receive the full outputs dict including `workflow`
+
+### Report Integration
+
+The HTML report's per-case detail view includes a workflow steps table showing
+step ID, type, duration, cost, retries, and status for each step, plus total
+retries across the workflow.
+
+## Changes
+
+| File | What changed |
+|------|-------------|
+| `agent_eval/config.py` | `WorkflowStepConfig`, `StepValidateConfig`, `WorkflowConfig` dataclasses; `workflow` field and `is_workflow` property on `EvalConfig`; parsing + validation in `from_yaml()` |
+| `agent_eval/agent/base.py` | `continue_session` and `skip_cleanup` params on `run_skill()` ABC; `cleanup_session()` method |
+| `agent_eval/agent/claude_code.py` | `--continue` flag support; deferred session cleanup |
+| `agent_eval/agent/cli_runner.py` | Signature update for ABC compatibility |
+| `agent_eval/agent/responses_api.py` | Signature update for ABC compatibility |
+| `skills/eval-run/scripts/execute.py` | `StepResult`, `_run_workflow_case()`, `_run_script_step()`, `_eval_step_condition()`, `_step_env()`, `_resolve_step_args()` |
+| `skills/eval-run/scripts/collect.py` | Exclude `workflow_result.json` from skill output collection |
+| `skills/eval-run/scripts/score.py` | Load `workflow_result.json` into case record; expose `{{ workflow }}` in Jinja2 |
+| `skills/eval-run/scripts/report.py` | Workflow steps table in per-case detail view |
+| `tests/test_workflow.py` | 30 unit tests covering config parsing, condition eval, script execution, argument resolution |
+
+## Backwards Compatibility
+
+- Existing `skill:` configs are unchanged — no `workflow:` key triggers the
+  existing single-skill path
+- `execution:`, `runner:`, `hooks:`, `judges:`, `outputs:` all compose with
+  `workflow:` naturally
+- `workflow_result.json` is additive — components that don't know about it
+  ignore it
+
+## Deferred
+
+- **Harbor/EvalHub execution:** The workflow step loop needs to run inside the
+  container/pod. Harbor can serialize `workflow:` config but executing steps
+  requires the loop from `execute.py`.
+- **DAG workflows:** Linear + conditionals covers all observed patterns. Add
+  `depends_on` later if needed.
+- **Per-step output isolation:** All steps share the workspace. Revisit if
+  collision becomes a problem.

--- a/specs/009-multi-step-workflows/design.md
+++ b/specs/009-multi-step-workflows/design.md
@@ -39,7 +39,7 @@ workflow:
   steps:
     - id: snapshot
       type: script
-      command: python3 scripts/payload_snapshot.py {payload_tag}
+      command: python3 scripts/payload_snapshot.py "$CASE_PAYLOAD_TAG"
       timeout: 120
 
     - id: analysis
@@ -65,7 +65,7 @@ workflow:
         Regenerate the required files now.
       max_retries: 3
 
-    - id: slack-summary
+    - id: slack_summary
       type: skill
       skill: ci:slack-summary
       arguments: "--input artifacts/payload-analysis.yaml"
@@ -88,8 +88,11 @@ Three types — the minimal set that covers the observed patterns:
 DAGs add complexity (cycle detection, join semantics, visualization) without
 covering additional real-world patterns. The `condition` field on any step
 provides skip-if-not-needed logic, which handles all observed branching patterns
-(timeout nudge, optional post-processing). If DAG workflows emerge later, this
-design extends naturally — add a `depends_on` field and topological sort.
+(timeout nudge, optional post-processing). Conditions are evaluated with an
+AST-whitelisted evaluator (not `eval()`) that only permits attribute access,
+boolean operators, comparisons, and constants — no function calls, imports, or
+arbitrary code. If DAG workflows emerge later, this design extends naturally —
+add a `depends_on` field and topological sort.
 
 **2. `validate` is a distinct step type, not a generic retry wrapper.**
 
@@ -109,11 +112,14 @@ the mechanism.
 
 **4. Inter-step data flow via shared workspace + env vars.**
 
-Steps share the case workspace filesystem. Each completed step also injects
+Steps share the case workspace filesystem. Each completed step injects
 environment variables (`STEP_<ID>_EXIT_CODE`, `STEP_<ID>_DURATION_S`,
-`STEP_<ID>_TIMED_OUT`, etc.) into subsequent steps. Argument templates support
-`{step_id.field}` for referencing prior step results (e.g., `{validate.stderr}`
-in retry prompts).
+`STEP_<ID>_TIMED_OUT`, etc.) into subsequent steps. Step IDs must match
+`[a-zA-Z0-9][a-zA-Z0-9_-]*` and are normalized (uppercased, hyphens → underscores)
+for env var names. Case data fields are passed to script steps via `CASE_<FIELD>`
+env vars (never interpolated into the shell command string) to prevent CWE-78.
+Skill step argument templates support `{step_id.field}` for referencing prior
+step results (e.g., `{validate.stderr}` in retry prompts).
 
 This avoids a separate data-passing mechanism — the filesystem is already the
 primary data channel between skills.
@@ -146,8 +152,9 @@ Each case produces `workflow_result.json` alongside `run_result.json`:
 Judges can access workflow data:
 
 - **Inline checks:** `outputs.get("workflow", {})` — e.g., assert retry count
-- **LLM judges:** `{{ workflow }}` Jinja2 variable — e.g., "the workflow needed
-  {{ workflow.total_retries }} validation retries"
+- **LLM judges:** `{{ workflow }}` Jinja2 variable — sanitized to metadata only
+  (status, timing, counters, retries); stdout/stderr are stripped to prevent
+  untrusted text or secrets from leaking into judge prompts
 - **Builtin/external judges:** receive the full outputs dict including `workflow`
 
 ### Report Integration
@@ -160,14 +167,14 @@ retries across the workflow.
 
 | File | What changed |
 |------|-------------|
-| `agent_eval/config.py` | `WorkflowStepConfig`, `StepValidateConfig`, `WorkflowConfig` dataclasses; `workflow` field and `is_workflow` property on `EvalConfig`; parsing + validation in `from_yaml()` |
+| `agent_eval/config.py` | `WorkflowStepConfig`, `StepValidateConfig`, `WorkflowConfig` dataclasses; `workflow` field and `is_workflow` property on `EvalConfig`; parsing + validation in `from_yaml()` including step ID format, `max_retries` type |
 | `agent_eval/agent/base.py` | `continue_session` and `skip_cleanup` params on `run_skill()` ABC; `cleanup_session()` method |
 | `agent_eval/agent/claude_code.py` | `--continue` flag support; deferred session cleanup |
 | `agent_eval/agent/cli_runner.py` | Signature update for ABC compatibility |
-| `agent_eval/agent/responses_api.py` | Signature update for ABC compatibility |
-| `skills/eval-run/scripts/execute.py` | `StepResult`, `_run_workflow_case()`, `_run_script_step()`, `_eval_step_condition()`, `_step_env()`, `_resolve_step_args()` |
+| `agent_eval/agent/responses_api.py` | Fails fast if `continue_session=True` (unsupported); honors `skip_cleanup` for container deletion |
+| `skills/eval-run/scripts/execute.py` | `StepResult`, `_run_workflow_case()`, `_run_script_step()` (case data via env vars, not shell interpolation), `_eval_step_condition()` (AST-whitelisted, no raw `eval()`), `_step_env()`, `_resolve_step_args()` |
 | `skills/eval-run/scripts/collect.py` | Exclude `workflow_result.json` from skill output collection |
-| `skills/eval-run/scripts/score.py` | Load `workflow_result.json` into case record; expose `{{ workflow }}` in Jinja2 |
+| `skills/eval-run/scripts/score.py` | Load `workflow_result.json` into case record; expose sanitized `{{ workflow }}` in Jinja2 (metadata only, no stdout/stderr) |
 | `skills/eval-run/scripts/report.py` | Workflow steps table in per-case detail view |
 | `tests/test_workflow.py` | 30 unit tests covering config parsing, condition eval, script execution, argument resolution |
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -230,6 +230,60 @@ workflow:
   steps: []
 """))
 
+    def test_invalid_step_id_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="must start with alphanumeric"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: bad-id
+workflow:
+  steps:
+    - id: "-bad"
+      type: script
+      command: echo
+"""))
+
+    def test_step_id_special_chars_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="must start with alphanumeric"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: bad-id
+workflow:
+  steps:
+    - id: "step;drop"
+      type: script
+      command: echo
+"""))
+
+    def test_max_retries_non_integer_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="max_retries must be a non-negative"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: bad-retries
+workflow:
+  steps:
+    - id: analyze
+      type: skill
+      skill: test
+    - id: check
+      type: validate
+      command: python validate.py
+      retry_step: analyze
+      max_retries: abc
+"""))
+
+    def test_max_retries_negative_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="max_retries must be a non-negative"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: bad-retries
+workflow:
+  steps:
+    - id: analyze
+      type: skill
+      skill: test
+    - id: check
+      type: validate
+      command: python validate.py
+      retry_step: analyze
+      max_retries: -1
+"""))
+
 
 # ── Execution helpers ───────────────────────────────────────
 
@@ -272,6 +326,33 @@ class TestStepConditionEval:
     def test_invalid_expression_returns_false(self):
         from execute import _eval_step_condition
         assert _eval_step_condition("invalid python !!!", {}) is False
+
+    def test_function_call_blocked(self):
+        from execute import _eval_step_condition
+        assert _eval_step_condition("__import__('os').system('id')", {}) is False
+
+    def test_lambda_blocked(self):
+        from execute import _eval_step_condition
+        assert _eval_step_condition("(lambda: True)()", {}) is False
+
+    def test_list_comprehension_blocked(self):
+        from execute import _eval_step_condition
+        assert _eval_step_condition("[x for x in range(10)]", {}) is False
+
+    def test_boolean_operators_allowed(self):
+        from execute import StepResult, _eval_step_condition
+        results = {
+            "a": StepResult(step_id="a", step_type="script",
+                            exit_code=0, duration_s=1, timed_out=False),
+            "b": StepResult(step_id="b", step_type="script",
+                            exit_code=1, duration_s=2, timed_out=True),
+        }
+        assert _eval_step_condition(
+            "steps.a.exit_code == 0 and steps.b.timed_out", results) is True
+        assert _eval_step_condition(
+            "steps.a.timed_out or steps.b.timed_out", results) is True
+        assert _eval_step_condition(
+            "not steps.a.timed_out", results) is True
 
 
 class TestStepEnv:
@@ -342,13 +423,13 @@ class TestRunScriptStep:
         assert result.exit_code == -1
         assert result.timed_out
 
-    def test_script_with_case_data_placeholders(self, tmp_path):
+    def test_script_with_case_data_env_vars(self, tmp_path):
         from execute import _run_script_step
         from agent_eval.config import WorkflowStepConfig
 
         step = WorkflowStepConfig(
             id="echo", type="script",
-            command="echo {payload_tag}")
+            command="echo $CASE_PAYLOAD_TAG")
         result = _run_script_step(
             step, tmp_path, {},
             case_data={"payload_tag": "4.18.0-0.nightly-test"})

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,407 @@
+"""Multi-step workflow config parsing and execution helpers."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.config import EvalConfig, WorkflowConfig, WorkflowStepConfig
+
+
+def _write(tmp_path, body, name="eval.yaml"):
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body)
+    return p
+
+
+# ── Config parsing ──────────────────────────────────────────
+
+
+class TestWorkflowConfigParsing:
+    def test_basic_workflow_parses(self, tmp_path):
+        cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: wf-test
+workflow:
+  steps:
+    - id: setup
+      type: script
+      command: echo hello
+    - id: analyze
+      type: skill
+      skill: test-skill
+      arguments: "--input foo"
+    - id: check
+      type: validate
+      command: python validate.py
+      retry_step: analyze
+      max_retries: 2
+      retry_prompt: "fix it: {check.stderr}"
+"""))
+        assert cfg.is_workflow
+        assert not cfg.skill
+        assert len(cfg.workflow.steps) == 3
+
+        s0 = cfg.workflow.steps[0]
+        assert s0.id == "setup"
+        assert s0.type == "script"
+        assert s0.command == "echo hello"
+
+        s1 = cfg.workflow.steps[1]
+        assert s1.id == "analyze"
+        assert s1.type == "skill"
+        assert s1.skill == "test-skill"
+        assert s1.arguments == "--input foo"
+
+        s2 = cfg.workflow.steps[2]
+        assert s2.id == "check"
+        assert s2.type == "validate"
+        assert s2.validate is not None
+        assert s2.validate.retry_step == "analyze"
+        assert s2.validate.max_retries == 2
+
+    def test_is_workflow_false_for_single_skill(self, tmp_path):
+        cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: single
+skill: test-skill
+"""))
+        assert not cfg.is_workflow
+        assert cfg.skill == "test-skill"
+
+    def test_mutual_exclusivity(self, tmp_path):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: bad
+skill: some-skill
+workflow:
+  steps:
+    - id: s
+      type: script
+      command: echo
+"""))
+
+    def test_duplicate_step_ids_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="duplicate"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: dup
+workflow:
+  steps:
+    - id: a
+      type: script
+      command: echo 1
+    - id: a
+      type: script
+      command: echo 2
+"""))
+
+    def test_retry_step_must_reference_skill(self, tmp_path):
+        with pytest.raises(ValueError, match="skill step"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: bad-retry
+workflow:
+  steps:
+    - id: setup
+      type: script
+      command: echo
+    - id: check
+      type: validate
+      command: python v.py
+      retry_step: setup
+"""))
+
+    def test_retry_step_must_exist(self, tmp_path):
+        with pytest.raises(ValueError, match="not found"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: missing
+workflow:
+  steps:
+    - id: check
+      type: validate
+      command: python v.py
+      retry_step: nonexistent
+"""))
+
+    def test_skill_step_requires_skill_field(self, tmp_path):
+        with pytest.raises(ValueError, match="require 'skill'"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: no-skill
+workflow:
+  steps:
+    - id: bad
+      type: skill
+      arguments: foo
+"""))
+
+    def test_script_step_requires_command(self, tmp_path):
+        with pytest.raises(ValueError, match="require 'command'"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: no-cmd
+workflow:
+  steps:
+    - id: bad
+      type: script
+"""))
+
+    def test_invalid_step_type_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="type must be"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: bad-type
+workflow:
+  steps:
+    - id: x
+      type: unknown
+      command: echo
+"""))
+
+    def test_on_failure_defaults_to_abort(self, tmp_path):
+        cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: defaults
+workflow:
+  steps:
+    - id: s
+      type: script
+      command: echo
+"""))
+        assert cfg.workflow.steps[0].on_failure == "abort"
+
+    def test_on_failure_continue(self, tmp_path):
+        cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: cont
+workflow:
+  steps:
+    - id: s
+      type: script
+      command: echo
+      on_failure: continue
+"""))
+        assert cfg.workflow.steps[0].on_failure == "continue"
+
+    def test_invalid_on_failure_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="on_failure"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: bad
+workflow:
+  steps:
+    - id: s
+      type: script
+      command: echo
+      on_failure: explode
+"""))
+
+    def test_continue_session_parsed(self, tmp_path):
+        cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: cont-sess
+workflow:
+  steps:
+    - id: main
+      type: skill
+      skill: test
+    - id: followup
+      type: skill
+      skill: test
+      continue_session: true
+"""))
+        assert not cfg.workflow.steps[0].continue_session
+        assert cfg.workflow.steps[1].continue_session
+
+    def test_step_condition_parsed(self, tmp_path):
+        cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: cond
+workflow:
+  steps:
+    - id: main
+      type: skill
+      skill: test
+    - id: nudge
+      type: skill
+      skill: test
+      condition: "steps.main.timed_out"
+"""))
+        assert cfg.workflow.steps[1].condition == "steps.main.timed_out"
+
+    def test_empty_steps_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="non-empty"):
+            EvalConfig.from_yaml(_write(tmp_path, """
+name: empty
+workflow:
+  steps: []
+"""))
+
+
+# ── Execution helpers ───────────────────────────────────────
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "eval-run" / "scripts"))
+
+
+class TestStepConditionEval:
+    def test_true_condition(self):
+        from execute import StepResult, _eval_step_condition
+        results = {
+            "main": StepResult(
+                step_id="main", step_type="skill",
+                exit_code=-1, duration_s=100, timed_out=True),
+        }
+        assert _eval_step_condition("steps.main.timed_out", results) is True
+
+    def test_false_condition(self):
+        from execute import StepResult, _eval_step_condition
+        results = {
+            "main": StepResult(
+                step_id="main", step_type="skill",
+                exit_code=0, duration_s=50, timed_out=False),
+        }
+        assert _eval_step_condition("steps.main.timed_out", results) is False
+
+    def test_exit_code_condition(self):
+        from execute import StepResult, _eval_step_condition
+        results = {
+            "setup": StepResult(
+                step_id="setup", step_type="script",
+                exit_code=1, duration_s=2),
+        }
+        assert _eval_step_condition("steps.setup.exit_code != 0", results) is True
+        assert _eval_step_condition("steps.setup.exit_code == 0", results) is False
+
+    def test_missing_step_returns_false(self):
+        from execute import _eval_step_condition
+        assert _eval_step_condition("steps.nonexistent.timed_out", {}) is False
+
+    def test_invalid_expression_returns_false(self):
+        from execute import _eval_step_condition
+        assert _eval_step_condition("invalid python !!!", {}) is False
+
+
+class TestStepEnv:
+    def test_builds_env_vars(self):
+        from execute import StepResult, _step_env
+        results = {
+            "my-step": StepResult(
+                step_id="my-step", step_type="skill",
+                exit_code=0, duration_s=42.5, cost_usd=1.23,
+                timed_out=False),
+        }
+        env = _step_env(results)
+        assert env["STEP_MY_STEP_EXIT_CODE"] == "0"
+        assert env["STEP_MY_STEP_DURATION_S"] == "42.5"
+        assert env["STEP_MY_STEP_TIMED_OUT"] == "0"
+        assert env["STEP_MY_STEP_COST_USD"] == "1.23"
+
+    def test_timed_out_flag(self):
+        from execute import StepResult, _step_env
+        results = {
+            "slow": StepResult(
+                step_id="slow", step_type="skill",
+                exit_code=-1, duration_s=3600, timed_out=True),
+        }
+        env = _step_env(results)
+        assert env["STEP_SLOW_TIMED_OUT"] == "1"
+
+    def test_stderr_truncated(self):
+        from execute import StepResult, _step_env
+        long_err = "x" * 5000
+        results = {
+            "err": StepResult(
+                step_id="err", step_type="script",
+                exit_code=1, duration_s=1, stderr=long_err),
+        }
+        env = _step_env(results)
+        assert len(env["STEP_ERR_STDERR"]) == 4096
+
+
+class TestRunScriptStep:
+    def test_successful_script(self, tmp_path):
+        from execute import _run_script_step
+        from agent_eval.config import WorkflowStepConfig
+
+        step = WorkflowStepConfig(
+            id="echo", type="script", command="echo hello")
+        result = _run_script_step(step, tmp_path, {})
+        assert result.exit_code == 0
+        assert "hello" in result.stdout
+
+    def test_failing_script(self, tmp_path):
+        from execute import _run_script_step
+        from agent_eval.config import WorkflowStepConfig
+
+        step = WorkflowStepConfig(
+            id="fail", type="script", command="exit 42")
+        result = _run_script_step(step, tmp_path, {})
+        assert result.exit_code == 42
+
+    def test_script_timeout(self, tmp_path):
+        from execute import _run_script_step
+        from agent_eval.config import WorkflowStepConfig
+
+        step = WorkflowStepConfig(
+            id="slow", type="script", command="sleep 60",
+            timeout=1)
+        result = _run_script_step(step, tmp_path, {})
+        assert result.exit_code == -1
+        assert result.timed_out
+
+    def test_script_with_case_data_placeholders(self, tmp_path):
+        from execute import _run_script_step
+        from agent_eval.config import WorkflowStepConfig
+
+        step = WorkflowStepConfig(
+            id="echo", type="script",
+            command="echo {payload_tag}")
+        result = _run_script_step(
+            step, tmp_path, {},
+            case_data={"payload_tag": "4.18.0-0.nightly-test"})
+        assert result.exit_code == 0
+        assert "4.18.0-0.nightly-test" in result.stdout
+
+
+class TestResolveStepArgs:
+    def test_step_result_reference(self):
+        from execute import StepResult, _resolve_step_args
+        results = {
+            "validate": StepResult(
+                step_id="validate", step_type="script",
+                exit_code=1, duration_s=2,
+                stderr="missing field: analysis"),
+        }
+        resolved = _resolve_step_args(
+            "Fix: {validate.stderr}", results)
+        assert "missing field: analysis" in resolved
+
+    def test_case_data_fallback(self):
+        from execute import _resolve_step_args
+        resolved = _resolve_step_args(
+            "{payload_tag} --snapshot", {},
+            case_data={"payload_tag": "4.18.0"})
+        assert resolved == "4.18.0 --snapshot"
+
+
+class TestWorkflowResultJson:
+    def test_workflow_result_loaded_in_case_record(self, tmp_path):
+        """Verify score.py loads workflow_result.json into the record."""
+        case_dir = tmp_path / "cases" / "case-001"
+        case_dir.mkdir(parents=True)
+
+        wf = {
+            "steps": {
+                "setup": {"exit_code": 0, "duration_s": 2, "type": "script",
+                          "skipped": False},
+                "analyze": {"exit_code": 0, "duration_s": 100, "type": "skill",
+                            "cost_usd": 1.5, "skipped": False},
+            },
+            "total_retries": 1,
+            "total_duration_s": 102,
+            "total_cost_usd": 1.5,
+        }
+        (case_dir / "workflow_result.json").write_text(json.dumps(wf))
+
+        from agent_eval.config import EvalConfig
+        config = EvalConfig(name="test", dataset=__import__(
+            "agent_eval.config", fromlist=["DatasetConfig"]).DatasetConfig())
+
+        from score import load_case_record
+        record = load_case_record(case_dir, config)
+        assert "workflow" in record
+        assert record["workflow"]["total_retries"] == 1
+        assert "analyze" in record["workflow"]["steps"]


### PR DESCRIPTION
## Summary

- Adds `workflow:` top-level key to eval.yaml for defining multi-step agent pipelines
- Three step types: `skill` (agent invocation), `script` (subprocess), `validate` (run command + retry skill on failure)
- Supports session continuation (`claude --continue`), conditional step execution, and configurable failure handling
- Enables testing the backpressure pattern (validate → retry → re-validate) that is critical in production but was previously untestable

Design doc: `specs/009-multi-step-workflows/design.md`

## Test plan

- [x] 30 new unit tests covering config parsing, condition evaluation, script execution, argument resolution, and score.py integration
- [x] All 489 existing tests pass (5 pre-existing failures in k8s tests from missing `kubernetes` module — unrelated)
- [ ] E2E test with a multi-step workflow against a real skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-step workflow evals with sequential steps, condition-based skipping, script/validate execution, and validate retry semantics with per-step outputs.
  * Reports and scoring now render workflow step details and totals when `workflow_result.json` is present.
  * Run execution can now continue a previous session and optionally skip session cleanup.

* **Bug Fixes**
  * Workflow artifacts (including `workflow_result.json`) are no longer shown in the generic output-files listing.
  * Cleanup behavior is now conditional based on the new session cleanup controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->