### PR TITLE
docs: eval.yaml schema diagram on the reference page

### DIFF
--- a/website/reference/eval-yaml.md
+++ b/website/reference/eval-yaml.md
@@ -10,7 +10,7 @@ one `judge`.
     Harbor, EvalHub) is always a CLI flag (`--runner`), never a config key — so the
     same file runs unchanged everywhere.
 
-<div class="schema-diagram" role="img" aria-label="eval.yaml schema map, grouped into four stages. Define: dataset, generation, inputs.tools, outputs. Execute: execution, runner, models, permissions, hooks (top-level skill is deprecated). Score: judges, thresholds, reward. Observe: mlflow, traces. Every top-level key is optional.">
+<div class="schema-diagram" role="region" aria-label="eval.yaml schema map">
   <p class="sd-meta">
     Every top-level key is optional. <code>name</code> and <code>description</code> are the only non-deprecated top-level scalars.
     <span class="sd-badge llm">LLM</span> marks natural-language fields interpreted by agents &amp; judges,

--- a/website/reference/eval-yaml.md
+++ b/website/reference/eval-yaml.md
@@ -10,6 +10,196 @@ one `judge`.
     Harbor, EvalHub) is always a CLI flag (`--runner`), never a config key — so the
     same file runs unchanged everywhere.
 
+<div class="schema-diagram" role="img" aria-label="eval.yaml schema map, grouped into four stages. Define: dataset, generation, inputs.tools, outputs. Execute: execution, runner, models, permissions, hooks (top-level skill is deprecated). Score: judges, thresholds, reward. Observe: mlflow, traces. Every top-level key is optional.">
+  <p class="sd-meta">
+    Every top-level key is optional. <code>name</code> and <code>description</code> are the only non-deprecated top-level scalars.
+    <span class="sd-badge llm">LLM</span> marks natural-language fields interpreted by agents &amp; judges,
+    <span class="sd-badge py">PY</span> marks Python code or expressions, and <code>[]</code> marks a list.
+  </p>
+  <div class="sd-grid">
+
+    <div class="sd-col define">
+      <div class="sd-group">Define · what to evaluate</div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/dataset/">dataset</a>
+        <div class="sd-purpose">Where cases live and what they contain</div>
+        <div class="sd-fields">
+          <span class="sd-f">path</span>
+          <span class="sd-f">schema<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">workspace.files[]</span>
+        </div>
+      </div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/generation/">generation</a>
+        <div class="sd-purpose">How <code>/eval-dataset</code> sources cases</div>
+        <div class="sd-fields">
+          <span class="sd-f">strategy</span>
+          <span class="sd-f">context<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">seeds[]</span>
+        </div>
+      </div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/inputs-tools/">inputs.tools[]</a>
+        <div class="sd-purpose">Tool interception for headless runs</div>
+        <div class="sd-fields">
+          <span class="sd-f">match<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">prompt<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">prompt_file<span class="sd-badge llm">LLM</span></span>
+        </div>
+      </div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/outputs/">outputs[]</a>
+        <div class="sd-purpose">Artifacts and tool calls to collect</div>
+        <div class="sd-fields">
+          <span class="sd-f">path</span>
+          <span class="sd-f">tool</span>
+          <span class="sd-f">schema<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">batch_pattern</span>
+          <span class="sd-f">types</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="sd-col execute">
+      <div class="sd-group">Execute · how it runs</div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/execution/">execution</a>
+        <div class="sd-purpose">What runs (skill <em>or</em> prompt), per case or batch</div>
+        <div class="sd-fields">
+          <span class="sd-f">mode</span>
+          <span class="sd-f">skill</span>
+          <span class="sd-f">prompt<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">arguments</span>
+          <span class="sd-f">timeout</span>
+          <span class="sd-f">max_budget_usd</span>
+          <span class="sd-f">parallelism</span>
+          <span class="sd-f">env</span>
+        </div>
+      </div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/runner/">runner</a>
+        <div class="sd-purpose">Agent runtime and knobs</div>
+        <div class="sd-fields">
+          <span class="sd-f">type</span>
+          <span class="sd-f">effort</span>
+          <span class="sd-f">settings</span>
+          <span class="sd-f">plugin_dirs[]</span>
+          <span class="sd-f">env</span>
+          <span class="sd-f">system_prompt<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">command</span>
+          <span class="sd-f">workspace_mode</span>
+        </div>
+      </div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/models/">models</a>
+        <div class="sd-purpose">Model per role (CLI flags override)</div>
+        <div class="sd-fields">
+          <span class="sd-f">skill</span>
+          <span class="sd-f">subagent</span>
+          <span class="sd-f">judge</span>
+          <span class="sd-f">hook</span>
+        </div>
+      </div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/permissions/">permissions</a>
+        <div class="sd-purpose">Tool allow / deny for headless runs</div>
+        <div class="sd-fields">
+          <span class="sd-f">allow[]</span>
+          <span class="sd-f">deny[]</span>
+        </div>
+      </div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/hooks/">hooks</a>
+        <div class="sd-purpose">Lifecycle shell commands</div>
+        <div class="sd-fields">
+          <span class="sd-f">before_all[]</span>
+          <span class="sd-f">before_each[]</span>
+          <span class="sd-f">after_each[]</span>
+          <span class="sd-f">before_scoring[]</span>
+          <span class="sd-f">after_all[]</span>
+          <span class="sd-f">before_report[]</span>
+        </div>
+      </div>
+      <div class="sd-card deprecated">
+        <div class="sd-key">skill<span class="sd-badge dep">deprecated</span></div>
+        <div class="sd-purpose">Top-level <code>skill:</code> — use <code>execution.skill</code></div>
+      </div>
+    </div>
+
+    <div class="sd-col score">
+      <div class="sd-group">Score · how it's judged</div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/judges/">judges[]</a>
+        <div class="sd-purpose">How each case is scored — four judge types</div>
+        <div class="sd-fields">
+          <span class="sd-f">name</span>
+          <span class="sd-f">description<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">if<span class="sd-badge py">PY</span></span>
+          <span class="sd-f">check<span class="sd-badge py">PY</span></span>
+          <span class="sd-f">prompt<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">prompt_file<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">llm_rubric<span class="sd-badge llm">LLM</span></span>
+          <span class="sd-f">builtin</span>
+          <span class="sd-f">module<span class="sd-badge py">PY</span></span>
+          <span class="sd-f">function<span class="sd-badge py">PY</span></span>
+          <span class="sd-f">context[]</span>
+          <span class="sd-f">model</span>
+          <span class="sd-f">arguments</span>
+          <span class="sd-f">samples</span>
+          <span class="sd-f">score_range</span>
+          <span class="sd-f">feedback_type</span>
+        </div>
+      </div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/thresholds/">thresholds</a>
+        <div class="sd-purpose">Regression gates per judge</div>
+        <div class="sd-fields">
+          <span class="sd-f">min_mean</span>
+          <span class="sd-f">min_pass_rate</span>
+          <span class="sd-f">min_win_rate</span>
+        </div>
+      </div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/reward/">reward</a>
+        <div class="sd-purpose">Collapse judges into an RL scalar in [0, 1]</div>
+        <div class="sd-fields">
+          <span class="sd-f">judge</span>
+          <span class="sd-f">normalize</span>
+          <span class="sd-f">formula<span class="sd-badge py">PY</span></span>
+          <span class="sd-f">weights</span>
+          <span class="sd-f">gate</span>
+          <span class="sd-f">score_range</span>
+          <span class="sd-f">raw[]</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="sd-col observe">
+      <div class="sd-group">Observe · what's captured</div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/mlflow/">mlflow</a>
+        <div class="sd-purpose">Experiment tracking — presence opts in</div>
+        <div class="sd-fields">
+          <span class="sd-f">experiment</span>
+          <span class="sd-f">tracking_uri</span>
+          <span class="sd-f">tags</span>
+        </div>
+      </div>
+      <div class="sd-card">
+        <a class="sd-key sd-link" href="../config/traces/">traces</a>
+        <div class="sd-purpose">Execution data captured for judges</div>
+        <div class="sd-fields">
+          <span class="sd-f">stdout</span>
+          <span class="sd-f">stderr</span>
+          <span class="sd-f">events</span>
+          <span class="sd-f">metrics</span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
 ## Top-level keys
 
 | Key | Purpose | Reference |

--- a/website/stylesheets/diagrams.css
+++ b/website/stylesheets/diagrams.css
@@ -227,7 +227,7 @@
 .schema-diagram .sd-col.score   .sd-card { --sd-bar: var(--sd-score); }
 .schema-diagram .sd-col.observe .sd-card { --sd-bar: var(--sd-observe); }
 .schema-diagram .sd-card:hover { border-color: var(--sd-bar, var(--md-default-fg-color--lighter)); }
-.schema-diagram .sd-card.deprecated { opacity: 0.65; }
+.schema-diagram .sd-card.deprecated { border-style: dashed; }
 
 .schema-diagram .sd-key {
   font-family: var(--md-code-font, monospace);
@@ -276,7 +276,7 @@
 .schema-diagram .sd-badge {
   margin-left: clamp(0.14rem, 0.5cqi, 0.28rem);
   padding: 0 0.26rem;
-  border: 1px solid currentColor;
+  border: 1px solid currentcolor;
   border-radius: 999px;
   font-family: var(--md-text-font, inherit);
   font-size: clamp(0.44rem, 1.15cqi, 0.56rem);

--- a/website/stylesheets/diagrams.css
+++ b/website/stylesheets/diagrams.css
@@ -137,3 +137,160 @@
 @media (prefers-reduced-motion: reduce) {
   .harbor-diagram .hd-box, .harbor-diagram .hd-edge { transition: none; }
 }
+
+/*
+ * Static, theme-aware eval.yaml schema map (embedded in reference/eval-yaml.md).
+ * Text, borders and surfaces use Material vars so the widget follows the
+ * light/dark toggle automatically. The four category hues and the two field
+ * badges are local tokens with a slate override — the same pattern as
+ * .harbor-diagram above.
+ */
+.schema-diagram {
+  --sd-define: #2563eb;
+  --sd-execute: #15803d;
+  --sd-score: #b45309;
+  --sd-observe: #7c3aed;
+  --sd-llm: #1d4ed8;
+  --sd-py: #92400e;
+
+  margin: 1.5em 0;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 12px;
+  container-type: inline-size;
+  padding: 1rem 1rem 1.15rem;
+  background: var(--md-default-bg-color);
+}
+
+[data-md-color-scheme="slate"] .schema-diagram {
+  --sd-define: #60a5fa;
+  --sd-execute: #4ade80;
+  --sd-score: #fbbf24;
+  --sd-observe: #a78bfa;
+  --sd-llm: #60a5fa;
+  --sd-py: #fbbf24;
+}
+
+.schema-diagram .sd-meta {
+  margin: 0 0 0.9rem;
+  font-size: clamp(0.58rem, 1.55cqi, 0.72rem);
+  line-height: 1.55;
+  color: var(--md-default-fg-color--light);
+}
+
+.schema-diagram .sd-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: clamp(0.4rem, 1.35cqi, 0.85rem);
+  align-items: start;
+}
+
+/* Phones / very narrow windows: four columns stop being legible — fall back
+   to two, preserving the Define → Execute → Score → Observe reading order.
+   Uses a viewport media query (reliable) rather than a container query. */
+@media screen and (max-width: 600px) {
+  .schema-diagram .sd-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media screen and (max-width: 430px) {
+  .schema-diagram .sd-grid { grid-template-columns: 1fr; }
+}
+
+.schema-diagram .sd-col {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.38rem, 1.05cqi, 0.6rem);
+  min-width: 0;
+}
+
+.schema-diagram .sd-group {
+  padding-left: 0.15rem;
+  font-size: clamp(0.52rem, 1.5cqi, 0.7rem);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+}
+.schema-diagram .sd-col.define  .sd-group { color: var(--sd-define); }
+.schema-diagram .sd-col.execute .sd-group { color: var(--sd-execute); }
+.schema-diagram .sd-col.score   .sd-group { color: var(--sd-score); }
+.schema-diagram .sd-col.observe .sd-group { color: var(--sd-observe); }
+
+.schema-diagram .sd-card {
+  position: relative;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-left: 3px solid var(--sd-bar, var(--md-default-fg-color--lighter));
+  border-radius: var(--doc-radius, 0.55rem);
+  padding: clamp(0.35rem, 1.05cqi, 0.5rem) clamp(0.4rem, 1.2cqi, 0.6rem) clamp(0.4rem, 1.15cqi, 0.55rem);
+  background: var(--md-default-bg-color);
+  transition: border-color 0.2s ease;
+}
+.schema-diagram .sd-col.define  .sd-card { --sd-bar: var(--sd-define); }
+.schema-diagram .sd-col.execute .sd-card { --sd-bar: var(--sd-execute); }
+.schema-diagram .sd-col.score   .sd-card { --sd-bar: var(--sd-score); }
+.schema-diagram .sd-col.observe .sd-card { --sd-bar: var(--sd-observe); }
+.schema-diagram .sd-card:hover { border-color: var(--sd-bar, var(--md-default-fg-color--lighter)); }
+.schema-diagram .sd-card.deprecated { opacity: 0.65; }
+
+.schema-diagram .sd-key {
+  font-family: var(--md-code-font, monospace);
+  font-size: clamp(0.6rem, 1.9cqi, 0.82rem);
+  font-weight: 700;
+  color: var(--md-default-fg-color);
+}
+
+/* Card title as a link; the ::after stretches over the whole card so a click
+   anywhere on the pane navigates to that key's reference page. */
+.schema-diagram a.sd-key {
+  text-decoration: none;
+  color: var(--md-default-fg-color);
+}
+.schema-diagram a.sd-key:hover { color: var(--sd-bar, var(--md-default-fg-color)); }
+.schema-diagram a.sd-link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.schema-diagram .sd-purpose {
+  margin: 0.12rem 0 0.42rem;
+  font-size: clamp(0.52rem, 1.5cqi, 0.71rem);
+  line-height: 1.4;
+  color: var(--md-default-fg-color--light);
+}
+
+.schema-diagram .sd-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(0.16rem, 0.5cqi, 0.28rem);
+}
+
+.schema-diagram .sd-f {
+  font-family: var(--md-code-font, monospace);
+  font-size: clamp(0.5rem, 1.45cqi, 0.68rem);
+  color: var(--md-default-fg-color);
+  background: var(--md-code-bg-color);
+  border-radius: 0.3rem;
+  padding: 0.06rem clamp(0.24rem, 0.7cqi, 0.36rem);
+  overflow-wrap: anywhere;
+}
+
+.schema-diagram .sd-badge {
+  margin-left: clamp(0.14rem, 0.5cqi, 0.28rem);
+  padding: 0 0.26rem;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  font-family: var(--md-text-font, inherit);
+  font-size: clamp(0.44rem, 1.15cqi, 0.56rem);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+.schema-diagram .sd-badge.llm { color: var(--sd-llm); }
+.schema-diagram .sd-badge.py  { color: var(--sd-py); }
+.schema-diagram .sd-badge.dep { color: var(--md-primary-fg-color); }
+
+.schema-diagram .sd-meta code { font-size: 0.9em; }
+
+@media (prefers-reduced-motion: reduce) {
+  .schema-diagram .sd-card { transition: none; }
+}


### PR DESCRIPTION
## Summary

Adds a visual **schema map** to the top of the `eval.yaml` reference page — a one-glance overview that groups every top-level key into the four stages **Define → Execute → Score → Observe**, sitting just above the existing key table.

- **Clickable panes** — each card links to that key's per-key reference page (`config/<key>/`); the whole card is a link.
- **Field tags** — fields are marked `LLM` (natural-language, interpreted by agents/judges) vs `PY` (Python code/expression), with `[]` for lists, reflecting the schema's core design.
- **Accurate** — content mirrors `agent_eval/config.py`: all top-level keys and fields, including `generation`, `hooks`, and `reward`; the deprecated top-level `skill` is shown as such.

## Implementation

- New `.schema-diagram` block in `website/stylesheets/diagrams.css`, following the existing `.harbor-diagram` house pattern: colours come from Material CSS variables with a `[data-md-color-scheme="slate"]` dark-mode override, so it follows the light/dark toggle.
- **Auto-fits the width** — font sizes, gaps and padding scale with the diagram's own width via container-query units (`cqi`) bounded by `clamp()`.
- **Responsive** — 4 columns on desktop/tablet, 2 at ≤600px, 1 at ≤430px; no horizontal overflow.
- Inline HTML via the already-enabled `md_in_html`; no `mkdocs.yml` change (the stylesheet is already loaded).

## Verification

- `mkdocs build` is clean with no link warnings; all 14 pane links resolve to existing `config/<key>/` pages.
- Headless-Chrome screenshots at 1280 / 960 / 700 / 500 px confirm the single-row → 2-col layout with no clipping or overflow.
- WCAG AA contrast checked for the group labels and `LLM`/`PY` badges in both light and dark mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a visual schema map to the `eval.yaml` reference, organized into Define, Execute, Score, and Observe stages.
  * Clarified that all top-level configuration keys are optional.
  * Added indicators for LLM text, Python expressions, and list-based fields.
  * Documented that `skill` is deprecated in favor of `execution.skill`.

* **Style**
  * Added responsive, theme-aware styling for the schema map, including category colors, interactive cards, and reduced-motion support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->