### PR TITLE
feat(mlflow): richer Harbor traces with user turns, thinking, and tool detail

### DIFF
--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -66,6 +66,7 @@ def _user_text_from_content(content):
 _MAX_TOOL_OUTPUT = 4000  # chars per tool result (stream or ATIF-enriched)
 _MAX_WRITE_CONTENT = 4000
 _MAX_EDIT_FRAGMENT = 2000
+_MAX_THINKING = 4000
 
 
 def _load_trajectory_json(trajectory_path):
@@ -210,8 +211,9 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
     traj_user_turns = _load_trajectory_user_steps(trajectory_path)
     if traj_user_turns:
         # Trajectory is the richer Harbor source of truth for user turns.
-        if not prompt:
-            prompt = "\n\n".join(t["message"] for t in traj_user_turns)
+        # Always derive prompt from it here too, so the root span's prompt
+        # attribute and the "user:" CHAIN spans agree on the same source.
+        prompt = "\n\n".join(t["message"] for t in traj_user_turns)
         user_turns_for_spans = traj_user_turns
     else:
         user_turns_for_spans = stream_user_turns
@@ -748,7 +750,7 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
         if llm_text:
             step_outputs["text"] = llm_text
         if thinkings:
-            step_outputs["thinking"] = thinkings[0][0]
+            step_outputs["thinking"] = thinkings[0][0][:_MAX_THINKING]
         step_span = make_span(
             trace_id, root_span_id,
             name=step_name,
@@ -774,7 +776,7 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
                 start_ns=t_start,
                 end_ns=t_end,
                 inputs={"model": model, "kind": "thinking"},
-                outputs={"thinking": think_text},
+                outputs={"thinking": think_text[:_MAX_THINKING]},
                 extra_attrs=({"mlflow.llm.model": json.dumps(model)}
                              if model else None),
             ))

--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -48,21 +48,71 @@ def make_span(trace_id, parent_id, name, span_type, start_ns, end_ns,
     }
 
 
+def _user_text_from_content(content):
+    """Extract plain user text from a stream-json message content field."""
+    if isinstance(content, str) and content.strip():
+        return content.strip()
+    if isinstance(content, list):
+        parts = []
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text":
+                text = (b.get("text") or "").strip()
+                if text:
+                    parts.append(text)
+        if parts:
+            return "\n\n".join(parts)
+    return ""
+
+
+def _load_trajectory_user_steps(trajectory_path):
+    """Load user steps from a Harbor ATIF trajectory.json (if present).
+
+    Returns a list of ``{"message": str, "timestamp": str|None}``.
+    """
+    if trajectory_path is None:
+        return []
+    path = Path(trajectory_path)
+    if not path.is_file():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    steps = data.get("steps") or []
+    out = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if step.get("source") != "user":
+            continue
+        msg = step.get("message")
+        if not isinstance(msg, str) or not msg.strip():
+            continue
+        out.append({
+            "message": msg.strip(),
+            "timestamp": step.get("timestamp"),
+        })
+    return out
+
+
 def build_trace(stdout_path, run_result, run_id, experiment_id,
                 trace_name="", subagent_dir=None,
-                subagent_model=None):
+                subagent_model=None, trajectory_path=None):
     """Build a hierarchical MLflow Trace from the stream-json stdout log.
 
     Structure:
       root AGENT
-        ├── LLM (text response)
-        ├── TOOL (single sequential tool call)
-        ├── TASK "N parallel agents" (group of parallel calls)
-        │   ├── AGENT (subagent 1)
-        │   ├── AGENT (subagent 2)
-        │   └── ...
-        ├── LLM (text response)
+        ├── CHAIN user (skill invoke / instructions; from trajectory or stream)
+        ├── AGENT step
+        │   ├── LLM thinking
+        │   ├── TOOL ...
+        │   └── LLM response
         └── ...
+
+    Harbor runs often omit user text from stream-json; pass ``trajectory_path``
+    (ATIF ``trajectory.json``) to restore user turns and the root prompt.
 
     Returns a dict suitable for Trace.from_dict(), or None.
     """
@@ -86,29 +136,36 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
     session_id = None
     prompt = ""
     final_response = ""
+    stream_user_turns = []
 
     for e in events:
         if not session_id:
             session_id = e.get("session_id")
 
     # Prompt: prefer first user text message (the skill invocation).
-    # Fall back to first assistant text if no user text is found
-    # (older runs without the synthetic prompt event).
+    # Harbor stream-json often has only tool_result user events — then fall
+    # back to trajectory.json user steps, then first assistant text.
     for e in events:
-        if e.get("type") == "user":
-            content = e.get("message", {}).get("content", "")
-            if isinstance(content, str) and content.strip():
-                prompt = content.strip()
-                break
-            elif isinstance(content, list):
-                for b in content:
-                    if isinstance(b, dict) and b.get("type") == "text":
-                        text = b.get("text", "").strip()
-                        if text:
-                            prompt = text
-                            break
-                if prompt:
-                    break
+        if e.get("type") != "user":
+            continue
+        text = _user_text_from_content(e.get("message", {}).get("content", ""))
+        if text:
+            stream_user_turns.append({
+                "message": text,
+                "timestamp": e.get("timestamp"),
+            })
+            if not prompt:
+                prompt = text
+
+    traj_user_turns = _load_trajectory_user_steps(trajectory_path)
+    if traj_user_turns:
+        # Trajectory is the richer Harbor source of truth for user turns.
+        if not prompt:
+            prompt = "\n\n".join(t["message"] for t in traj_user_turns)
+        user_turns_for_spans = traj_user_turns
+    else:
+        user_turns_for_spans = stream_user_turns
+
     if not prompt:
         for e in events:
             if e.get("type") == "assistant":
@@ -395,7 +452,11 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
             for b in content:
                 if not isinstance(b, dict):
                     continue
-                if b.get("type") == "text" and b.get("text", "").strip():
+                if b.get("type") == "thinking" and (b.get("thinking") or "").strip():
+                    _flush_batch()
+                    segments.append(("thinking", b["thinking"].strip(),
+                                     e.get("timestamp"), None))
+                elif b.get("type") == "text" and b.get("text", "").strip():
                     _flush_batch()
                     context = "; ".join(_recent_tools) if _recent_tools else ""
                     segments.append(("llm", b["text"].strip(),
@@ -477,8 +538,27 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
         "attributes": root_attrs,
     }]
 
+    # User turns as CHAIN spans under root (visible in the MLflow graph).
+    user_cursor = trace_start
+    for idx, turn in enumerate(user_turns_for_spans):
+        ts = turn.get("timestamp")
+        start_ns = iso_to_ns(ts) if ts else user_cursor
+        end_ns = start_ns + int(0.1e9)
+        user_cursor = end_ns
+        msg = turn["message"]
+        first_line = msg.split("\n")[0].strip()[:80] or f"user-{idx + 1}"
+        spans.append(make_span(
+            trace_id, root_span_id,
+            name=f"user: {first_line}",
+            span_type="CHAIN",
+            start_ns=start_ns,
+            end_ns=end_ns,
+            inputs={"role": "user", "turn": idx + 1},
+            outputs={"message": msg},
+        ))
+
     # ── Group segments into agent steps ───────────────────────────
-    # Each step = one LLM reasoning output + the tool actions it triggered.
+    # Each step = optional thinking + one LLM text output + tool actions.
     # Steps are direct children of root; tools are nested inside steps.
     #
     # Segments before the first LLM text (e.g. initial tool calls from
@@ -498,11 +578,14 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
         re.IGNORECASE,
     )
 
-    steps = []  # list of (llm_text, llm_ts, llm_context, [batch_segments])
+    # list of (llm_text, llm_ts, llm_context, [batch_segments], [thinkings])
+    # thinkings: list of (text, timestamp)
+    steps = []
     current_llm = None
     current_ts = None
     current_context = []
     current_batches = []
+    current_thinkings = []
     # Track whether the current step launched background agents
     _has_bg_agents = False
 
@@ -511,17 +594,25 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
         first_line = text.split("\n")[0].strip()
         return bool(_STATUS_RE.match(first_line) or _WAITING_RE.search(first_line))
 
+    def _flush_step():
+        nonlocal current_llm, current_ts, current_context, current_batches
+        nonlocal current_thinkings, _has_bg_agents
+        if current_llm is not None or current_batches or current_thinkings:
+            steps.append((current_llm, current_ts, current_context,
+                          current_batches, current_thinkings))
+            current_batches = []
+            current_thinkings = []
+            _has_bg_agents = False
+
     for seg_type, seg_data, *rest in segments:
-        if seg_type == "llm":
+        if seg_type == "thinking":
+            current_thinkings.append((seg_data, rest[0] if rest else None))
+        elif seg_type == "llm":
             if _has_bg_agents and _is_status_update(seg_data):
                 # Merge status update into the current dispatch step
                 continue
             # Save previous step
-            if current_llm is not None or current_batches:
-                steps.append((current_llm, current_ts, current_context,
-                              current_batches))
-                current_batches = []
-                _has_bg_agents = False
+            _flush_step()
             current_llm = seg_data
             current_ts = rest[0] if rest else None
             current_context = rest[1] if len(rest) > 1 else []
@@ -531,16 +622,19 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
             if any(name == "Agent" for _, _, name, _ in seg_data):
                 _has_bg_agents = True
     # Flush final step
-    if current_llm is not None or current_batches:
-        steps.append((current_llm, current_ts, current_context,
-                      current_batches))
+    _flush_step()
 
     # ── Build spans from steps ──────────────────────────────────
     cursor_ns = trace_start
 
-    for step_idx, (llm_text, llm_ts, llm_context, batches) in enumerate(steps):
+    for step_idx, (llm_text, llm_ts, llm_context, batches, thinkings) in enumerate(steps):
         # Compute step timing from its children
-        step_start = iso_to_ns(llm_ts) if llm_ts else cursor_ns
+        if llm_ts:
+            step_start = iso_to_ns(llm_ts)
+        elif thinkings and thinkings[0][1]:
+            step_start = iso_to_ns(thinkings[0][1])
+        else:
+            step_start = cursor_ns
         step_end = step_start
 
         # Pre-compute batch timing to find step_end
@@ -567,11 +661,20 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
         if step_end <= step_start:
             step_end = step_start + int(1e9)
 
-        # Step label from first line of LLM text
+        # Include thinking timestamps in step window
+        for think_text, think_ts in thinkings:
+            if think_ts:
+                t_ns = iso_to_ns(think_ts)
+                step_start = min(step_start, t_ns) if step_start else t_ns
+                step_end = max(step_end, t_ns + int(0.5e9))
+
+        # Step label from first line of LLM text (or thinking / Setup)
         if llm_text:
             first_line = llm_text.split("\n")[0].strip()
             # Strip markdown headers
             step_name = first_line.lstrip("#").strip()[:80]
+        elif thinkings:
+            step_name = thinkings[0][0].split("\n")[0].strip()[:80] or "thinking"
         else:
             step_name = "Setup"
 
@@ -585,6 +688,24 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
         )
         step_span_id = step_span["span_id"]
         spans.append(step_span)
+
+        # Thinking spans (extended thinking / reasoning_content)
+        think_cursor = step_start
+        for think_text, think_ts in thinkings:
+            t_start = iso_to_ns(think_ts) if think_ts else think_cursor
+            t_end = t_start + int(0.5e9)
+            think_cursor = t_end
+            spans.append(make_span(
+                trace_id, step_span_id,
+                name="thinking",
+                span_type="LLM",
+                start_ns=t_start,
+                end_ns=t_end,
+                inputs={"model": model, "kind": "thinking"},
+                outputs={"thinking": think_text},
+                extra_attrs=({"mlflow.llm.model": json.dumps(model)}
+                             if model else None),
+            ))
 
         # LLM span inside the step
         if llm_text:

--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -5,7 +5,6 @@ and the standalone claude-trace wrapper.
 """
 
 import json
-import os
 import re
 import sys
 import uuid
@@ -1090,7 +1089,6 @@ def log_trace(trace_dict):
     becomes available, this should be updated.
     """
     try:
-        import mlflow
         from mlflow import MlflowClient
         from mlflow.entities.trace import Trace
 

--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -20,6 +20,17 @@ def iso_to_ns(ts_str):
     return int(_dt_parse(ts_str).timestamp() * 1e9)
 
 
+def _clamp_ns(ns, lo, hi):
+    """Clamp a timestamp into [lo, hi].
+
+    Trajectory.json timestamps come from a different clock/source than the
+    stream-json events that define the trace window; without clamping, a
+    clock offset can push a child span (CHAIN/thinking) before the trace
+    start or after the trace end, rendering outside its own parent span.
+    """
+    return max(lo, min(ns, hi))
+
+
 def make_span(trace_id, parent_id, name, span_type, start_ns, end_ns,
                inputs=None, outputs=None, extra_attrs=None):
     """Create a span dict for the trace."""
@@ -146,6 +157,24 @@ def _load_trajectory_tool_data(trajectory_path):
             # with Write file body) over the short stream-json success line.
             tool_results[tuid] = content.strip()[:_MAX_TOOL_OUTPUT]
     return tool_args, tool_results
+
+
+def _load_trajectory_reasoning(trajectory_path):
+    """Ordered list of non-empty ``reasoning_content`` from ATIF agent steps.
+
+    Returns ``[(text, timestamp|None), ...]`` in trajectory step order.
+    """
+    data = _load_trajectory_json(trajectory_path)
+    if not data:
+        return []
+    out = []
+    for step in data.get("steps") or []:
+        if not isinstance(step, dict) or step.get("source") != "agent":
+            continue
+        reasoning = step.get("reasoning_content")
+        if isinstance(reasoning, str) and reasoning.strip():
+            out.append((reasoning.strip(), step.get("timestamp")))
+    return out
 
 
 def build_trace(stdout_path, run_result, run_id, experiment_id,
@@ -537,6 +566,27 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
                     ))
     _flush_batch()
 
+    # Backfill thinking from ATIF reasoning_content when the stream has none
+    # at all (e.g. Harbor runs where extended thinking wasn't captured in
+    # stream-json). Only applies when the stream is fully silent on thinking,
+    # so it never second-guesses/conflicts with real per-turn stream data.
+    if not any(seg_type == "thinking" for seg_type, *_ in segments):
+        traj_reasoning = _load_trajectory_reasoning(trajectory_path)
+        if traj_reasoning:
+            reasoning_iter = iter(traj_reasoning)
+            backfilled = []
+            for seg in segments:
+                if seg[0] == "llm":
+                    reasoning = next(reasoning_iter, None)
+                    if reasoning:
+                        text, _ts = reasoning
+                        # Use the llm segment's own timestamp so the
+                        # synthetic thinking lands right before its turn,
+                        # matching natural stream ordering.
+                        backfilled.append(("thinking", text, seg[2], None))
+                backfilled.append(seg)
+            segments = backfilled
+
     # ── Derive timing from event timestamps ─────────────────────
     all_event_ts = [iso_to_ns(e["timestamp"])
                     for e in events if e.get("timestamp")]
@@ -604,7 +654,8 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
     for idx, turn in enumerate(user_turns_for_spans):
         ts = turn.get("timestamp")
         start_ns = iso_to_ns(ts) if ts else user_cursor
-        end_ns = start_ns + int(0.1e9)
+        start_ns = _clamp_ns(start_ns, trace_start, trace_end)
+        end_ns = _clamp_ns(start_ns + int(0.1e9), trace_start, trace_end)
         user_cursor = end_ns
         msg = turn["message"]
         first_line = msg.split("\n")[0].strip()[:80] or f"user-{idx + 1}"
@@ -781,7 +832,8 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
         think_cursor = step_start
         for think_text, think_ts in thinkings:
             t_start = iso_to_ns(think_ts) if think_ts else think_cursor
-            t_end = t_start + int(0.5e9)
+            t_start = _clamp_ns(t_start, trace_start, trace_end)
+            t_end = _clamp_ns(t_start + int(0.5e9), trace_start, trace_end)
             think_cursor = t_end
             spans.append(make_span(
                 trace_id, step_span_id,

--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -64,21 +64,32 @@ def _user_text_from_content(content):
     return ""
 
 
+_MAX_TOOL_OUTPUT = 4000  # chars per tool result (stream or ATIF-enriched)
+_MAX_WRITE_CONTENT = 4000
+_MAX_EDIT_FRAGMENT = 2000
+
+
+def _load_trajectory_json(trajectory_path):
+    """Load ATIF trajectory.json as a dict, or None."""
+    if trajectory_path is None:
+        return None
+    path = Path(trajectory_path)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def _load_trajectory_user_steps(trajectory_path):
     """Load user steps from a Harbor ATIF trajectory.json (if present).
 
     Returns a list of ``{"message": str, "timestamp": str|None}``.
     """
-    if trajectory_path is None:
-        return []
-    path = Path(trajectory_path)
-    if not path.is_file():
-        return []
-    try:
-        data = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return []
-    if not isinstance(data, dict):
+    data = _load_trajectory_json(trajectory_path)
+    if not data:
         return []
     steps = data.get("steps") or []
     out = []
@@ -95,6 +106,46 @@ def _load_trajectory_user_steps(trajectory_path):
             "timestamp": step.get("timestamp"),
         })
     return out
+
+
+def _load_trajectory_tool_data(trajectory_path):
+    """Index ATIF agent tool_calls and observations by tool id.
+
+    Returns ``(tool_args, tool_results)`` where:
+      - tool_args: tool_call_id -> arguments dict
+      - tool_results: source_call_id -> richer result string
+    """
+    data = _load_trajectory_json(trajectory_path)
+    if not data:
+        return {}, {}
+    tool_args = {}
+    tool_results = {}
+    for step in data.get("steps") or []:
+        if not isinstance(step, dict) or step.get("source") != "agent":
+            continue
+        for call in step.get("tool_calls") or []:
+            if not isinstance(call, dict):
+                continue
+            tuid = call.get("tool_call_id") or ""
+            args = call.get("arguments")
+            if tuid and isinstance(args, dict):
+                tool_args[tuid] = args
+        obs = step.get("observation") or {}
+        if not isinstance(obs, dict):
+            continue
+        for result in obs.get("results") or []:
+            if not isinstance(result, dict):
+                continue
+            tuid = result.get("source_call_id") or ""
+            if not tuid:
+                continue
+            content = result.get("content")
+            if not isinstance(content, str) or not content.strip():
+                continue
+            # Prefer observation content (often includes [metadata] JSON
+            # with Write file body) over the short stream-json success line.
+            tool_results[tuid] = content.strip()[:_MAX_TOOL_OUTPUT]
+    return tool_args, tool_results
 
 
 def build_trace(stdout_path, run_result, run_id, experiment_id,
@@ -190,10 +241,13 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
             if final_response:
                 break
 
+    # ATIF trajectory tool args / richer observations (Harbor).
+    traj_tool_args, traj_tool_results = _load_trajectory_tool_data(
+        trajectory_path)
+
     # ── Build tool_result timestamp and content lookups ─────────
     tool_result_ns = {}  # tool_use_id -> timestamp_ns
     tool_result_content = {}  # tool_use_id -> truncated output string
-    _MAX_TOOL_OUTPUT = 500  # chars per tool result
     for e in events:
         if e.get("type") != "user":
             continue
@@ -222,6 +276,12 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
                         if text:
                             tool_result_content[tuid] = (
                                 text[:_MAX_TOOL_OUTPUT])
+
+    # Prefer richer ATIF observation text when available.
+    for tuid, text in traj_tool_results.items():
+        existing = tool_result_content.get(tuid, "")
+        if len(text) > len(existing):
+            tool_result_content[tuid] = text
 
     # ── Override timestamps for background agents ───────────────
     # Background agents return an immediate "async launched" tool_result,
@@ -678,13 +738,26 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
         else:
             step_name = "Setup"
 
+        step_tool_names = []
+        for _, _, batch, _ in batch_timings:
+            for _, _, name, _ in batch:
+                step_tool_names.append(name)
+        step_inputs = {"step": step_idx + 1}
+        if step_tool_names:
+            step_inputs["tools"] = step_tool_names
+        step_outputs = {}
+        if llm_text:
+            step_outputs["text"] = llm_text
+        if thinkings:
+            step_outputs["thinking"] = thinkings[0][0]
         step_span = make_span(
             trace_id, root_span_id,
             name=step_name,
             span_type="AGENT",
             start_ns=step_start,
             end_ns=step_end,
-            inputs={"step": step_idx + 1},
+            inputs=step_inputs,
+            outputs=step_outputs or None,
         )
         step_span_id = step_span["span_id"]
         spans.append(step_span)
@@ -754,6 +827,20 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
             for (_, tuid, name, inp), end_ns in zip(batch, batch_ends):
                 child_end = end_ns if end_ns else b_end
                 span_type = "AGENT" if name == "Agent" else "TOOL"
+                # Merge richer ATIF tool arguments when stream input is thin.
+                merged_inp = inp if isinstance(inp, dict) else {}
+                traj_args = traj_tool_args.get(tuid)
+                if isinstance(traj_args, dict):
+                    merged_inp = {**traj_args, **merged_inp}
+                    # Prefer traj values that stream omitted or left empty.
+                    for k, v in traj_args.items():
+                        if k not in merged_inp or merged_inp.get(k) in (
+                                None, "", {}, []):
+                            merged_inp[k] = v
+                        elif (isinstance(v, str) and isinstance(
+                                merged_inp.get(k), str)
+                              and len(v) > len(merged_inp[k])):
+                            merged_inp[k] = v
                 # Include tool result content as span output
                 tool_output = None
                 if tuid in tool_result_content:
@@ -764,7 +851,7 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
                     span_type=span_type,
                     start_ns=b_start,
                     end_ns=child_end,
-                    inputs=summarize_tool_input(name, inp),
+                    inputs=summarize_tool_input(name, merged_inp),
                     outputs=tool_output,
                 )
                 spans.append(tool_span)
@@ -955,11 +1042,32 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
 
 
 def summarize_tool_input(tool_name, tool_input):
-    """One-line summary of a tool call for span display."""
+    """Compact tool-call payload for span display (keeps file bodies)."""
+    tool_input = tool_input if isinstance(tool_input, dict) else {}
     if tool_name == "Bash":
         return {"command": tool_input.get("command", "")[:200]}
-    elif tool_name in ("Write", "Edit", "Read"):
-        return {"file_path": tool_input.get("file_path", "")}
+    elif tool_name == "Write":
+        out = {"file_path": tool_input.get("file_path", "")}
+        content = tool_input.get("content")
+        if isinstance(content, str) and content:
+            out["content"] = content[:_MAX_WRITE_CONTENT]
+        return out
+    elif tool_name == "Edit":
+        out = {"file_path": tool_input.get("file_path", "")}
+        old = tool_input.get("old_string")
+        new = tool_input.get("new_string")
+        if isinstance(old, str) and old:
+            out["old_string"] = old[:_MAX_EDIT_FRAGMENT]
+        if isinstance(new, str) and new:
+            out["new_string"] = new[:_MAX_EDIT_FRAGMENT]
+        return out
+    elif tool_name == "Read":
+        out = {"file_path": tool_input.get("file_path", "")}
+        if tool_input.get("offset") is not None:
+            out["offset"] = tool_input.get("offset")
+        if tool_input.get("limit") is not None:
+            out["limit"] = tool_input.get("limit")
+        return out
     elif tool_name == "Agent":
         return {"description": tool_input.get("description", "")}
     elif tool_name == "Skill":

--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -647,6 +647,12 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
     current_context = []
     current_batches = []
     current_thinkings = []
+    # Thinking precedes its own turn's "llm" text segment in stream order, so
+    # it can't be appended to current_thinkings directly: _flush_step() fires
+    # on the *next* llm segment, which would close out the *previous* step
+    # bundled with thinking that actually belongs to the incoming turn. Stash
+    # it here until the matching llm segment arrives and claims it.
+    pending_thinkings = []
     # Track whether the current step launched background agents
     _has_bg_agents = False
 
@@ -667,22 +673,30 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
 
     for seg_type, seg_data, *rest in segments:
         if seg_type == "thinking":
-            current_thinkings.append((seg_data, rest[0] if rest else None))
+            pending_thinkings.append((seg_data, rest[0] if rest else None))
         elif seg_type == "llm":
             if _has_bg_agents and _is_status_update(seg_data):
-                # Merge status update into the current dispatch step
+                # Merge status update (and any thinking ahead of it) into the
+                # current dispatch step rather than starting a new one.
+                current_thinkings.extend(pending_thinkings)
+                pending_thinkings = []
                 continue
             # Save previous step
             _flush_step()
             current_llm = seg_data
             current_ts = rest[0] if rest else None
             current_context = rest[1] if len(rest) > 1 else []
+            # Pending thinking belongs to *this* turn's step, not the one
+            # just flushed.
+            current_thinkings = pending_thinkings
+            pending_thinkings = []
         elif seg_type == "batch":
             current_batches.append(seg_data)
             # Detect if this batch contains Agent calls (potential bg agents)
             if any(name == "Agent" for _, _, name, _ in seg_data):
                 _has_bg_agents = True
-    # Flush final step
+    # Any trailing thinking with no following turn belongs to the last step.
+    current_thinkings.extend(pending_thinkings)
     _flush_step()
 
     # ── Build spans from steps ──────────────────────────────────

--- a/agent_eval/mlflow/trace_builder.py
+++ b/agent_eval/mlflow/trace_builder.py
@@ -718,6 +718,11 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
         if current_llm is not None or current_batches or current_thinkings:
             steps.append((current_llm, current_ts, current_context,
                           current_batches, current_thinkings))
+            # Reset all step fields so a subsequent thinking→tool (no text)
+            # turn cannot reuse the previous step's llm text.
+            current_llm = None
+            current_ts = None
+            current_context = []
             current_batches = []
             current_thinkings = []
             _has_bg_agents = False
@@ -742,6 +747,13 @@ def build_trace(stdout_path, run_result, run_id, experiment_id,
             current_thinkings = pending_thinkings
             pending_thinkings = []
         elif seg_type == "batch":
+            if pending_thinkings:
+                # If we have pending thinking but no llm segment arrived before
+                # the batch (e.g. a tool-only turn), flush the previous step
+                # and attach the thinking to the new step that will own this batch.
+                _flush_step()
+                current_thinkings = pending_thinkings
+                pending_thinkings = []
             current_batches.append(seg_data)
             # Detect if this batch contains Agent calls (potential bg agents)
             if any(name == "Agent" for _, _, name, _ in seg_data):

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -408,8 +408,9 @@ def main():
                     continue
                 step_rr = _harbor_step_run_result(case_dir, step_name,
                                                   run_result, transcript)
-                trace_name = (f"{config.skill} ({step_key})"
-                              if config.skill else step_key)
+                _skill = _resolve_skill(config)
+                trace_name = (f"{_skill} ({step_key})"
+                              if _skill else step_key)
                 traj = transcript.parent / "trajectory.json"
                 trace_dict = build_trace(
                     transcript, step_rr, step_key,

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -89,6 +89,19 @@ def _resolve_harbor_job_dir(raw, run_dir):
     return None
 
 
+def _safe_trajectory_path(transcript, job_root):
+    """Resolve <transcript-dir>/trajectory.json, rejecting symlinks/escapes.
+
+    trajectory.json lives alongside the Claude transcript in Harbor's job
+    output; guard it the same way as the other harbor-job paths (CWE-22/CWE-59)
+    so a tampered or symlinked file can't smuggle unrelated data into traces.
+    """
+    traj = transcript.parent / "trajectory.json"
+    if traj.is_file() and not traj.is_symlink() and _is_within(traj, job_root):
+        return traj
+    return None
+
+
 def _harbor_steps(job_dir):
     """Yield (case_id, case_dir, step_name, transcript_path, subagent_dir) per step.
 
@@ -411,12 +424,11 @@ def main():
                 _skill = _resolve_skill(config)
                 trace_name = (f"{_skill} ({step_key})"
                               if _skill else step_key)
-                traj = transcript.parent / "trajectory.json"
                 trace_dict = build_trace(
                     transcript, step_rr, step_key,
                     experiment_id, trace_name=trace_name,
                     subagent_dir=sub_dir,
-                    trajectory_path=traj if traj.is_file() else None,
+                    trajectory_path=_safe_trajectory_path(transcript, job_dir),
                 )
                 if trace_dict:
                     tid = log_trace(trace_dict)

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -392,9 +392,13 @@ def main():
                                                   run_result, transcript)
                 trace_name = (f"{config.skill} ({step_key})"
                               if config.skill else step_key)
-                trace_dict = build_trace(transcript, step_rr, step_key,
-                                         experiment_id, trace_name=trace_name,
-                                         subagent_dir=sub_dir)
+                traj = transcript.parent / "trajectory.json"
+                trace_dict = build_trace(
+                    transcript, step_rr, step_key,
+                    experiment_id, trace_name=trace_name,
+                    subagent_dir=sub_dir,
+                    trajectory_path=traj if traj.is_file() else None,
+                )
                 if trace_dict:
                     tid = log_trace(trace_dict)
                     if tid:

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -41,6 +41,24 @@ from agent_eval.mlflow.trace_builder import build_trace, log_trace
 from agent_eval.harbor.results import _extract_transcript_metrics
 
 
+def _resolve_skill(config: EvalConfig) -> str | None:
+    """Skill name compatible with AEH v1.0.3 and newer EvalConfig APIs."""
+    if hasattr(config, "resolve_skill"):
+        return config.resolve_skill()
+    return getattr(config, "skill", None) or None
+
+
+def _eval_name(config: EvalConfig) -> str:
+    """Eval subdirectory name compatible with AEH v1.0.3 and newer APIs."""
+    if hasattr(config, "eval_name"):
+        return config.eval_name()
+    return (
+        getattr(config, "skill", None)
+        or getattr(config, "name", None)
+        or "eval"
+    )
+
+
 def _is_within(path, root):
     """True if ``path`` resolves to ``root`` or a descendant (symlinks resolved)."""
     try:
@@ -172,7 +190,7 @@ def main():
     config = EvalConfig.from_yaml(args.config)
     mlflow.set_tracking_uri(resolve_tracking_uri(config))
     runs_base = Path(os.environ.get("AGENT_EVAL_RUNS_DIR", "eval/runs"))
-    runs_dir = runs_base / config.eval_name()
+    runs_dir = runs_base / _eval_name(config)
     run_dir = runs_dir / args.run_id
 
     # Load summary
@@ -205,8 +223,8 @@ def main():
 
         # ── Params ───────────────────────────────────────────────
         params = {
-            "skill": config.resolve_skill(),
-            "eval_name": config.eval_name(),
+            "skill": _resolve_skill(config),
+            "eval_name": _eval_name(config),
             "runner": config.runner.type,
             "run_id": args.run_id,
             "model": run_result.get("model", ""),
@@ -362,7 +380,7 @@ def main():
                 if case_id in case_trace_map:
                     continue
                 case_result = run_result.get("per_case", {}).get(case_id, run_result)
-                _skill = config.resolve_skill()
+                _skill = _resolve_skill(config)
                 trace_name = f"{_skill} ({case_id})" if _skill else case_id
                 trace_dict = build_trace(case_stdout, case_result, case_id,
                                          experiment_id, trace_name=trace_name)
@@ -411,8 +429,8 @@ def main():
     else:
         stdout_path = run_dir / "stdout.log"
         if stdout_path.exists() and run_result:
-            _skill = config.resolve_skill()
-            trace_name = f"{_skill} ({args.run_id})" if _skill else config.eval_name()
+            _skill = _resolve_skill(config)
+            trace_name = f"{_skill} ({args.run_id})" if _skill else _eval_name(config)
             trace_dict = build_trace(stdout_path, run_result, args.run_id,
                                      experiment_id, trace_name=trace_name)
             if trace_dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,14 +38,18 @@ def make_tool(name, tool_use_id, input_dict=None):
 
 
 def make_assistant(msg_id, tools=None, text=None, model="claude-sonnet-4-5",
-                   parent_tool_use_id=None, input_tokens=100, output_tokens=50):
+                   parent_tool_use_id=None, input_tokens=100, output_tokens=50,
+                   thinking=None):
     """Build an assistant event.
 
     Args:
         tools: list of (name, tool_use_id, input_dict) tuples.
         parent_tool_use_id: set this to make it a foreground subagent message.
+        thinking: optional extended-thinking text block.
     """
     content = []
+    if thinking:
+        content.append({"type": "thinking", "thinking": thinking})
     if text:
         content.append({"type": "text", "text": text})
     for name, tuid, inp in (tools or []):

--- a/tests/test_log_results.py
+++ b/tests/test_log_results.py
@@ -1,0 +1,88 @@
+"""Tests for log_results.py path-safety helpers (harbor job-dir traversal)."""
+
+import pytest
+
+try:
+    from log_results import _is_within, _safe_trajectory_path
+    _has_mlflow = True
+except (ImportError, SystemExit):
+    _has_mlflow = False
+
+
+@pytest.mark.skipif(not _has_mlflow, reason="mlflow not installed")
+class TestSafeTrajectoryPath:
+    def test_accepts_real_file_under_job_root(self, tmp_path):
+        """A regular trajectory.json alongside the transcript is accepted."""
+        job_root = tmp_path / "job"
+        step_dir = job_root / "case__abc" / "agent"
+        step_dir.mkdir(parents=True)
+        transcript = step_dir / "claude-code.txt"
+        transcript.write_text("{}\n")
+        traj = step_dir / "trajectory.json"
+        traj.write_text("{}")
+
+        result = _safe_trajectory_path(transcript, job_root)
+        assert result == traj
+
+    def test_missing_trajectory_returns_none(self, tmp_path):
+        """No trajectory.json present -> None, no error."""
+        job_root = tmp_path / "job"
+        step_dir = job_root / "case__abc" / "agent"
+        step_dir.mkdir(parents=True)
+        transcript = step_dir / "claude-code.txt"
+        transcript.write_text("{}\n")
+
+        assert _safe_trajectory_path(transcript, job_root) is None
+
+    def test_rejects_symlinked_trajectory(self, tmp_path):
+        """A trajectory.json symlink pointing outside job_root is rejected."""
+        job_root = tmp_path / "job"
+        step_dir = job_root / "case__abc" / "agent"
+        step_dir.mkdir(parents=True)
+        transcript = step_dir / "claude-code.txt"
+        transcript.write_text("{}\n")
+
+        secret = tmp_path / "outside" / "secret.json"
+        secret.parent.mkdir(parents=True)
+        secret.write_text('{"leaked": true}')
+        traj = step_dir / "trajectory.json"
+        traj.symlink_to(secret)
+
+        assert _safe_trajectory_path(transcript, job_root) is None
+
+    def test_rejects_symlink_even_when_target_is_inside_root(self, tmp_path):
+        """Symlinks are rejected outright, regardless of where they point."""
+        job_root = tmp_path / "job"
+        step_dir = job_root / "case__abc" / "agent"
+        step_dir.mkdir(parents=True)
+        transcript = step_dir / "claude-code.txt"
+        transcript.write_text("{}\n")
+
+        real = job_root / "real_trajectory.json"
+        real.write_text("{}")
+        traj = step_dir / "trajectory.json"
+        traj.symlink_to(real)
+
+        assert _safe_trajectory_path(transcript, job_root) is None
+
+
+@pytest.mark.skipif(not _has_mlflow, reason="mlflow not installed")
+class TestIsWithin:
+    def test_descendant_path_is_within(self, tmp_path):
+        root = tmp_path / "root"
+        child = root / "a" / "b.txt"
+        child.parent.mkdir(parents=True)
+        child.write_text("x")
+        assert _is_within(child, root) is True
+
+    def test_escaping_path_is_not_within(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        outside = tmp_path / "outside.txt"
+        outside.write_text("x")
+        assert _is_within(outside, root) is False
+
+    def test_nonexistent_path_is_not_within(self, tmp_path):
+        root = tmp_path / "root"
+        root.mkdir()
+        assert _is_within(root / "missing.txt", root) is False

--- a/tests/test_log_results.py
+++ b/tests/test_log_results.py
@@ -5,7 +5,16 @@ import pytest
 try:
     from log_results import _is_within, _safe_trajectory_path
     _has_mlflow = True
-except (ImportError, SystemExit):
+except ModuleNotFoundError as exc:
+    # Skip only when mlflow itself is missing; re-raise unrelated import errors
+    # so path-safety regressions are never silently skipped.
+    if exc.name != "mlflow":
+        raise
+    _has_mlflow = False
+except SystemExit as exc:
+    # log_results.py calls sys.exit(0) when mlflow is missing at import time.
+    if exc.code not in (0, None):
+        raise
     _has_mlflow = False
 
 

--- a/tests/test_trace_builder.py
+++ b/tests/test_trace_builder.py
@@ -199,3 +199,124 @@ class TestBuildTrace:
         ]
         assert any("/aeh-hello-world" in m for m in messages)
         assert any("Hello, World!" in m for m in messages)
+
+    def test_write_tool_span_includes_file_content(self, tmp_path):
+        """Write TOOL span inputs keep the file body, not just file_path."""
+        events = [
+            make_system_init(),
+            make_assistant(
+                "msg_001",
+                thinking="Write hello.py",
+                tools=[("Write", "tu_001",
+                        {"file_path": "/workspace/hello.py",
+                         "content": 'print("Hello, World!")\n'})],
+            ),
+            make_user(tool_results=[("tu_001", "File created")]),
+            make_assistant("msg_002", text="Created hello.py"),
+            make_result(cost_usd=0.10, num_turns=2),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        trace = build_trace(stdout, _basic_run_result(),
+                            run_id="test-run", experiment_id="exp-001")
+        write = next(s for s in trace["data"]["spans"] if s["name"] == "Write")
+        inputs = json.loads(write["attributes"]["mlflow.spanInputs"])
+        assert inputs["file_path"] == "/workspace/hello.py"
+        assert 'print("Hello, World!")' in inputs["content"]
+
+    def test_trajectory_observation_enriches_tool_output(self, tmp_path):
+        """ATIF observation content replaces a short stream tool_result."""
+        events = [
+            make_system_init(),
+            make_assistant(
+                "msg_001",
+                thinking="Write the file.",
+                # Stream omits content; trajectory supplies full args + observation.
+                tools=[("Write", "tu_001", {"file_path": "/workspace/hello.py"})],
+            ),
+            make_user(tool_results=[("tu_001", "File created successfully")]),
+            make_assistant("msg_002", text="Created hello.py"),
+            make_result(cost_usd=0.10, num_turns=2),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        rich = (
+            "File created successfully at: /workspace/hello.py\n\n"
+            '[metadata] {"type": "create", "filePath": "/workspace/hello.py", '
+            '"content": "print(\\"Hello, World!\\")\\n"}'
+        )
+        traj = tmp_path / "trajectory.json"
+        traj.write_text(json.dumps({
+            "schema_version": "ATIF-v1.7",
+            "steps": [
+                {
+                    "step_id": 1,
+                    "source": "user",
+                    "message": "Create hello.py",
+                },
+                {
+                    "step_id": 2,
+                    "source": "agent",
+                    "tool_calls": [{
+                        "tool_call_id": "tu_001",
+                        "function_name": "Write",
+                        "arguments": {
+                            "file_path": "/workspace/hello.py",
+                            "content": 'print("Hello, World!")\n',
+                        },
+                    }],
+                    "observation": {
+                        "results": [{
+                            "source_call_id": "tu_001",
+                            "content": rich,
+                        }],
+                    },
+                },
+            ],
+        }))
+        trace = build_trace(
+            stdout, _basic_run_result(),
+            run_id="test-run", experiment_id="exp-001",
+            trajectory_path=traj,
+        )
+        write = next(s for s in trace["data"]["spans"] if s["name"] == "Write")
+        inputs = json.loads(write["attributes"]["mlflow.spanInputs"])
+        outputs = json.loads(write["attributes"]["mlflow.spanOutputs"])
+        assert 'print("Hello, World!")' in inputs["content"]
+        assert "Hello, World!" in outputs["result"]
+        assert "[metadata]" in outputs["result"]
+
+    def test_agent_step_spans_include_outputs(self, tmp_path):
+        """AGENT step spans expose text/thinking and tool names."""
+        events = [
+            make_system_init(),
+            make_assistant(
+                "msg_001",
+                thinking="I should write a hello world file.",
+                tools=[("Write", "tu_001",
+                        {"file_path": "/workspace/hello.py",
+                         "content": 'print("Hi")\n'})],
+            ),
+            make_user(tool_results=[("tu_001", "ok")]),
+            make_assistant("msg_002", text="Created hello.py"),
+            make_result(cost_usd=0.10, num_turns=2),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        trace = build_trace(stdout, _basic_run_result(),
+                            run_id="test-run", experiment_id="exp-001")
+        agent_steps = [
+            s for s in trace["data"]["spans"]
+            if _get_span_type(s) == "AGENT" and s["parent_span_id"] is not None
+        ]
+        assert agent_steps
+        # At least one step should carry thinking or final text in outputs.
+        outputs_list = [
+            json.loads(s["attributes"].get("mlflow.spanOutputs", "{}"))
+            for s in agent_steps
+            if "mlflow.spanOutputs" in s["attributes"]
+        ]
+        assert any(o.get("thinking") or o.get("text") for o in outputs_list)
+        # The write step should list Write among tools.
+        inputs_list = [
+            json.loads(s["attributes"]["mlflow.spanInputs"])
+            for s in agent_steps
+        ]
+        assert any("Write" in (i.get("tools") or []) for i in inputs_list)

--- a/tests/test_trace_builder.py
+++ b/tests/test_trace_builder.py
@@ -507,3 +507,90 @@ class TestBuildTrace:
         assert len(thinking_spans) == 1
         outputs = json.loads(thinking_spans[0]["attributes"]["mlflow.spanOutputs"])
         assert outputs["thinking"] == "Real stream thinking."
+
+    def test_thinking_flushed_before_tool_only_turn(self, tmp_path):
+        """Pending thinking is attached to a tool-only turn (no llm text)."""
+        events = [
+            make_system_init(),
+            make_assistant("msg_001", thinking="Thinking before tool.",
+                           tools=[("Write", "tu_001",
+                                   {"file_path": "/x", "content": "a = 1\n"})]),
+            make_user(tool_results=[("tu_001", "ok")]),
+            make_result(cost_usd=0.10, num_turns=1),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        trace = build_trace(
+            stdout, _basic_run_result(),
+            run_id="test-run", experiment_id="exp-001",
+        )
+        agent_steps = [
+            s for s in trace["data"]["spans"]
+            if _get_span_type(s) == "AGENT" and s["parent_span_id"] is not None
+        ]
+        assert len(agent_steps) == 1
+        outputs = json.loads(agent_steps[0]["attributes"]["mlflow.spanOutputs"])
+        assert "Thinking before tool" in outputs.get("thinking", "")
+
+    def test_thinking_tool_only_turn_does_not_reuse_prior_llm_text(self, tmp_path):
+        """A thinking→tool turn after a texted step must not reuse that text.
+
+        Regression: _flush_step used to leave current_llm set, so a later
+        no-text tool turn inherited the previous step's assistant text.
+        """
+        events = [
+            make_system_init(),
+            make_assistant(
+                "msg_001",
+                text="Writing file A now.",
+                tools=[("Write", "tu_001",
+                        {"file_path": "/workspace/a.py", "content": "a = 1\n"})],
+            ),
+            make_user(tool_results=[("tu_001", "File A created")]),
+            make_assistant(
+                "msg_002",
+                thinking="Plan: write file B with no spoken text.",
+                tools=[("Write", "tu_002",
+                        {"file_path": "/workspace/b.py", "content": "b = 2\n"})],
+            ),
+            make_user(tool_results=[("tu_002", "File B created")]),
+            make_assistant("msg_003", text="Done."),
+            make_result(cost_usd=0.10, num_turns=3),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        trace = build_trace(stdout, _basic_run_result(),
+                            run_id="test-run", experiment_id="exp-001")
+        agent_steps = [
+            s for s in trace["data"]["spans"]
+            if _get_span_type(s) == "AGENT" and s["parent_span_id"] is not None
+        ]
+
+        def _io(step):
+            return (
+                json.loads(step["attributes"].get("mlflow.spanInputs", "{}")),
+                json.loads(step["attributes"].get("mlflow.spanOutputs", "{}")),
+            )
+
+        step_a = next(
+            s for s in agent_steps
+            if "Writing file A" in _io(s)[1].get("text", "")
+        )
+        step_b = next(
+            s for s in agent_steps
+            if "write file B" in _io(s)[1].get("thinking", "")
+        )
+        step_c = next(
+            s for s in agent_steps
+            if _io(s)[1].get("text", "") == "Done."
+        )
+
+        _, out_a = _io(step_a)
+        in_b, out_b = _io(step_b)
+        _, out_c = _io(step_c)
+
+        assert out_a.get("text") == "Writing file A now."
+        assert "write file B" not in out_a.get("thinking", "")
+        assert "Write" in (in_b.get("tools") or [])
+        assert out_b.get("text") in (None, "")
+        assert "Writing file A" not in (out_b.get("text") or "")
+        assert out_c.get("text") == "Done."
+        assert "Writing file A" not in (out_c.get("text") or "")

--- a/tests/test_trace_builder.py
+++ b/tests/test_trace_builder.py
@@ -412,3 +412,98 @@ class TestBuildTrace:
         assert "file B next" not in step_a.get("thinking", "")
         assert "file B next" in step_b.get("thinking", "")
         assert "file A first" not in step_b.get("thinking", "")
+
+    def test_chain_span_clamped_to_trace_window(self, tmp_path):
+        """A trajectory timestamp far outside the trace window gets clamped."""
+        events = [
+            make_system_init(),
+            make_assistant("msg_001", text="Created /x"),
+            make_result(cost_usd=0.10, num_turns=1),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        traj = tmp_path / "trajectory.json"
+        traj.write_text(json.dumps({
+            "schema_version": "ATIF-v1.7",
+            "steps": [
+                {
+                    # Clock way before the stream-json events (skewed source).
+                    "timestamp": "1970-01-01T00:00:00.000Z",
+                    "source": "user",
+                    "message": "Create a simple Hello, World! Python program.",
+                },
+            ],
+        }))
+        trace = build_trace(
+            stdout, _basic_run_result(),
+            run_id="test-run", experiment_id="exp-001",
+            trajectory_path=traj,
+        )
+        root = next(s for s in trace["data"]["spans"] if s["parent_span_id"] is None)
+        user_span = next(
+            s for s in trace["data"]["spans"]
+            if _get_span_type(s) == "CHAIN" and s["name"].startswith("user:")
+        )
+        assert user_span["start_time_unix_nano"] >= root["start_time_unix_nano"]
+        assert user_span["end_time_unix_nano"] <= root["end_time_unix_nano"]
+
+    def test_reasoning_content_backfills_thinking_when_stream_has_none(self, tmp_path):
+        """ATIF reasoning_content fills in thinking when the stream has none."""
+        events = [
+            make_system_init(),
+            make_assistant("msg_001", text="Writing file A now.",
+                           tools=[("Write", "tu_001",
+                                   {"file_path": "/x", "content": "a = 1\n"})]),
+            make_user(tool_results=[("tu_001", "ok")]),
+            make_assistant("msg_002", text="Done."),
+            make_result(cost_usd=0.10, num_turns=2),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        traj = tmp_path / "trajectory.json"
+        traj.write_text(json.dumps({
+            "schema_version": "ATIF-v1.7",
+            "steps": [
+                {
+                    "source": "agent",
+                    "reasoning_content": "Backfilled plan for file A.",
+                },
+            ],
+        }))
+        trace = build_trace(
+            stdout, _basic_run_result(),
+            run_id="test-run", experiment_id="exp-001",
+            trajectory_path=traj,
+        )
+        thinking_spans = [s for s in trace["data"]["spans"] if s["name"] == "thinking"]
+        assert len(thinking_spans) == 1
+        outputs = json.loads(thinking_spans[0]["attributes"]["mlflow.spanOutputs"])
+        assert "Backfilled plan for file A" in outputs["thinking"]
+
+    def test_reasoning_content_does_not_override_existing_stream_thinking(self, tmp_path):
+        """Trajectory reasoning_content is ignored when stream already has thinking."""
+        events = [
+            make_system_init(),
+            make_assistant("msg_001", thinking="Real stream thinking.",
+                           text="Writing file A now.",
+                           tools=[("Write", "tu_001",
+                                   {"file_path": "/x", "content": "a = 1\n"})]),
+            make_user(tool_results=[("tu_001", "ok")]),
+            make_assistant("msg_002", text="Done."),
+            make_result(cost_usd=0.10, num_turns=2),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        traj = tmp_path / "trajectory.json"
+        traj.write_text(json.dumps({
+            "schema_version": "ATIF-v1.7",
+            "steps": [
+                {"source": "agent", "reasoning_content": "Should not appear."},
+            ],
+        }))
+        trace = build_trace(
+            stdout, _basic_run_result(),
+            run_id="test-run", experiment_id="exp-001",
+            trajectory_path=traj,
+        )
+        thinking_spans = [s for s in trace["data"]["spans"] if s["name"] == "thinking"]
+        assert len(thinking_spans) == 1
+        outputs = json.loads(thinking_spans[0]["attributes"]["mlflow.spanOutputs"])
+        assert outputs["thinking"] == "Real stream thinking."

--- a/tests/test_trace_builder.py
+++ b/tests/test_trace_builder.py
@@ -200,6 +200,46 @@ class TestBuildTrace:
         assert any("/aeh-hello-world" in m for m in messages)
         assert any("Hello, World!" in m for m in messages)
 
+    def test_prompt_matches_chain_spans_when_stream_also_has_user_text(self, tmp_path):
+        """Root prompt must agree with the CHAIN spans, not mix stream + trajectory."""
+        events = [
+            make_system_init(),
+            make_user(text="stale prompt from a retried stream"),
+            make_assistant("msg_001", text="Created /x"),
+            make_result(cost_usd=0.10, num_turns=1),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        traj = tmp_path / "trajectory.json"
+        traj.write_text(json.dumps({
+            "schema_version": "ATIF-v1.7",
+            "steps": [
+                {
+                    "step_id": 1,
+                    "timestamp": "2026-04-14T19:59:59.000Z",
+                    "source": "user",
+                    "message": "Create a simple Hello, World! Python program.",
+                },
+            ],
+        }))
+        trace = build_trace(
+            stdout, _basic_run_result(),
+            run_id="test-run", experiment_id="exp-001",
+            trajectory_path=traj,
+        )
+        root = next(s for s in trace["data"]["spans"] if s["parent_span_id"] is None)
+        root_inputs = json.loads(root["attributes"]["mlflow.spanInputs"])
+        user_spans = [
+            s for s in trace["data"]["spans"]
+            if _get_span_type(s) == "CHAIN" and s["name"].startswith("user:")
+        ]
+        chain_message = json.loads(
+            user_spans[0]["attributes"]["mlflow.spanOutputs"])["message"]
+
+        # Root prompt and the CHAIN span must come from the same source
+        # (trajectory), not disagree with each other.
+        assert root_inputs["prompt"] == chain_message
+        assert "stale prompt" not in root_inputs["prompt"]
+
     def test_write_tool_span_includes_file_content(self, tmp_path):
         """Write TOOL span inputs keep the file body, not just file_path."""
         events = [

--- a/tests/test_trace_builder.py
+++ b/tests/test_trace_builder.py
@@ -110,3 +110,92 @@ class TestBuildTrace:
                              _basic_run_result(),
                              run_id="x", experiment_id="e")
         assert result is None
+
+    def test_thinking_blocks_become_llm_spans(self, tmp_path):
+        """Extended thinking content blocks are emitted as thinking LLM spans."""
+        events = [
+            make_system_init(),
+            make_assistant(
+                "msg_001",
+                thinking="I should write a hello world file.",
+                tools=[("Write", "tu_001",
+                        {"file_path": "/workspace/hello.py",
+                         "content": 'print("Hello")\n'})],
+            ),
+            make_user(tool_results=[("tu_001", "File created")]),
+            make_assistant("msg_002", text="Created hello.py"),
+            make_result(cost_usd=0.10, num_turns=2),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        trace = build_trace(stdout, _basic_run_result(),
+                            run_id="test-run", experiment_id="exp-001")
+        assert trace is not None
+        spans = trace["data"]["spans"]
+        thinking = [s for s in spans if s["name"] == "thinking"]
+        assert len(thinking) == 1
+        outputs = json.loads(thinking[0]["attributes"]["mlflow.spanOutputs"])
+        assert "hello world" in outputs["thinking"]
+
+    def test_trajectory_user_steps_seed_prompt_and_chain_spans(self, tmp_path):
+        """Harbor trajectory.json user steps become root prompt + CHAIN spans."""
+        events = [
+            make_system_init(),
+            # Harbor-like: no user text in stream-json, only tool_result user event
+            make_assistant(
+                "msg_001",
+                thinking="Plan the file write.",
+                tools=[("Write", "tu_001", {"file_path": "/x", "content": "x"})],
+            ),
+            make_user(tool_results=[("tu_001", "ok")]),
+            make_assistant("msg_002", text="Created /x"),
+            make_result(cost_usd=0.10, num_turns=2),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        traj = tmp_path / "trajectory.json"
+        traj.write_text(json.dumps({
+            "schema_version": "ATIF-v1.7",
+            "steps": [
+                {
+                    "step_id": 1,
+                    "timestamp": "2026-04-14T19:59:59.000Z",
+                    "source": "user",
+                    "message": "<command-name>/aeh-hello-world</command-name>",
+                },
+                {
+                    "step_id": 2,
+                    "timestamp": "2026-04-14T19:59:59.100Z",
+                    "source": "user",
+                    "message": "Create a simple Hello, World! Python program.",
+                },
+                {
+                    "step_id": 3,
+                    "source": "agent",
+                    "message": "Created /x",
+                    "reasoning_content": "Plan the file write.",
+                },
+            ],
+        }))
+        trace = build_trace(
+            stdout, _basic_run_result(),
+            run_id="test-run", experiment_id="exp-001",
+            trajectory_path=traj,
+        )
+        assert trace is not None
+        root = next(s for s in trace["data"]["spans"] if s["parent_span_id"] is None)
+        root_inputs = json.loads(root["attributes"]["mlflow.spanInputs"])
+        assert "/aeh-hello-world" in root_inputs["prompt"]
+        assert "Hello, World!" in root_inputs["prompt"]
+        # Must not fall back to the assistant's final text as the prompt
+        assert root_inputs["prompt"] != "Created /x"
+
+        user_spans = [
+            s for s in trace["data"]["spans"]
+            if _get_span_type(s) == "CHAIN" and s["name"].startswith("user:")
+        ]
+        assert len(user_spans) == 2
+        messages = [
+            json.loads(s["attributes"]["mlflow.spanOutputs"])["message"]
+            for s in user_spans
+        ]
+        assert any("/aeh-hello-world" in m for m in messages)
+        assert any("Hello, World!" in m for m in messages)

--- a/tests/test_trace_builder.py
+++ b/tests/test_trace_builder.py
@@ -360,3 +360,55 @@ class TestBuildTrace:
             for s in agent_steps
         ]
         assert any("Write" in (i.get("tools") or []) for i in inputs_list)
+
+    def test_thinking_attributed_to_its_own_turns_step(self, tmp_path):
+        """Each step's thinking output is its OWN turn's, not the next turn's.
+
+        Regression test: thinking is emitted before its turn's text/tool_use
+        in stream order, so a step-grouping bug can misattribute it to the
+        *previous* step instead of the one it actually belongs to.
+        """
+        events = [
+            make_system_init(),
+            make_assistant(
+                "msg_001",
+                thinking="Plan: write file A first.",
+                text="Writing file A now.",
+                tools=[("Write", "tu_001",
+                        {"file_path": "/workspace/a.py", "content": "a = 1\n"})],
+            ),
+            make_user(tool_results=[("tu_001", "File A created")]),
+            make_assistant(
+                "msg_002",
+                thinking="Plan: write file B next.",
+                text="Writing file B now.",
+                tools=[("Write", "tu_002",
+                        {"file_path": "/workspace/b.py", "content": "b = 2\n"})],
+            ),
+            make_user(tool_results=[("tu_002", "File B created")]),
+            make_assistant("msg_003", text="Done."),
+            make_result(cost_usd=0.10, num_turns=3),
+        ]
+        stdout = _write_stream(tmp_path, events)
+        trace = build_trace(stdout, _basic_run_result(),
+                            run_id="test-run", experiment_id="exp-001")
+        agent_steps = [
+            s for s in trace["data"]["spans"]
+            if _get_span_type(s) == "AGENT" and s["parent_span_id"] is not None
+        ]
+
+        def _outputs(step_text_substr):
+            step = next(
+                s for s in agent_steps
+                if step_text_substr in json.loads(
+                    s["attributes"].get("mlflow.spanOutputs", "{}")
+                ).get("text", "")
+            )
+            return json.loads(step["attributes"]["mlflow.spanOutputs"])
+
+        step_a = _outputs("Writing file A")
+        step_b = _outputs("Writing file B")
+        assert "file A first" in step_a.get("thinking", "")
+        assert "file B next" not in step_a.get("thinking", "")
+        assert "file B next" in step_b.get("thinking", "")
+        assert "file A first" not in step_b.get("thinking", "")


### PR DESCRIPTION
## Summary

Harbor's stream-json output often omits user text and full tool payloads that Claude Code's own transcripts capture. This PR uses Harbor's ATIF `trajectory.json` (when available) to backfill that detail in MLflow traces, so Harbor runs get the same trace richness as native runs.

- Seed the root prompt and per-turn `CHAIN` user spans from `trajectory.json` when stream-json lacks user text
- Emit extended-thinking blocks as `LLM` spans so MLflow graphs show the full agent turn sequence
- Include `Write`/`Edit` file payloads and richer ATIF tool-call arguments/observations in `TOOL` spans
- Attach tool names, text, and thinking on `AGENT` step spans for closer parity with `trajectory.json`
- Keep v1.0.3 `EvalConfig` compatibility in `log_results.py` (`resolve_skill()`/`eval_name()` fallback shims)
- All new behavior is opt-in via an optional `trajectory_path` kwarg — falls back cleanly to stream-json-only behavior when absent

## Test plan

- [x] `tests/test_trace_builder.py` — 9/9 pass, including 5 new tests (thinking spans, trajectory-seeded prompt/CHAIN spans, Write content preservation, ATIF observation enrichment, AGENT step outputs)
- [x] Full suite passes on top of current `main`
- [x] `ruff check` clean



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MLflow traces can now use available Harbor `trajectory.json` to restore user turns and enrich tool inputs/outputs.
  - Added dedicated `thinking` spans for assistant reasoning (including backfilling from trajectory when needed).
  - Improved compact tool summaries (e.g., full Write bodies, Edit old/new, Read offset/limit).
  - Trace naming is now consistent across execution modes.

- **Bug Fixes**
  - Prefer trajectory-derived observations and long-form tool result text when it’s more complete than stream events.
  - Fixed span/step attribution so thinking belongs to the correct turn and timestamps stay within trace bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->