### PR TITLE
feat: pass GCP_SA_ACCESS_TOKEN to AnthropicVertex when available

### DIFF
--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -1439,7 +1439,12 @@ def _get_anthropic_client():
     region = os.environ.get("CLOUD_ML_REGION", "us-east5")
     if project_id:
         from anthropic import AnthropicVertex
-        return AnthropicVertex(project_id=project_id, region=region)
+        access_token = os.environ.get("GCP_SA_ACCESS_TOKEN")
+        return AnthropicVertex(
+            project_id=project_id,
+            region=region,
+            access_token=access_token or None,
+        )
     api_key = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_AUTH_TOKEN")
     if api_key:
         from anthropic import Anthropic

--- a/tests/test_get_anthropic_client.py
+++ b/tests/test_get_anthropic_client.py
@@ -1,0 +1,54 @@
+"""Tests for _get_anthropic_client() in score.py."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from score import _get_anthropic_client
+
+
+class TestGetAnthropicClient:
+
+    # Vertex AI path: GCP_SA_ACCESS_TOKEN should be forwarded to AnthropicVertex
+    @patch.dict(os.environ, {
+        "ANTHROPIC_VERTEX_PROJECT_ID": "my-project",
+        "GCP_SA_ACCESS_TOKEN": "test-token",
+    }, clear=True)
+    def test_vertex_with_access_token(self):
+        from anthropic import AnthropicVertex
+        client = _get_anthropic_client()
+        assert isinstance(client, AnthropicVertex)
+        assert client.project_id == "my-project"
+        assert client.region == "us-east5"
+        assert client.access_token == "test-token"
+
+    # Vertex AI path without token: access_token should be None (falls back to google-auth)
+    @patch.dict(os.environ, {
+        "ANTHROPIC_VERTEX_PROJECT_ID": "my-project",
+    }, clear=True)
+    def test_vertex_without_access_token(self):
+        from anthropic import AnthropicVertex
+        client = _get_anthropic_client()
+        assert isinstance(client, AnthropicVertex)
+        assert client.access_token is None
+
+    # Direct API path: ANTHROPIC_API_KEY should produce a standard Anthropic client
+    @patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}, clear=True)
+    def test_api_key(self):
+        from anthropic import Anthropic
+        client = _get_anthropic_client()
+        assert isinstance(client, Anthropic)
+
+    # Direct API path: ANTHROPIC_AUTH_TOKEN should work as a fallback for API key
+    @patch.dict(os.environ, {"ANTHROPIC_AUTH_TOKEN": "sk-auth"}, clear=True)
+    def test_auth_token_fallback(self):
+        from anthropic import Anthropic
+        client = _get_anthropic_client()
+        assert isinstance(client, Anthropic)
+
+    # No credentials set: should raise RuntimeError with guidance
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_credentials_raises(self):
+        with pytest.raises(RuntimeError, match="Set ANTHROPIC_VERTEX_PROJECT_ID"):
+            _get_anthropic_client()


### PR DESCRIPTION
Inside an OpenShell sandbox, the network policy restricts which binaries can reach external endpoints. Only binaries listed in the policy (e.g. claude, python3) can route through the gateway. Additionally, google-auth discovery fails because the GCP service account key file is not available inside the sandbox — the OpenShell provider injects a rotated access token (GCP_SA_ACCESS_TOKEN) instead.

Without this change, score.py must be run through Claude Code (claude -p) as a command executor just to get network access, which adds cost and indirection. With it, python3 can be added to the sandbox policy binary list and score.py calls Vertex AI directly.

When GCP_SA_ACCESS_TOKEN is set, pass it to AnthropicVertex as access_token. When absent, fall back to google-auth discovery (the existing behavior for non-sandbox environments).

## How Has This Been Tested?
I am currently patching this solution into my use of agent-eval-harness

A standalone test would look like:

```
import os
from anthropic import AnthropicVertex

access_token = os.environ.get('GCP_SA_ACCESS_TOKEN')
client = AnthropicVertex(
    project_id='test-project',
    region='us-east5',
    access_token=access_token or None,
)
assert client.access_token == 'fake-token', f"Expected 'fake-token', got {client.access_token!r}"
print('PASS: AnthropicVertex accepts access_token from env var')
```

Run with:
```
pip install anthropic
GCP_SA_ACCESS_TOKEN=fake-token python3 test_vertex_token.py
```

Unit tests added as part of this PR.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication when connecting to the Anthropic service on Google Cloud.
  * Supports optional access tokens supplied through the environment, while preserving existing behavior when no token is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->