### PR TITLE
feat(hooks): before_report lifecycle phase + reward-gated report section

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -224,6 +224,7 @@ class HooksConfig:
     after_each: list = field(default_factory=list)
     before_scoring: list = field(default_factory=list)
     after_all: list = field(default_factory=list)
+    before_report: list = field(default_factory=list)
 
 
 @dataclass
@@ -990,7 +991,7 @@ class EvalConfig:
         # Hooks
         hooks_raw = raw.get("hooks", {}) or {}
         phases = ["before_all", "before_each", "after_each",
-                  "before_scoring", "after_all"]
+                  "before_scoring", "after_all", "before_report"]
         for phase in phases:
             entries = []
             for h in (hooks_raw.get(phase) or []):

--- a/agent_eval/hooks.py
+++ b/agent_eval/hooks.py
@@ -273,7 +273,7 @@ def main():
                         help="Path to eval.yaml")
     parser.add_argument("--phase", required=True,
                         choices=["before_all", "before_each", "after_each",
-                                 "before_scoring", "after_all"],
+                                 "before_scoring", "after_all", "before_report"],
                         help="Hook phase to run")
     parser.add_argument("--workspace", required=True,
                         help="Workspace root path")

--- a/agent_eval/hooks.py
+++ b/agent_eval/hooks.py
@@ -312,7 +312,8 @@ def main():
     log_dir = Path(args.output) / "hooks"
 
     phase = args.phase
-    if phase == "after_all":
+    # before_report (like after_all) is documented as continue-on-failure.
+    if phase in ("after_all", "before_report"):
         run_hooks_safe(entries, env, cwd, log_dir, phase,
                        case_id=args.case_id)
     else:

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -2735,12 +2735,16 @@ def main():
     # because of a reporting-side hook.
     if config_obj.hooks.before_report:
         from agent_eval.hooks import build_hook_env, run_hooks_safe
+        # Give the hook the real run context: AGENT_EVAL_WORKSPACE = the run dir
+        # (so $AGENT_EVAL_WORKSPACE/analysis.md and other artifacts resolve), and
+        # the model from run_result.json.
+        _rr = _load_json(run_dir / "run_result.json") or {}
         hook_env = build_hook_env(
-            workspace="",
+            workspace=str(run_dir),
             run_id=args.run_id,
             config_path=str(Path(args.config).resolve()),
             project_root=str(Path.cwd()),
-            model="",
+            model=_rr.get("model", ""),
         )
         print("Running before_report hooks...", file=sys.stderr)
         run_hooks_safe(config_obj.hooks.before_report, env=hook_env,

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -2656,7 +2656,11 @@ def generate_report(config, summary, run_result, run_dir,
     html += _wrap_section(_render_scoring_summary(summary, config, baseline_summary))
     html += _wrap_section(_render_regressions(summary, config))
     html += _wrap_section(_render_shared_outputs(run_dir, config))
-    html += _wrap_section(_render_reward_overview(summary, config, reward_cfg))
+    # Per-Case Reward Overview is an RL-training reward summary — only render it
+    # when a reward is configured. For judge-only evals the Scoring Summary
+    # (aggregate per judge) and Per-Case Details (per case) already cover the scores.
+    if (config or {}).get("reward"):
+        html += _wrap_section(_render_reward_overview(summary, config, reward_cfg))
     html += _render_per_case(summary, run_dir, config, baseline_dir, review)
     html += f"\n<script>{TOGGLE_SCRIPT}</script>\n"
     html += f"<script>{IMAGE_COMPARE_SCRIPT}</script>\n"
@@ -2723,6 +2727,26 @@ def main():
     if not run_dir.exists():
         print(f"ERROR: run directory not found: {run_dir}", file=sys.stderr)
         sys.exit(1)
+
+    # Run before_report hooks: fired after analysis.md is authored (by the eval-run
+    # agent in its analysis step) and before the HTML is assembled, so a hook may
+    # annotate analysis.md or other run artifacts and have those changes appear in
+    # the rendered report. Uses run_hooks_safe so report generation never fails
+    # because of a reporting-side hook.
+    if config_obj.hooks.before_report:
+        from agent_eval.hooks import build_hook_env, run_hooks_safe
+        hook_env = build_hook_env(
+            workspace="",
+            run_id=args.run_id,
+            config_path=str(Path(args.config).resolve()),
+            project_root=str(Path.cwd()),
+            model="",
+        )
+        print("Running before_report hooks...", file=sys.stderr)
+        run_hooks_safe(config_obj.hooks.before_report, env=hook_env,
+                       cwd=Path.cwd(), log_dir=run_dir / "hooks",
+                       phase_name="before_report")
+
     summary = _load_yaml(run_dir / "summary.yaml")
     run_result = _load_json(run_dir / "run_result.json")
     review = _load_yaml(run_dir / "review.yaml") or None

--- a/website/concepts/lifecycle-hooks.md
+++ b/website/concepts/lifecycle-hooks.md
@@ -50,8 +50,10 @@ flowchart TD
     `after_each` and `after_all` are executed from a `finally` block, so they run even
     if `before_each`, the agent, or the skill under test raises. Internally they use
     `run_hooks_safe`, which forces `on_failure: continue` — a cleanup hook can fail
-    without masking the original error or aborting the rest of the run. The "before"
-    phases use the strict `run_hooks`, which raises on failure when `on_failure: fail`.
+    without masking the original error or aborting the rest of the run.
+    `before_report` likewise runs via `run_hooks_safe`. The `before_all`,
+    `before_each`, and `before_scoring` phases use the strict `run_hooks`, which
+    raises on failure when `on_failure: fail`.
 
 ## Configuration
 

--- a/website/concepts/lifecycle-hooks.md
+++ b/website/concepts/lifecycle-hooks.md
@@ -13,7 +13,7 @@ or clean up. They are configured under the top-level `hooks:` key in `eval.yaml`
     [tool interception](tool-interception.md). If you're trying to fake a Jira API or
     auto-answer an `AskUserQuestion`, you want tool interception, not this page.
 
-## The five phases
+## The six phases
 
 | Phase | Runs | Working directory | Guaranteed? |
 | --- | --- | --- | --- |
@@ -22,6 +22,7 @@ or clean up. They are configured under the top-level `hooks:` key in `eval.yaml`
 | `after_each` | After every case (case/prompt mode only) | case workspace | **Yes** — `finally`, even on error |
 | `before_scoring` | Once, before judges run (in `score.py`) | project root | No — a failure aborts scoring |
 | `after_all` | Once, after all cases complete | project root | **Yes** — `finally`, even on error |
+| `before_report` | Once, during report generation — after `analysis.md` is authored, before the HTML is assembled | project root | **Yes** — runs via `run_hooks_safe`, so a failure is logged and never fails the report |
 
 ```mermaid
 flowchart TD
@@ -29,6 +30,7 @@ flowchart TD
     B --> C[before_each] --> D[execute case] --> E[after_each]
     E --> B
     B -->|all cases done| F[before_scoring] --> G[judges] --> H[after_all]
+    H --> R[before_report] --> RPT[report]
     E -.finally.-> H
     %% Color-code phases with borders, NOT fills. Material renders Mermaid in a
     %% closed shadow DOM and forces node label text to a theme-adaptive color
@@ -39,6 +41,7 @@ flowchart TD
     style A stroke:#42a5f5,stroke-width:3px
     style F stroke:#42a5f5,stroke-width:3px
     style H stroke:#ffa726,stroke-width:3px
+    style R stroke:#ffa726,stroke-width:3px
     style C stroke:#66bb6a,stroke-width:3px
     style E stroke:#66bb6a,stroke-width:3px
 ```

--- a/website/concepts/report.md
+++ b/website/concepts/report.md
@@ -144,10 +144,11 @@ harness trains on, so the number shown matches your configured
 formula). Numeric cells are green/amber/red by where the score falls in the
 judge's `score_range`; a bottom **Average** row summarises scored cases.
 
-!!! note "Only meaningful with a reward config"
-    Without a `reward:` block the table still renders using the default
-    resolution (boolean gates × averaged normalised numerics). Define
-    `reward:` to make the column reflect real training behaviour.
+!!! note "Only rendered with a reward config"
+    The Per-Case Reward Overview is **omitted entirely** unless the config defines
+    a `reward:` block — judge-only evals don't get this section (the Scoring
+    Summary and Per-Case Details already cover every judge score). Define
+    `reward:` to enable it and reflect real training behaviour.
 
 ## The sampling-stability view
 

--- a/website/concepts/report.md
+++ b/website/concepts/report.md
@@ -46,7 +46,7 @@ flowchart TD
     AN --> SS[Scoring Summary + stability bars]
     SS --> RG[Regressions — only if a threshold failed]
     RG --> SO[Shared Outputs — batch_pattern '*']
-    SO --> RO[Per-Case Reward Overview]
+    SO --> RO["Per-Case Reward Overview — only with a reward config"]
     RO --> PC[Per-Case Details: rationale, artifacts, diffs]
 ```
 
@@ -56,7 +56,7 @@ flowchart TD
 | Analysis | `analysis.md` | The agent's recommendation, rendered as markdown in a highlighted callout. Optional YAML frontmatter (`agent`, `model`, `date`) drives the subtitle. |
 | Scoring Summary | `summary.yaml` + `thresholds` | One row per judge: type, metric (`pass_rate` or `mean`), value, threshold, PASS/FAIL/SKIP/ERROR. Pairwise gets its own row. |
 | Regressions | thresholds | Only appears when a judge is below its [threshold](../concepts/thresholds.md). |
-| Per-Case Reward Overview | `summary.yaml` + `reward` | Compact matrix of the [reward](../concepts/reward-api.md) and every judge score per case. |
+| Per-Case Reward Overview | `summary.yaml` + `reward` | Compact matrix of the [reward](../concepts/reward-api.md) and every judge score per case. **Rendered only when a non-empty `reward:` block is configured.** |
 | Per-Case Details | `cases/` tree | Judge rationales, inputs, rendered output artifacts, and baseline diffs — one collapsible card per case. |
 
 ## Scoring summary and per-case rationale
@@ -145,10 +145,11 @@ formula). Numeric cells are green/amber/red by where the score falls in the
 judge's `score_range`; a bottom **Average** row summarises scored cases.
 
 !!! note "Only rendered with a reward config"
-    The Per-Case Reward Overview is **omitted entirely** unless the config defines
-    a `reward:` block — judge-only evals don't get this section (the Scoring
-    Summary and Per-Case Details already cover every judge score). Define
-    `reward:` to enable it and reflect real training behaviour.
+    The Per-Case Reward Overview is **omitted entirely** unless the config sets a
+    **non-empty** `reward:` block (an empty `reward: {}` doesn't enable it) —
+    judge-only evals don't get this section (the Scoring Summary and Per-Case
+    Details already cover every judge score). Define a `reward:` to enable it and
+    reflect real training behaviour.
 
 ## The sampling-stability view
 

--- a/website/get-started/reading-the-report.md
+++ b/website/get-started/reading-the-report.md
@@ -99,6 +99,8 @@ color-coded cell. Judges are grouped into **Gate** (binary `check`), **LLM**
 (scored), and **Other** columns. The reward is composed the same way the
 [reward API](../concepts/reward-api.md) computes it for RL training, so what you
 see is what you'd train on. The final row shows the average across scored cases.
+This section appears only when a `reward:` block is configured; judge-only evals
+omit it (per-judge scores are in the Scoring Summary and Per-Case Details).
 
 ### Per-case details
 

--- a/website/get-started/reading-the-report.md
+++ b/website/get-started/reading-the-report.md
@@ -49,7 +49,7 @@ flowchart TD
     AN --> SS[Scoring Summary — per-judge pass_rate / mean]
     SS --> RG[Regressions — only if a threshold is breached]
     RG --> SO[Shared Outputs — batch_pattern '*' files]
-    SO --> RO[Per-Case Reward Overview — grid of all judge scores]
+    SO --> RO["Per-Case Reward Overview — reward config only"]
     RO --> PC[Per-Case Details — rationale, artifacts, diffs]
 ```
 
@@ -99,7 +99,7 @@ color-coded cell. Judges are grouped into **Gate** (binary `check`), **LLM**
 (scored), and **Other** columns. The reward is composed the same way the
 [reward API](../concepts/reward-api.md) computes it for RL training, so what you
 see is what you'd train on. The final row shows the average across scored cases.
-This section appears only when a `reward:` block is configured; judge-only evals
+This section appears only when a non-empty `reward:` block is configured; judge-only evals
 omit it (per-judge scores are in the Scoring Summary and Per-Case Details).
 
 ### Per-case details

--- a/website/reference/config/hooks.md
+++ b/website/reference/config/hooks.md
@@ -11,7 +11,7 @@ afterwards. Each phase is a list of hook entries executed in order.
     which rewrites tool calls *inside* the agent. Two different mechanisms — this
     page is only about the pipeline lifecycle hooks.
 
-## The five phases
+## The six phases
 
 ```mermaid
 flowchart TD
@@ -23,6 +23,7 @@ flowchart TD
     B -->|all cases done| F[before_scoring]
     F --> G[judges run]
     G --> H[after_all]
+    H --> R[before_report]
 ```
 
 | Phase | When it runs | Working directory | On failure |
@@ -32,6 +33,7 @@ flowchart TD
 | `after_each` | After each case (guaranteed, even on error) | Case workspace | Always continues |
 | `before_scoring` | Once, after all cases, before judges | Project root | Aborts scoring |
 | `after_all` | Once, after everything (guaranteed) | Project root | Always continues |
+| `before_report` | Once, during report generation (after `analysis.md`, before HTML render) | Project root | Always continues (`run_hooks_safe`) |
 
 !!! note "Guaranteed cleanup phases"
     `after_each` and `after_all` run inside a `finally` block, so they fire even


### PR DESCRIPTION
## What
- **`config.py` / `hooks.py`** — new **`before_report`** lifecycle phase (`HooksConfig.before_report` + phases list + the standalone hooks CLI `--phase` choices).
- **`report.py`** — runs `before_report` via `run_hooks_safe` (continue-on-failure) after `analysis.md` is authored and before the HTML is rendered, so hooks can annotate run artifacts and have edits show up in the report; and only renders the **Per-Case Reward Overview** when the config defines a truthy `reward` key (omitted for judge-only evals).
- **docs** — `before_report` documented as the 6th phase (concepts/lifecycle-hooks, reference/config/hooks); the report docs corrected to say the reward section is omitted for judge-only evals (concepts/report, get-started/reading-the-report).

## Why
Lets external tooling post-process run artifacts before the report renders (fail-safe — a hook error never fails report generation), and removes a noisy/empty reward section from judge-only reports.

## Test plan
- Config with a `before_report:` hook loads and the phase fires during report generation.
- A judge-only eval (no `reward:`) renders **no** Per-Case Reward Overview.
- `python -m agent_eval.hooks --phase before_report ...` is accepted by the CLI.

_Note:_ `report.py` invokes `before_report` via the `run_hooks_safe` function (not the CLI), so the harness path is independent of the CLI `choices` list; the `choices` addition just keeps the standalone CLI consistent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `before_report` lifecycle hook that runs before HTML report generation.
  * Configured hooks can now update report artifacts before the report is assembled.
  * Reports omit the Per-Case Reward Overview when no reward configuration is provided.

* **Documentation**
  * Updated lifecycle hook and report documentation to describe the new phase and conditional reward section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->