### PR TITLE
docs(eval-run): explain SIGPIPE risk when piping execute.py output

### DIFF
--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -164,7 +164,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
 
 Launch with `run_in_background: true` (no pipes). Monitor via `tail -20 <output_file>`. After completion, check `run_result.json` — if `exit_code` is non-zero, report the failure and stop. See `${CLAUDE_SKILL_DIR}/references/execution-monitoring.md` for CLI flag fallbacks, monitoring patterns, and problem detection.
 
-> **No pipes means no pipes.** Piping through `head`, `tail`, `grep`, or any filter closes stdout early, sending SIGPIPE to the Python process. Symptom: exit code -1, ~14s runtime, "Broken pipe" in stderr, no stdout.log. Always use `run_in_background: true` and Read the output file afterward.
+> **Do not pipe `execute.py`'s live output through commands that may terminate early.** For example, `head` can close stdout and cause SIGPIPE/Broken pipe failures. Use `run_in_background: true`, monitor the output file, and inspect `run_result.json` after completion.
 
 ## Step 5: Collect Artifacts
 

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -164,6 +164,8 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
 
 Launch with `run_in_background: true` (no pipes). Monitor via `tail -20 <output_file>`. After completion, check `run_result.json` — if `exit_code` is non-zero, report the failure and stop. See `${CLAUDE_SKILL_DIR}/references/execution-monitoring.md` for CLI flag fallbacks, monitoring patterns, and problem detection.
 
+> **No pipes means no pipes.** Piping through `head`, `tail`, `grep`, or any filter closes stdout early, sending SIGPIPE to the Python process. Symptom: exit code -1, ~14s runtime, "Broken pipe" in stderr, no stdout.log. Always use `run_in_background: true` and Read the output file afterward.
+
 ## Step 5: Collect Artifacts
 
 Distribute workspace outputs into per-case directories so judges can score each case independently:


### PR DESCRIPTION
## Summary

- Add inline gotcha explaining why piping execute.py output through `head`/`tail`/`grep` kills the subprocess via SIGPIPE
- Documents the symptom (exit code -1, ~14s runtime, "Broken pipe" in stderr, no stdout.log) and the fix
- Placed directly after the existing "no pipes" instruction so it's impossible to miss

Hit this in production: piping through `| head -5` closed stdout early, sending SIGPIPE to the Python process after 14 seconds.

## Test plan

- [x] Verified the instruction reads clearly in context of Step 4
- [x] No code changes, documentation only

Assisted-By: 🤖 Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a warning that piping live run output through commands like `head` can close stdout early, leading to SIGPIPE/Broken pipe failures.
  * Updated recommended monitoring for background runs (`run_in_background: true`) to avoid pipes and instead review the generated output file and `run_result.json` after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->