### PR TITLE
feat(traces): chain-of-thought-aware judging ({{ reasoning }}, per-case batch traces)

### DIFF
--- a/agent_eval/events.py
+++ b/agent_eval/events.py
@@ -126,8 +126,8 @@ def _extract_content_blocks(content_blocks, result_cap):
     """Split an assistant message's content blocks into (text, thinking, tools).
 
     Only string values are collected, so a null or non-string ``text`` /
-    ``thinking`` from a non-Anthropic provider (via the LiteLLM proxy) is
-    skipped rather than raising and aborting the whole parse. A
+    ``thinking`` from a non-Anthropic provider is skipped rather than raising
+    and aborting the whole parse. A
     ``redacted_thinking`` block contributes a marker so a fully-redacted turn
     isn't mistaken for an absence of reasoning. Multiple thinking blocks are
     joined with newlines to preserve their boundaries.

--- a/agent_eval/events.py
+++ b/agent_eval/events.py
@@ -122,18 +122,37 @@ def parse_stream_events(stdout_text, result_cap=DEFAULT_RESULT_CAP):
     return events
 
 
-def _parse_assistant_event(obj, result_cap):
-    message = obj.get("message", {})
-    content_blocks = message.get("content", [])
-    timestamp = obj.get("timestamp")
+def _extract_content_blocks(content_blocks, result_cap):
+    """Split an assistant message's content blocks into (text, thinking, tools).
 
+    Only string values are collected, so a null or non-string ``text`` /
+    ``thinking`` from a non-Anthropic provider (via the LiteLLM proxy) is
+    skipped rather than raising and aborting the whole parse. A
+    ``redacted_thinking`` block contributes a marker so a fully-redacted turn
+    isn't mistaken for an absence of reasoning. Multiple thinking blocks are
+    joined with newlines to preserve their boundaries.
+    """
     text_parts = []
+    thinking_parts = []
     tools = []
 
+    if not isinstance(content_blocks, list):
+        return "", "", tools
+
     for block in content_blocks:
+        if not isinstance(block, dict):
+            continue
         block_type = block.get("type")
         if block_type == "text":
-            text_parts.append(block.get("text", ""))
+            value = block.get("text")
+            if isinstance(value, str) and value:
+                text_parts.append(value)
+        elif block_type == "thinking":
+            value = block.get("thinking")
+            if isinstance(value, str) and value:
+                thinking_parts.append(value)
+        elif block_type == "redacted_thinking":
+            thinking_parts.append("[redacted thinking]")
         elif block_type == "tool_use":
             tool_input = _cap_values(block.get("input", {}), result_cap)
             tools.append({
@@ -142,12 +161,24 @@ def _parse_assistant_event(obj, result_cap):
                 "input": tool_input,
             })
 
+    return "".join(text_parts), "\n".join(thinking_parts), tools
+
+
+def _parse_assistant_event(obj, result_cap):
+    message = obj.get("message", {})
+    content_blocks = message.get("content", [])
+    timestamp = obj.get("timestamp")
+
+    text, thinking, tools = _extract_content_blocks(content_blocks, result_cap)
+
     event = {
         "type": "assistant",
-        "text": "".join(text_parts),
+        "text": text,
         "tools": tools,
         "timestamp": timestamp,
     }
+    if thinking:
+        event["thinking"] = thinking
 
     msg_id = message.get("id")
     if msg_id:
@@ -300,6 +331,12 @@ def merge_subagent_transcripts(events, subagent_dir, result_cap=DEFAULT_RESULT_C
         return events
 
     seen_msg_ids = _collect_message_ids(events)
+    # Map for backfilling richer fields onto an already-seen copy: an inline
+    # stdout copy of a subagent message carries no thinking block, so when the
+    # transcript copy (which does) is deduped by _msg_id we still recover its
+    # chain-of-thought instead of dropping it under all-or-nothing dedup.
+    events_by_msg_id = {e.get("_msg_id"): e for e in events
+                        if e.get("type") == "assistant" and e.get("_msg_id")}
     new_events = []
 
     for transcript in sorted(subagent_path.iterdir()):
@@ -324,6 +361,13 @@ def merge_subagent_transcripts(events, subagent_dir, result_cap=DEFAULT_RESULT_C
             msg = obj.get("message", {})
             msg_id = msg.get("id")
             if msg_id and msg_id in seen_msg_ids:
+                existing = events_by_msg_id.get(msg_id)
+                if (existing is not None and not existing.get("thinking")
+                        and msg.get("role") == "assistant"):
+                    parsed = _parse_transcript_assistant(
+                        obj, agent_id, result_cap)
+                    if parsed and parsed.get("thinking"):
+                        existing["thinking"] = parsed["thinking"]
                 continue
             if msg_id:
                 seen_msg_ids.add(msg_id)
@@ -332,6 +376,8 @@ def merge_subagent_transcripts(events, subagent_dir, result_cap=DEFAULT_RESULT_C
                 event = _parse_transcript_assistant(obj, agent_id, result_cap)
                 if event:
                     new_events.append(event)
+                    if event.get("_msg_id"):
+                        events_by_msg_id[event["_msg_id"]] = event
 
     if new_events:
         events.extend(new_events)
@@ -357,30 +403,19 @@ def _parse_transcript_assistant(obj, agent_id, result_cap=DEFAULT_RESULT_CAP):
     content_blocks = message.get("content", [])
     timestamp = obj.get("timestamp")
 
-    text_parts = []
-    tools = []
-
-    for block in content_blocks:
-        block_type = block.get("type")
-        if block_type == "text":
-            text_parts.append(block.get("text", ""))
-        elif block_type == "tool_use":
-            tool_input = _cap_values(block.get("input", {}), result_cap)
-            tools.append({
-                "name": block.get("name", ""),
-                "id": block.get("id", ""),
-                "input": tool_input,
-            })
+    text, thinking, tools = _extract_content_blocks(content_blocks, result_cap)
 
     parent_tool_use_id = obj.get("parent_tool_use_id")
 
     event = {
         "type": "assistant",
-        "text": "".join(text_parts),
+        "text": text,
         "tools": tools,
         "timestamp": timestamp,
         "agent_id": agent_id,
     }
+    if thinking:
+        event["thinking"] = thinking
 
     msg_id = message.get("id")
     if msg_id:
@@ -484,11 +519,26 @@ def _format_tool_input(name, tool_input):
     return "(no input)"
 
 
-def extract_conversation_text(events):
-    """Extract root-level assistant text from events.
+# Judge-facing guard: cap the reasoning-inclusive conversation so an unusually
+# verbose run can't overflow a judge prompt and silently error the judge call.
+# Generous enough (~100K tokens) that normal cases never reach it.
+CONVERSATION_THINKING_CAP = 400000
 
-    Filters out subagent events (those with parent_tool_use_id) and
-    concatenates assistant text blocks.
+
+def extract_conversation_text(events, include_thinking=False):
+    """Extract root-level assistant conversation from events.
+
+    Filters out subagent events (those with parent_tool_use_id) and, for each
+    remaining assistant turn, emits its visible text.
+
+    With ``include_thinking=True`` each turn's extended-thinking
+    (chain-of-thought) is emitted, labeled ``[thinking]``, before its visible
+    text — this lets a reasoning-quality judge grade the actual thought process
+    rather than the terse inter-tool narration. The default is text-only, so the
+    plain ``{{ conversation }}`` variable (consumed by other judges, e.g. the
+    safety judge that grades visible output) keeps its original semantics. The
+    reasoning-inclusive form is capped at ``CONVERSATION_THINKING_CAP`` chars
+    with a truncation marker.
     """
     parts = []
     for event in events:
@@ -496,7 +546,15 @@ def extract_conversation_text(events):
             continue
         if event.get("parent_tool_use_id"):
             continue
+        if include_thinking:
+            thinking = event.get("thinking", "")
+            if thinking:
+                parts.append(f"[thinking]\n{thinking}")
         text = event.get("text", "")
         if text:
             parts.append(text)
-    return "\n\n".join(parts)
+    rendered = "\n\n".join(parts)
+    if include_thinking and len(rendered) > CONVERSATION_THINKING_CAP:
+        rendered = (rendered[:CONVERSATION_THINKING_CAP]
+                    + "\n\n[conversation truncated]")
+    return rendered

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -186,7 +186,8 @@ Skills that modify input files using the Edit tool (rather than writing to an ou
 
 **Template variables in LLM judges**: All LLM judge prompts (both `prompt`/`prompt_file` and `builtin` LLM judges) are rendered with Jinja2. Available variables:
 - `{{ outputs }}` — renders ALL file entries including `_modified/` as markdown sections
-- `{{ conversation }}` — root-level assistant text from the JSONL event stream (excludes subagent text and tool calls)
+- `{{ conversation }}` — root-level assistant **visible** text from the JSONL event stream (excludes subagent text, tool calls, and extended-thinking)
+- `{{ reasoning }}` — like `{{ conversation }}` but also includes the model's extended-thinking (chain-of-thought), for reasoning-quality judges; capped at ~400K chars. Needs `traces.events: true`
 - `{{ inputs }}` — the case's `input.yaml` formatted as `**key**: value` per field (nested dict/list values are `yaml.safe_dump`ed for readability)
 - `{{ evidence }}` — a structured summary of what the agent actually did (turn count, cost, tools invoked, scripts executed, files read/written), derived from the parsed event stream. Extracted lazily and cached, only when the prompt references `{{ evidence }}`. Runner-agnostic — matches tool-name / input-key aliases across Claude Code, opencode, codex, responses-api
 - `{{ tool_trace }}` — chronological trace of tool calls (Read, Bash, Agent, etc.) with key inputs. Use for behavior judges (navigation, tool usage)
@@ -217,7 +218,7 @@ Use `{{ arguments.key }}` to parameterize prompts without editing the prompt tex
 - Example with arguments: `limit = arguments.get("max_chars", 10000)`
 
 **LLM judge** (`prompt` or `prompt_file` field):
-- All prompts are Jinja2 rendered with variables: `{{ outputs }}`, `{{ conversation }}`, `{{ inputs }}`, `{{ evidence }}`, `{{ tool_trace }}`, `{{ annotations }}`, `{{ arguments }}`
+- All prompts are Jinja2 rendered with variables: `{{ outputs }}`, `{{ conversation }}`, `{{ reasoning }}`, `{{ inputs }}`, `{{ evidence }}`, `{{ tool_trace }}`, `{{ annotations }}`, `{{ arguments }}`
 - `context` files are appended to the prompt
 - `arguments:` field makes prompts parameterizable without editing the prompt text
 - Returns `{"score": N, "rationale": "..."}` or `{"passed": bool, "rationale": "..."}`

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -141,6 +141,16 @@ def main():
     # Generate events.json from run-level stdout.log (shared across all cases)
     if config.traces.events:
         _generate_events_json(workspace, output_dir, config)
+        # In batch mode there is no per-case transcript; route each case's own
+        # subagent transcripts into a per-case events.json so judges that read
+        # {{ conversation }} see that case's reasoning, not the shared whole-batch
+        # trace. Unmapped cases keep the run-root fallback.
+        bp = next((o.batch_pattern for o in config.outputs
+                   if o.batch_pattern and "{" in o.batch_pattern), None)
+        routed = _route_subagent_events_per_case(
+            workspace, output_dir, case_order, bp)
+        if routed:
+            print(f"  routed per-case subagent traces for {routed} cases")
 
     if not results:
         print("WARNING: no artifacts collected", file=sys.stderr)
@@ -224,6 +234,96 @@ def _collect_per_case(workspace, output_dir, config):
 
     if not results:
         print("WARNING: no artifacts collected", file=sys.stderr)
+
+
+def _subagent_entity_num(transcript_path, prefix):
+    """Map a subagent transcript to the entity number it worked on, or None.
+
+    Batch runs assign each subagent an id like ``<prefix><n>`` (the numbering
+    the output batch_pattern uses). The opening task message carries it either
+    as an explicit ``ID=<prefix><n>`` or as the first ``<prefix><n>`` mention.
+    Returns the integer ``<n>``, or None when no id is present — in which case
+    the caller leaves that case on the shared run-root trace (never worse than
+    the prior behaviour).
+    """
+    import re
+    esc = re.escape(prefix)
+    try:
+        with open(transcript_path, encoding="utf-8", errors="replace") as fh:
+            first = fh.readline()
+    except OSError:
+        return None
+    try:
+        content = json.loads(first).get("message", {}).get("content", "")
+    except (json.JSONDecodeError, ValueError, AttributeError):
+        content = ""
+    if isinstance(content, list):
+        content = " ".join(
+            c.get("text", "") if isinstance(c, dict) else str(c) for c in content)
+    content = str(content)
+    m = (re.search(r'ID=' + esc + r'0*(\d+)', content)
+         or re.search(esc + r'0*(\d+)', content))
+    return int(m.group(1)) if m else None
+
+
+def _route_subagent_events_per_case(workspace, output_dir, case_order, batch_pattern):
+    """Write a per-case events.json from each case's own subagent transcripts.
+
+    In batch mode there is no per-case transcript, so judges that read
+    {{ conversation }} otherwise fall back to the shared whole-batch trace and
+    score every case against the same text. This maps each subagent transcript
+    to its case via the ``<prefix><n>`` id it processed (same numbering the
+    batch_pattern uses) and merges that case's transcripts into
+    cases/<case>/events.json, which score.py prefers over the run-root fallback.
+    Cases with no mapped transcript are left untouched (they keep the shared
+    fallback). Returns the number of cases given a per-case trace.
+    """
+    subdir = workspace / "subagents"
+    if not subdir.is_dir() or not batch_pattern or "{" not in batch_pattern:
+        return 0
+    prefix = batch_pattern.split("{", 1)[0]
+    if not prefix:
+        return 0
+    from collections import defaultdict
+    groups = defaultdict(list)
+    for tp in sorted(subdir.glob("*.jsonl")):
+        n = _subagent_entity_num(tp, prefix)
+        if n is not None:
+            groups[n].append(tp)
+    if not groups:
+        return 0
+
+    routed = 0
+    batch_idx = 1
+    for entry in case_order:
+        cid = entry["case_id"] if isinstance(entry, dict) else entry
+        count = entry.get("entry_count", 1) if isinstance(entry, dict) else 1
+        tps = [t for n in range(batch_idx, batch_idx + count)
+               for t in groups.get(n, [])]
+        batch_idx += count
+        if not tps:
+            continue
+        case_dir = output_dir / "cases" / _safe_path_component(cid, "case_id")
+        case_sub = case_dir / "subagents"
+        case_sub.mkdir(parents=True, exist_ok=True)
+        for tp in tps:
+            shutil.copy2(tp, case_sub / tp.name)
+        events = merge_subagent_transcripts([], str(case_sub),
+                                            result_cap=DEFAULT_RESULT_CAP)
+        dest = case_dir / "events.json"
+        fd, tmp_path = tempfile.mkstemp(dir=str(case_dir), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(events, f, indent=2)
+            os.rename(tmp_path, str(dest))
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        routed += 1
+    return routed
 
 
 def _generate_events_json(case_dir, output_case_dir, config):

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -145,8 +145,18 @@ def main():
         # subagent transcripts into a per-case events.json so judges that read
         # {{ conversation }} see that case's reasoning, not the shared whole-batch
         # trace. Unmapped cases keep the run-root fallback.
-        bp = next((o.batch_pattern for o in config.outputs
-                   if o.batch_pattern and "{" in o.batch_pattern), None)
+        # Routing keys on the batch_pattern's prefix (e.g. "RFE-" from
+        # "RFE-{n:03d}"). If placeholder outputs disagree on that prefix, one
+        # can't be chosen reliably — warn and use the first (unmapped cases
+        # still fall back to the run-root trace).
+        placeholder_bps = [o.batch_pattern for o in config.outputs
+                           if o.batch_pattern and "{" in o.batch_pattern]
+        prefixes = {b.split("{", 1)[0] for b in placeholder_bps}
+        if len(prefixes) > 1:
+            print(f"  WARNING: outputs use different batch-pattern prefixes "
+                  f"{sorted(prefixes)}; per-case trace routing uses the first",
+                  file=sys.stderr)
+        bp = placeholder_bps[0] if placeholder_bps else None
         routed = _route_subagent_events_per_case(
             workspace, output_dir, case_order, bp)
         if routed:
@@ -286,10 +296,18 @@ def _route_subagent_events_per_case(workspace, output_dir, case_order, batch_pat
         return 0
     from collections import defaultdict
     groups = defaultdict(list)
+    total = unmapped = 0
     for tp in sorted(subdir.glob("*.jsonl")):
+        total += 1
         n = _subagent_entity_num(tp, prefix)
         if n is not None:
             groups[n].append(tp)
+        else:
+            unmapped += 1
+    if unmapped:
+        print(f"  WARNING: {unmapped}/{total} subagent transcripts had no "
+              f"'{prefix}<n>' id marker; left on the shared run-root trace",
+              file=sys.stderr)
     if not groups:
         return 0
 

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -600,6 +600,12 @@ def _render_jinja2_template(template_text, arguments, outputs):
         from agent_eval.events import extract_conversation_text
         reasoning = extract_conversation_text(
             out["events"], include_thinking=True)
+    # Loud-not-silent: a judge referencing {{ reasoning }} with no event trace
+    # would silently score visible text only. Warn (reasoning needs traces.events).
+    if not out.get("events") and re.search(r"\{\{\s*reasoning\s*\}\}", template_text):
+        _TEMPLATE_LOGGER.warning(
+            "template references {{ reasoning }} but no event trace is available; "
+            "set traces.events: true — reasoning will be empty")
 
     # Pre-render case inputs for {{ inputs }}
     inputs_text = out.get("inputs", "")

--- a/skills/eval-run/scripts/score.py
+++ b/skills/eval-run/scripts/score.py
@@ -16,6 +16,7 @@ import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 import argparse
 import importlib
 import json
+import logging
 import os
 import re
 import sys
@@ -29,6 +30,14 @@ from typing import Optional
 import yaml
 
 from agent_eval.config import EvalConfig, _is_valid_eval_name, _validate_path_segment
+
+# Log (don't silently blank) any undefined variable a judge template references.
+_TEMPLATE_LOGGER = logging.getLogger("agent_eval.judge_template")
+if not _TEMPLATE_LOGGER.handlers:
+    _h = logging.StreamHandler(sys.stderr)
+    _h.setFormatter(logging.Formatter("judge-template WARNING: %(message)s"))
+    _TEMPLATE_LOGGER.addHandler(_h)
+    _TEMPLATE_LOGGER.setLevel(logging.WARNING)
 
 
 def _get_runs_dir(eval_name: str = ""):
@@ -550,11 +559,15 @@ def _render_jinja2_template(template_text, arguments, outputs):
     - {{ annotations }} - formatted text (via __str__), also supports
       {{ annotations.get('category') }} / {{ annotations.category }} access
     - {{ annotations_text }} - formatted annotation text for display
-    - {{ conversation }} - root-level assistant text from events
+    - {{ conversation }} - root-level assistant visible text from events
+    - {{ reasoning }} - conversation including extended-thinking
+      (chain-of-thought), for reasoning-quality judges
+    - {{ inputs }} - the case's input.yaml rendered as text
     - {{ tool_trace }} - chronological trace of tool calls (Read, Bash, etc.)
     """
-    from jinja2 import Environment
-    env = Environment()
+    from jinja2 import Environment, Undefined, make_logging_undefined
+    env = Environment(
+        undefined=make_logging_undefined(logger=_TEMPLATE_LOGGER, base=Undefined))
     env.filters["tojson"] = lambda v: json.dumps(v, indent=2, default=str)
 
     out = _OutputsProxy(outputs or {})
@@ -573,11 +586,20 @@ def _render_jinja2_template(template_text, arguments, outputs):
     # still supporting {{ annotations.get('category') }} structured access.
     ann = _AnnotationsProxy(ann_data, ann_text)
 
-    # Pre-render conversation text for {{ conversation }}
+    # Pre-render conversation text for {{ conversation }} (visible text only)
     conversation = out.get("conversation", "")
     if not conversation and out.get("events"):
         from agent_eval.events import extract_conversation_text
         conversation = extract_conversation_text(out["events"])
+
+    # Pre-render reasoning-inclusive conversation for {{ reasoning }}
+    # (chain-of-thought + text). Kept separate from {{ conversation }} so judges
+    # that grade visible output (e.g. safety) aren't fed the model's private CoT.
+    reasoning = out.get("reasoning", "")
+    if not reasoning and out.get("events"):
+        from agent_eval.events import extract_conversation_text
+        reasoning = extract_conversation_text(
+            out["events"], include_thinking=True)
 
     # Pre-render case inputs for {{ inputs }}
     inputs_text = out.get("inputs", "")
@@ -603,6 +625,7 @@ def _render_jinja2_template(template_text, arguments, outputs):
         annotations=ann,  # Formatted text via __str__, .get() for structured access
         annotations_text=ann_text,  # Formatted text for display
         conversation=conversation,
+        reasoning=reasoning,
         inputs=inputs_text,
         evidence=evidence_text,
         tool_trace=tool_trace,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -502,6 +502,209 @@ class TestConversationRendering:
         assert extract_conversation_text(events) == ""
 
 
+class TestThinkingPreservation:
+    """Extended-thinking (chain-of-thought) blocks must survive parsing and,
+    via extract_conversation_text(include_thinking=True), reach the
+    reasoning-quality judge through {{ reasoning }}. Without
+    this the judge grades only terse inter-tool narration (e.g. "DONE RFE-017").
+    The plain {{ conversation }} (include_thinking=False) stays visible-text-only
+    so judges that grade output (e.g. safety) don't see private CoT."""
+
+    def test_parse_stream_preserves_thinking(self):
+        """Main-stream assistant events keep thinking alongside text/tools."""
+        raw = {
+            "type": "assistant",
+            "message": {
+                "id": "msg_t1",
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking",
+                     "thinking": "Let me weigh the rubric criteria.",
+                     "signature": "sig"},
+                    {"type": "text", "text": "DONE RFE-017"},
+                    {"type": "tool_use", "name": "Write", "id": "tu_1",
+                     "input": {"file_path": "/f"}},
+                ],
+            },
+            "timestamp": "2026-04-14T20:00:01.000Z",
+        }
+        events = parse_stream_events(json.dumps(raw))
+        assert len(events) == 1
+        assert events[0]["thinking"] == "Let me weigh the rubric criteria."
+        assert events[0]["text"] == "DONE RFE-017"
+        assert events[0]["tools"][0]["name"] == "Write"
+
+    def test_parse_stream_no_thinking_key_when_absent(self):
+        """Events without thinking blocks omit the key (backward compatible)."""
+        raw = {
+            "type": "assistant",
+            "message": {"id": "msg_t2", "role": "assistant",
+                        "content": [{"type": "text", "text": "hi"}]},
+            "timestamp": "2026-04-14T20:00:01.000Z",
+        }
+        events = parse_stream_events(json.dumps(raw))
+        assert "thinking" not in events[0]
+
+    def test_parse_null_thinking_does_not_crash(self):
+        """A null/non-string thinking value (non-Anthropic provider) is skipped,
+        not fatal — otherwise the whole stream parse would abort."""
+        raw = {
+            "type": "assistant",
+            "message": {"id": "msg_n", "role": "assistant",
+                        "content": [
+                            {"type": "thinking", "thinking": None},
+                            {"type": "text", "text": "ok"},
+                        ]},
+            "timestamp": "2026-04-14T20:00:01.000Z",
+        }
+        events = parse_stream_events(json.dumps(raw))  # must not raise
+        assert events[0]["text"] == "ok"
+        assert "thinking" not in events[0]
+
+    def test_redacted_thinking_marker(self):
+        """redacted_thinking contributes a marker so a redacted turn isn't
+        mistaken for absence of reasoning."""
+        raw = {
+            "type": "assistant",
+            "message": {"id": "msg_r", "role": "assistant",
+                        "content": [
+                            {"type": "redacted_thinking", "data": "enc"},
+                            {"type": "tool_use", "name": "Read", "id": "tu_r",
+                             "input": {}},
+                        ]},
+            "timestamp": "2026-04-14T20:00:01.000Z",
+        }
+        events = parse_stream_events(json.dumps(raw))
+        assert events[0]["thinking"] == "[redacted thinking]"
+        assert "[redacted thinking]" in extract_conversation_text(
+            events, include_thinking=True)
+
+    def test_multiple_thinking_blocks_separated(self):
+        """Multiple thinking blocks in one message keep their boundaries."""
+        raw = {
+            "type": "assistant",
+            "message": {"id": "msg_m", "role": "assistant",
+                        "content": [
+                            {"type": "thinking", "thinking": "first"},
+                            {"type": "thinking", "thinking": "second"},
+                        ]},
+            "timestamp": "2026-04-14T20:00:01.000Z",
+        }
+        events = parse_stream_events(json.dumps(raw))
+        assert events[0]["thinking"] == "first\nsecond"
+
+    def test_merge_subagent_preserves_thinking(self, tmp_path):
+        """Subagent transcripts (the reasoning_quality source) keep thinking."""
+        subdir = tmp_path / "subagents"
+        subdir.mkdir()
+        transcript = [
+            {"message": {"id": "msg_s1", "role": "assistant",
+                         "content": [
+                             {"type": "thinking",
+                              "thinking": "Deliberating S/M/L sizing."},
+                             {"type": "text", "text": "sized M"},
+                         ]},
+             "timestamp": "2026-04-14T20:00:01.000Z"},
+        ]
+        (subdir / "agent-sub1.jsonl").write_text(
+            "\n".join(json.dumps(e) for e in transcript))
+        merged = merge_subagent_transcripts([], str(subdir))
+        assert len(merged) == 1
+        assert merged[0]["thinking"] == "Deliberating S/M/L sizing."
+        assert merged[0]["agent_id"] == "agent-sub1"
+
+    def test_merge_backfills_thinking_on_dedup(self, tmp_path):
+        """Case mode: a thinking-less stdout copy seen first gets its CoT
+        backfilled from the transcript copy rather than dropped."""
+        stream = {
+            "type": "assistant",
+            "parent_tool_use_id": "tu_agent",
+            "agent_id": "agent-sub1",
+            "message": {"id": "msg_dup", "role": "assistant",
+                        "content": [{"type": "tool_use", "name": "Read",
+                                     "id": "tu_x", "input": {"file_path": "/f"}}]},
+            "timestamp": "2026-04-14T20:00:01.000Z",
+        }
+        seed = parse_stream_events(json.dumps(stream))
+        assert "thinking" not in seed[0]
+
+        subdir = tmp_path / "subagents"
+        subdir.mkdir()
+        transcript = [
+            {"message": {"id": "msg_dup", "role": "assistant",
+                         "content": [
+                             {"type": "thinking", "thinking": "the real CoT"},
+                             {"type": "tool_use", "name": "Read", "id": "tu_x",
+                              "input": {"file_path": "/f"}},
+                         ]},
+             "timestamp": "2026-04-14T20:00:01.000Z"},
+        ]
+        (subdir / "agent-sub1.jsonl").write_text(
+            "\n".join(json.dumps(e) for e in transcript))
+        merged = merge_subagent_transcripts(seed, str(subdir))
+        dup = [e for e in merged if e.get("_msg_id") == "msg_dup"]
+        assert len(dup) == 1  # deduped, not duplicated
+        assert dup[0]["thinking"] == "the real CoT"
+
+    def test_conversation_default_excludes_thinking(self):
+        """Default extract stays visible-text-only (safety judge / baseline safe)."""
+        events = [
+            {"type": "assistant", "thinking": "private cot", "text": "visible",
+             "tools": [], "timestamp": "2026-04-14T20:00:01.000Z"},
+        ]
+        rendered = extract_conversation_text(events)  # include_thinking=False
+        assert rendered == "visible"
+        assert "private cot" not in rendered
+        assert "[thinking]" not in rendered
+
+    def test_conversation_includes_thinking_before_text(self):
+        """include_thinking emits thinking (labeled) before visible text."""
+        events = [
+            {"type": "assistant",
+             "thinking": "Deliberating S/M/L sizing.",
+             "text": "sized M", "tools": [],
+             "timestamp": "2026-04-14T20:00:01.000Z"},
+        ]
+        rendered = extract_conversation_text(events, include_thinking=True)
+        assert "[thinking]" in rendered
+        assert "Deliberating S/M/L sizing." in rendered
+        assert rendered.index("Deliberating") < rendered.index("sized M")
+
+    def test_conversation_thinking_only(self):
+        """A turn with only thinking (no visible text) still contributes."""
+        events = [
+            {"type": "assistant", "thinking": "pure reasoning", "text": "",
+             "tools": [], "timestamp": "2026-04-14T20:00:01.000Z"},
+        ]
+        assert "pure reasoning" in extract_conversation_text(
+            events, include_thinking=True)
+
+    def test_conversation_skips_subagent_thinking(self):
+        """Subagent-embedded events (parent_tool_use_id) remain filtered even
+        with include_thinking."""
+        events = [
+            {"type": "assistant", "thinking": "sub cot", "text": "sub text",
+             "tools": [], "parent_tool_use_id": "tu_agent",
+             "agent_id": "agent-001",
+             "timestamp": "2026-04-14T20:00:01.000Z"},
+        ]
+        assert extract_conversation_text(events, include_thinking=True) == ""
+
+    def test_conversation_thinking_capped(self):
+        """Reasoning-inclusive conversation is capped so a verbose run can't
+        overflow the judge prompt."""
+        from agent_eval.events import CONVERSATION_THINKING_CAP
+        big = "x" * (CONVERSATION_THINKING_CAP + 5000)
+        events = [
+            {"type": "assistant", "thinking": big, "text": "", "tools": [],
+             "timestamp": "2026-04-14T20:00:01.000Z"},
+        ]
+        rendered = extract_conversation_text(events, include_thinking=True)
+        assert rendered.endswith("[conversation truncated]")
+        assert len(rendered) <= CONVERSATION_THINKING_CAP + len(
+            "\n\n[conversation truncated]")
+
+
 
 # ---------------------------------------------------------------------------
 # T014: process quality judge pattern

--- a/website/concepts/judges.md
+++ b/website/concepts/judges.md
@@ -103,10 +103,12 @@ parsing, so key names come straight from disk. Commonly available keys:
 !!! tip "LLM judge template variables"
     Inside a `prompt`/`prompt_file`/`llm_rubric` template you also get convenience
     variables rendered from the record: `{{ outputs }}` (formatted file listing),
-    `{{ conversation }}`, `{{ tool_trace }}` (chronological tool calls),
-    `{{ inputs }}`, `{{ annotations }}`, `{{ evidence }}` (verifiable tool-call
-    summary), and `{{ arguments }}`. Use `{{ tool_trace }}` to judge *behaviour*
-    (navigation, tool usage) and `{{ conversation }}` to judge the *response*.
+    `{{ conversation }}` (visible text only), `{{ reasoning }}` (visible text plus
+    the model's extended-thinking / chain-of-thought, for reasoning-quality judges),
+    `{{ tool_trace }}` (chronological tool calls), `{{ inputs }}`, `{{ annotations }}`,
+    `{{ evidence }}` (verifiable tool-call summary), and `{{ arguments }}`. Use
+    `{{ tool_trace }}` to judge *behaviour* (navigation, tool usage) and
+    `{{ conversation }}` to judge the *response*.
 
 ## Boolean vs numeric values
 

--- a/website/cookbook/custom-judges.md
+++ b/website/cookbook/custom-judges.md
@@ -181,7 +181,8 @@ The prompt is rendered with these variables:
 | Variable | Value |
 | --- | --- |
 | `{{ outputs }}` | The record. Bare, it renders every artifact file as text; use `{{ outputs.files }}`, `{{ outputs.cost_usd }}`, etc. for structured access |
-| `{{ conversation }}` | Root-level assistant text from the event stream |
+| `{{ conversation }}` | Root-level assistant **visible** text from the event stream (excludes extended-thinking) |
+| `{{ reasoning }}` | `{{ conversation }}` plus the model's extended-thinking (chain-of-thought), for reasoning-quality judges |
 | `{{ inputs }}` | The case's `input.yaml`, formatted as `**key**: value` |
 | `{{ tool_trace }}` | Chronological trace of tool calls (Read, Bash, …) |
 | `{{ evidence }}` | Summary of verifiable tool evidence (turns, cost, files read/written) — derived only if referenced |
@@ -192,8 +193,8 @@ The prompt is rendered with these variables:
 !!! tip "Score scale vs. pass/fail"
     By default an LLM judge returns an integer **1–5 score** (aggregated as a mean). Set
     `feedback_type: bool` to make it a **pass/fail** judge (aggregated as a pass rate).
-    `{{ tool_trace }}` and `{{ evidence }}` need `traces.events: true`; `{{ conversation }}`
-    falls back to `stdout.log` when no events were captured.
+    `{{ tool_trace }}`, `{{ evidence }}`, and `{{ reasoning }}` need `traces.events: true`;
+    `{{ conversation }}` falls back to `stdout.log` when no events were captured.
 
 LLM judges are the only type that can be **sampled**. Set `samples: 3` to call the model
 several times per case and reduce the noise (median for scores, majority vote for

--- a/website/reference/config/judges.md
+++ b/website/reference/config/judges.md
@@ -129,7 +129,8 @@ LLM prompts (and `context` files) are rendered with these variables:
 | Variable | Contents |
 | --- | --- |
 | `{{ outputs }}` | File artifacts and modified files rendered as markdown. Also supports structured access: `{{ outputs.files }}`, `{{ outputs.events }}`. |
-| `{{ conversation }}` | Root-level assistant text (excludes subagent text and tool calls). |
+| `{{ conversation }}` | Root-level assistant **visible** text only (excludes subagent text, tool calls, and extended-thinking). |
+| `{{ reasoning }}` | Like `{{ conversation }}` but also includes the model's extended-thinking (chain-of-thought) — for reasoning-quality judges. Needs `traces.events: true`. |
 | `{{ tool_trace }}` | Chronological trace of tool calls (Read, Bash, Agent, …). |
 | `{{ inputs }}` | The case's `input.yaml` rendered as `**key**: value` per field. |
 | `{{ evidence }}` | Summary of tool activity (turns, cost, tools, files read/written). Lazily derived and cached. |


### PR DESCRIPTION
## What
- **`events.py`** — preserve extended-thinking (chain-of-thought) through the event pipeline. Shared `_extract_content_blocks()` for the main-stream and subagent parsers: collects `thinking` blocks (newline-joined), emits a `[redacted thinking]` marker, and skips null/non-string values so a non-Anthropic provider can't abort the whole parse. `merge_subagent_transcripts` backfills thinking onto an already-deduped event. `extract_conversation_text(include_thinking=)` (capped at `CONVERSATION_THINKING_CAP`).
- **`score.py`** — new **`{{ reasoning }}`** judge template variable (CoT + visible text). `{{ conversation }}` is now **visible-text-only**, so output/safety judges never see private chain-of-thought. Undefined judge-template variables now warn (`make_logging_undefined`) instead of rendering blank.
- **`collect.py`** — route per-case subagent traces in batch mode: each case gets its own `cases/<case>/events.json`, so judges stop scoring every case against the shared whole-batch trace.
- **docs** — document `{{ reasoning }}` and the `{{ conversation }}` visible-only clarification (reference/config/judges, concepts/judges, cookbook/custom-judges, data-pipeline).

## Why
The reasoning-quality judge was grading terse inter-tool narration (and, in batch mode, a shared whole-batch trace) instead of the model's actual chain-of-thought.

## Test plan
`pytest tests/test_events.py` → **49 passing** (12 new in `TestThinkingPreservation`: both parse paths, null/redacted/multi-block guards, dedup backfill, default-excludes-thinking, cap).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `{{ reasoning }}` for judge prompts, exposing extended thinking with a size cap.
  * Improved evaluation event handling and batch routing to generate per-case `events` from subagent transcripts.
  * Added clearer diagnostics when judge templates reference undefined variables.
* **Bug Fixes**
  * Preserved and backfilled extended thinking when merging duplicate transcript events, with consistent truncation and ordering in judge outputs.
* **Documentation**
  * Updated judge variable docs: `{{ conversation }}` is visible root-level text only; `{{ reasoning }}` includes extended thinking.
* **Tests**
  * Added end-to-end coverage for thinking preservation, truncation, and conversation formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
