### PR TITLE
docs(website): sync site_description with reworked home page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,8 @@
 # Re-run that generator (or edit nav here directly once content stabilizes).
 site_name: Agent Eval Harness
 site_description: >-
-  Evaluation framework for Claude Code skills and agent capabilities, built on MLflow.
+  A generic evaluation framework for skills and agent capabilities — analyze, build a
+  dataset, run, score with LLM and code judges, and improve, all from one declarative eval.yaml.
 site_url: https://opendatahub-io.github.io/agent-eval-harness/
 repo_url: https://github.com/opendatahub-io/agent-eval-harness
 repo_name: opendatahub-io/agent-eval-harness
@@ -96,8 +97,10 @@ plugins:
   # (full concatenated docs) for coding agents / LLMs.
   - llmstxt:
       markdown_description: >-
-        Evaluation framework for Claude Code skills and agent capabilities,
-        built on MLflow for tracing, datasets, and reporting.
+        A generic evaluation framework for skills and agent capabilities, driven by a
+        single declarative eval.yaml — drive any agent runner (Claude Code, OpenCode),
+        run locally or on the Harbor and EvalHub backends, export rewards for RL training,
+        and record traces, datasets, and reports in MLflow.
       full_output: llms-full.txt
       sections:
         Getting started:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,7 +98,7 @@ plugins:
   - llmstxt:
       markdown_description: >-
         A generic evaluation framework for skills and agent capabilities, driven by a
-        single declarative eval.yaml — drive any agent runner (Claude Code, OpenCode),
+        single declarative eval.yaml — drive any agent harness (Claude Code, OpenCode, Pi, etc),
         run locally or on the Harbor and EvalHub backends, export rewards for RL training,
         and record traces, datasets, and reports in MLflow.
       full_output: llms-full.txt


### PR DESCRIPTION
## What

Update `site_description` (and the `llmstxt` export blurb) in `mkdocs.yml` to match the reworked home-page intro.

## Why

When you share the docs site on Slack, the link preview shows the **old** description that led with MLflow:

> Evaluation framework for Claude Code skills and agent capabilities, built on MLflow.

Slack's unfurl reads the page's `<meta name="description">` tag, which MkDocs Material fills from `site_description`. That string was never updated when 79f68d0 reworked the home page (`website/index.md`) to lead with the generic capability instead of MLflow — so the preview drifted out of sync with the actual home page. (There are no `og:`/`twitter:` tags — the Material `social` plugin isn't enabled — so `<meta name="description">` is exactly what Slack shows.)

## Changes

- **`site_description`** — now mirrors the home-page opening:
  > A generic evaluation framework for skills and agent capabilities — analyze, build a dataset, run, score with LLM and code judges, and improve, all from one declarative eval.yaml.
- **`llmstxt.markdown_description`** — same stale MLflow-led wording; realigned so MLflow reads as one integration among agent runners, backends, and RL rewards rather than the lead.

The home page has no `description:` frontmatter, so it inherits `site_description` — no other files needed changing.

## Notes

- Takes effect once merged and the GitHub Actions → Pages build redeploys.
- Slack caches link unfurls; to force a fresh preview immediately, paste the URL with a throwaway query param, e.g. `…/agent-eval-harness/?v=2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the site description to present the project as a general evaluation framework.
  * Clarified support for declarative `eval.yaml` workflows, multiple agent runners and backends, and evaluation exports, traces, and reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->