### PR TITLE
feat(eval-run): console.log mirror, no-redirect launch, per-run cost header

### DIFF
--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -162,7 +162,9 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
   [--parallelism <n>]
 ```
 
-Launch with `run_in_background: true` (no pipes). **You must poll until the task completes** — do not end your turn while execute.py is running. Background tasks are killed when the session becomes idle: in `-p` mode, an `end_turn` exits the session immediately; in interactive mode, Claude Code SIGTERMs background tasks after ~55 minutes of inactivity. Poll progress every 2–3 minutes with `tail -20 <output_file>` to keep the session active. After completion, check `run_result.json` — if `exit_code` is non-zero, report the failure and stop. See `${CLAUDE_SKILL_DIR}/references/execution-monitoring.md` for polling patterns, problem detection, and CLI flag fallbacks.
+**Launch with `run_in_background: true` and do NOT redirect its output — no `>`, `|`, `tee`, or `2>&1`.** Claude Code's background-command viewer (and the output-file path the Bash tool returns) shows the process's *own* stdout/stderr stream; a redirect diverts that stream and leaves the viewer blank. You don't need a redirect for a stable log path: `execute.py` already mirrors its live console to `<output_dir>/console.log`.
+
+**You must poll until the task completes** — do not end your turn while execute.py is running. Background tasks are killed when the session becomes idle: in `-p` mode, an `end_turn` exits the session immediately; in interactive mode, Claude Code SIGTERMs background tasks after ~55 minutes of inactivity. **Monitor** every 2–3 minutes via the output-file path the Bash tool returns, or `tail -20 <output_dir>/console.log` (never a self-created redirect) — this tracks progress and keeps the session active. `execute.py` also emits a `WARNING:` if it detects its stdout was redirected into the run directory. After completion, check `run_result.json` — if `exit_code` is non-zero, report the failure and stop. See `${CLAUDE_SKILL_DIR}/references/execution-monitoring.md` for polling patterns, problem detection, and CLI flag fallbacks.
 
 ## Step 5: Collect Artifacts
 

--- a/skills/eval-run/references/execution-monitoring.md
+++ b/skills/eval-run/references/execution-monitoring.md
@@ -2,10 +2,14 @@
 
 ## Launching
 
-Launch execute.py using the Bash tool with `run_in_background: true`. **Do NOT
-pipe the command** through `tail`, `head`, `grep`, or any other filter — piping
-buffers all output and prevents progress monitoring. The command must be the bare
-`python3 ... execute.py ...` invocation with no pipes.
+Launch execute.py using the Bash tool with `run_in_background: true`, and **do NOT
+redirect or pipe its output** — no `>`, `|`, `tee`, `2>&1`, `tail`, `head`, or
+`grep`. Claude Code's background-command viewer (and the output-file path the Bash
+tool returns) shows the process's *own* stdout/stderr stream; any redirect or pipe
+diverts that stream and leaves the viewer blank. The command must be the bare
+`python3 ... execute.py ...` invocation. You don't need a redirect for a durable
+log: execute.py already mirrors its live console to `<output_dir>/console.log`, and
+emits a `WARNING:` if it detects its stdout was redirected into the run directory.
 
 ## Session lifecycle warning
 
@@ -20,15 +24,19 @@ modes:
   killed silently if no tool calls keep the session active.
 
 You must keep polling until execution completes. Poll every 2–3 minutes with
-`tail -20 <output_file>` — this keeps the session active and prevents the idle
+`tail -20 <output_file>` (the path the Bash tool returned) or
+`tail -20 <output_dir>/console.log` (the run dir passed via `--output`) — never a
+self-created redirect. Polling keeps the session active and prevents the idle
 timeout from firing.
 
 ## Monitoring progress
 
-Once launched, the Bash tool returns an output file path. Monitor by reading it:
+Once launched, the Bash tool returns an output file path. Monitor by reading it (or
+the stable `console.log` mirror) — never a self-created redirect:
 
 ```bash
-tail -20 <output_file>
+tail -20 <output_file>             # the path the Bash tool returned
+tail -20 <output_dir>/console.log  # execute.py's own mirrored console
 ```
 
 Look for phase markers (`## Phase`, `## Step`, `Batch N/M`), agent counts

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -49,6 +49,111 @@ _HARNESS_SYSTEM_PROMPT = (
 )
 
 
+class _Tee:
+    """Mirror writes to a real stream and a log file, flushing both.
+
+    Installed on ``sys.stdout``/``sys.stderr`` so execute.py populates the
+    background-command output stream (the real stdout/stderr that Claude
+    Code's viewer displays) AND a stable ``<output_dir>/console.log`` for
+    tailing. This removes any reason to redirect with ``>`` (which would
+    divert the real stream and leave the background viewer blank).
+    """
+
+    def __init__(self, stream, logfile):
+        self._stream = stream
+        self._logfile = logfile
+
+    def write(self, data):
+        n = self._stream.write(data)
+        try:
+            self._stream.flush()
+        except Exception:
+            pass
+        try:
+            self._logfile.write(data)
+            self._logfile.flush()
+        except Exception:
+            pass  # logging is best-effort; never break the run
+        return n
+
+    def flush(self):
+        for s in (self._stream, self._logfile):
+            try:
+                s.flush()
+            except Exception:
+                pass
+
+    def isatty(self):
+        try:
+            return self._stream.isatty()
+        except Exception:
+            return False
+
+    def fileno(self):
+        return self._stream.fileno()
+
+    def __getattr__(self, name):
+        # Delegate everything else (encoding, writable, buffer, …) to the
+        # real stream so the Tee is a faithful stand-in.
+        return getattr(self._stream, name)
+
+
+def _fd_path(fd):
+    """Best-effort absolute path backing a file descriptor, or None."""
+    try:
+        if sys.platform == "darwin":
+            import fcntl
+            F_GETPATH = 50  # macOS fcntl command: resolve an fd to its path
+            raw = fcntl.fcntl(fd, F_GETPATH, b"\0" * 1024)
+            return os.fsdecode(raw.split(b"\0", 1)[0])
+        return os.readlink(f"/proc/self/fd/{fd}")
+    except (OSError, ValueError, ImportError):
+        return None
+
+
+def _setup_console_log(output_dir):
+    """Mirror console output to ``<output_dir>/console.log`` and warn on a
+    stdout redirect into the run directory.
+
+    Claude Code's background-command viewer displays the launched process's
+    own stdout/stderr stream. Redirecting that stream to a file
+    (``python3 execute.py … > run/execute.log 2>&1``) leaves the viewer
+    blank. Teeing here gives a stable, tailable log without any redirect;
+    the guard flags the specific footgun of redirecting into the run dir
+    (the harness's own capture file lives in a separate temp tasks dir, so
+    this never false-fires on a correct background launch).
+
+    Returns the console.log Path, or None if it could not be opened.
+    """
+    console_log = output_dir / "console.log"
+    try:
+        fh = open(console_log, "w", buffering=1, encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    sys.stdout = _Tee(sys.stdout, fh)
+    sys.stderr = _Tee(sys.stderr, fh)
+    import atexit
+    atexit.register(fh.flush)
+
+    fd1 = _fd_path(1)
+    if fd1:
+        try:
+            p = Path(fd1).resolve()
+            out = output_dir.resolve()
+            if out == p or out in p.parents:
+                print(
+                    f"WARNING: execute.py stdout is redirected to {p}, inside the run "
+                    f"directory. Claude Code's background-command viewer shows the "
+                    f"process's own stdout stream and will appear BLANK. Re-launch "
+                    f"WITHOUT a '>' redirect (see eval-run SKILL.md Step 4); the live "
+                    f"console is already mirrored to {console_log}.",
+                    file=sys.stderr,
+                )
+        except OSError:
+            pass
+    return console_log
+
+
 def _resolve_permissions(config):
     """Return the permission rules to pass to the runner.
 
@@ -127,6 +232,11 @@ def main():
 
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Mirror all console output to <output_dir>/console.log so callers never
+    # need to redirect stdout with '>' (which blanks the background-command
+    # viewer). The real stdout/stderr streams still receive everything.
+    _setup_console_log(output_dir)
 
     # Resolve skill args: CLI override > config > empty
     # Treat empty/whitespace-only strings as unset (normalize before fallback)

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -77,6 +77,12 @@ def main():
         print("ERROR: run-id must match [A-Za-z0-9._-]+", file=sys.stderr)
         sys.exit(1)
 
+    # Auto-tag every model request with the run-id for per-run cost attribution.
+    # Configs whose execution.env references $EVAL_RUN_HEADER (e.g. eval-openrouter.yaml
+    # -> ANTHROPIC_CUSTOM_HEADERS) pick this up via _inject_env; other configs ignore it.
+    # Overriding here guarantees the tag always matches --run-id (no manual export).
+    os.environ["EVAL_RUN_HEADER"] = f"x-eval-run-id: {args.run_id}"
+
     # Create workspace in secure temp directory
     base_dir = (Path(tempfile.gettempdir()) / "agent-eval").resolve()
     workspace = (base_dir / args.run_id).resolve()


### PR DESCRIPTION
One of 4 independent PRs splitting a batch of eval-harness improvements (disjoint file sets — mergeable in any order).

## What
- **`execute.py`** — tee stdout/stderr to a stable `<output_dir>/console.log`, and WARN if stdout was redirected into the run dir (which blanks Claude Code's background-command viewer).
- **`SKILL.md`** Step 4 — launch with `run_in_background` and do **not** redirect output (no `>`, `|`, `tee`, `2>&1`); monitor via the Bash output-file path or `tail <output_dir>/console.log`.
- **`workspace.py`** — auto-set `EVAL_RUN_HEADER="x-eval-run-id: <run-id>"` so configs that map it into `execution.env` (e.g. `ANTHROPIC_CUSTOM_HEADERS` for a gateway) get per-run cost attribution without a manual export.
- **docs** — `references/execution-monitoring.md` updated to match (no-redirect rule, `console.log` mirror, redirect WARNING, `tail console.log` monitoring path).

## Why
Redirecting execute.py's output diverts the process's own stdout stream and leaves the background-command viewer blank, breaking the polling-to-keep-session-alive workflow; and per-run cost attribution previously required a manual `export`.

## Test plan
Behavioral (no unit tests): launch a background run and confirm `<output_dir>/console.log` is written, the viewer shows live output, and a stdout redirect triggers the WARNING.
