### PR TITLE
fix: prevent background task death in headless and interactive modes

### DIFF
--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -162,7 +162,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
   [--parallelism <n>]
 ```
 
-Launch with `run_in_background: true` (no pipes). **You must poll until the task completes** — do not end your turn while execute.py is running. In `-p` mode, ending the turn kills the session and all background tasks. After completion, check `run_result.json` — if `exit_code` is non-zero, report the failure and stop. See `${CLAUDE_SKILL_DIR}/references/execution-monitoring.md` for polling patterns, problem detection, and CLI flag fallbacks.
+Launch with `run_in_background: true` (no pipes). **You must poll until the task completes** — do not end your turn while execute.py is running. Background tasks are killed when the session becomes idle: in `-p` mode, an `end_turn` exits the session immediately; in interactive mode, Claude Code SIGTERMs background tasks after ~55 minutes of inactivity. Poll progress every 2–3 minutes with `tail -20 <output_file>` to keep the session active. After completion, check `run_result.json` — if `exit_code` is non-zero, report the failure and stop. See `${CLAUDE_SKILL_DIR}/references/execution-monitoring.md` for polling patterns, problem detection, and CLI flag fallbacks.
 
 ## Step 5: Collect Artifacts
 

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -162,7 +162,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
   [--parallelism <n>]
 ```
 
-Launch with `run_in_background: true` (no pipes). Monitor via `tail -20 <output_file>`. After completion, check `run_result.json` — if `exit_code` is non-zero, report the failure and stop. See `${CLAUDE_SKILL_DIR}/references/execution-monitoring.md` for CLI flag fallbacks, monitoring patterns, and problem detection.
+Launch with `run_in_background: true` (no pipes). **You must poll until the task completes** — do not end your turn while execute.py is running. In `-p` mode, ending the turn kills the session and all background tasks. After completion, check `run_result.json` — if `exit_code` is non-zero, report the failure and stop. See `${CLAUDE_SKILL_DIR}/references/execution-monitoring.md` for polling patterns, problem detection, and CLI flag fallbacks.
 
 ## Step 5: Collect Artifacts
 

--- a/skills/eval-run/references/execution-monitoring.md
+++ b/skills/eval-run/references/execution-monitoring.md
@@ -7,6 +7,12 @@ pipe the command** through `tail`, `head`, `grep`, or any other filter — pipin
 buffers all output and prevents progress monitoring. The command must be the bare
 `python3 ... execute.py ...` invocation with no pipes.
 
+## Session lifecycle warning
+
+**Do not end your turn while execute.py is running.** In `-p` mode, ending the
+turn terminates the session and kills all background tasks — producing empty
+results that CI reports as green. You must keep polling until execution completes.
+
 ## Monitoring progress
 
 Once launched, the Bash tool returns an output file path. Monitor by reading it:

--- a/skills/eval-run/references/execution-monitoring.md
+++ b/skills/eval-run/references/execution-monitoring.md
@@ -9,9 +9,19 @@ buffers all output and prevents progress monitoring. The command must be the bar
 
 ## Session lifecycle warning
 
-**Do not end your turn while execute.py is running.** In `-p` mode, ending the
-turn terminates the session and kills all background tasks — producing empty
-results that CI reports as green. You must keep polling until execution completes.
+**Do not end your turn while execute.py is running.** Background tasks are killed
+when the session becomes idle — this applies to both headless and interactive
+modes:
+
+- **Headless (`-p`):** ending the turn exits the session immediately, killing all
+  background tasks and producing empty results that CI reports as green.
+- **Interactive:** Claude Code SIGTERMs background tasks after ~55 minutes of
+  session inactivity. A long-running execute.py (common with 20+ cases) will be
+  killed silently if no tool calls keep the session active.
+
+You must keep polling until execution completes. Poll every 2–3 minutes with
+`tail -20 <output_file>` — this keeps the session active and prevents the idle
+timeout from firing.
 
 ## Monitoring progress
 


### PR DESCRIPTION
## Summary

- Always background `execute.py` (preserves parallelism), but require mandatory polling until completion
- Cover both headless (`-p`) and interactive idle-SIGTERM failure modes
- Validate `run_result.json` before collection/scoring (fail closed)

## Problem

The eval-run skill launches `execute.py` with `run_in_background: true`. Background tasks can be killed in two ways:

1. **Headless (`-p`):** if the model ends its turn, the session exits and kills all background tasks. Whether the model polls or not is nondeterministic.
2. **Interactive:** Claude Code SIGTERMs background tasks after ~55 minutes of session inactivity. A long-running execute.py (common with 20+ eval cases) is killed silently if no tool calls keep the session active.

Both produce false-green results with empty artifacts.

### Headless failure (observed on [openshift-eng/ai-helpers#627](https://github.com/openshift-eng/ai-helpers/pull/627))

Two runs with identical harness code (cloned from `main`):

**Failing run (Jul 17, 168s):** model backgrounded execute.py, checked progress once, then hit `end_turn`. Session exited, background task killed, CI reported green with empty artifacts.

```
Line 430: "I'll continue with collection, scoring, and reporting once execution completes."
Line 431: {"type":"result","subtype":"success","stop_reason":"end_turn","terminal_reason":"completed",...}
Line 433: {"type":"system","subtype":"task_updated","task_id":"brkjy2a5p","patch":{"status":"killed",...}}
```

**Passing run (Jul 23, 4880s):** model backgrounded execute.py, then happened to issue blocking `sleep && tail` calls in a loop, keeping the session alive by accident.

### Interactive failure

Observed during eval runs with 20+ cases taking >1 hour. The session appeared idle (no tool calls while waiting for the background task), triggering Claude Code's ~55-minute idle timeout which SIGTERMs the background process.

## Fix

- Make polling instructions explicit in both SKILL.md and execution-monitoring.md
- Cover both failure modes (headless end_turn + interactive idle-SIGTERM)
- Specify polling cadence (every 2-3 minutes) to keep the session active
- Validate `run_result.json` exists, parses, and has `exit_code == 0` before proceeding

## Companion fix

[openshift/release#82091](https://github.com/openshift/release/pull/82091) adds a safety net in the CI step script.