### PR TITLE
feat(harbor): per-model usage breakdown + fix placeholder-model accounting

### DIFF
--- a/agent_eval/agent/stream_capture.py
+++ b/agent_eval/agent/stream_capture.py
@@ -49,6 +49,19 @@ def inject_timestamp(line: str) -> str:
 
 # ── Usage extraction ─────────────────────────────────────────────────
 
+def _is_real_model(name):
+    """Whether ``name`` is a genuine model, not a Claude Code placeholder.
+
+    Claude Code stamps some assistant messages with a bracketed pseudo-model
+    such as ``"<synthetic>"`` — zero-token placeholder turns it materializes
+    itself (e.g. a turn terminated by a stop sequence, which has no
+    server-attributed model). These must be excluded from model/turn
+    accounting, otherwise the pseudo-model surfaces as a spurious "subagent
+    model" and pollutes per-model turn counts.
+    """
+    return bool(name) and not (name.startswith("<") and name.endswith(">"))
+
+
 def extract_usage(stdout_lines):
     """Extract token usage, cost, turns, and models from stream-json events.
 
@@ -92,16 +105,19 @@ def extract_usage(stdout_lines):
         if obj.get("type") == "assistant":
             msg_id = obj.get("message", {}).get("id")
             model = obj.get("message", {}).get("model")
+            # Keep placeholder turns in seen_msg_ids (they are real stream
+            # turns for dedup/total counting), but exclude their pseudo-model
+            # from per-model accounting and models_seen.
             if msg_id:
                 seen_msg_ids.add(msg_id)
-                if model:
+                if _is_real_model(model):
                     seen_msg_ids_by_model.setdefault(model, set()).add(msg_id)
             u = obj.get("message", {}).get("usage", {})
             fb_input += u.get("input_tokens", 0)
             fb_output += u.get("output_tokens", 0)
             fb_cache_read += u.get("cache_read_input_tokens", 0)
             fb_cache_create += u.get("cache_creation_input_tokens", 0)
-            if model:
+            if _is_real_model(model):
                 models_seen.add(model)
         elif obj.get("type") == "result":
             cost_usd = obj.get("total_cost_usd", cost_usd)
@@ -227,7 +243,7 @@ def count_subagent_turns_by_model(subagent_dir, already_seen_by_model=None):
                     if msg.get("role") == "assistant":
                         msg_id = msg.get("id")
                         model = msg.get("model")
-                        if msg_id and model:
+                        if msg_id and _is_real_model(model):
                             seen.setdefault(model, set()).add(msg_id)
         except OSError:
             continue

--- a/agent_eval/harbor/results.py
+++ b/agent_eval/harbor/results.py
@@ -21,10 +21,34 @@ def _case_id_from_dir(trial_dir: Path) -> str:
     return name.rsplit("__", 1)[0] if "__" in name else name
 
 
+def _merge_per_model(acc: dict, pmu: dict | None) -> None:
+    """Accumulate a per-model usage dict into ``acc`` (sum per model, per key).
+
+    Used to aggregate per-model token/cost breakdowns across steps (multi-step
+    trials) and across trials (whole job). None-safe on both the source dict and
+    individual values.
+    """
+    if not pmu:
+        return
+    for model, stats in pmu.items():
+        if not isinstance(stats, dict):
+            continue
+        dst = acc.setdefault(model, {"input": 0, "output": 0,
+                                     "cache_read": 0, "cache_create": 0,
+                                     "cost_usd": None})
+        for k in ("input", "output", "cache_read", "cache_create"):
+            v = stats.get(k)
+            if isinstance(v, (int, float)):
+                dst[k] = (dst[k] or 0) + v
+        c = stats.get("cost_usd")
+        if isinstance(c, (int, float)):
+            dst["cost_usd"] = (dst["cost_usd"] or 0) + c
+
+
 def _extract_transcript_metrics(transcript_path: Path) -> dict:
     """Extract cost, tokens, turns, duration, version from a stream-json transcript."""
     result: dict = {
-        "cost_usd": None, "token_usage": None,
+        "cost_usd": None, "token_usage": None, "per_model_usage": None,
         "num_turns": None, "duration_s": None, "agent_version": None,
     }
     if not transcript_path.is_file():
@@ -57,6 +81,24 @@ def _extract_transcript_metrics(transcript_path: Path) -> dict:
                         "cache_read": usage.get("cache_read_input_tokens"),
                         "cache_create": usage.get("cache_creation_input_tokens"),
                     }
+                # Per-model breakdown from the result event's modelUsage (same
+                # source the local runner uses in stream_capture.py) — enables
+                # per-model columns in the report's Model Usage table.
+                mu = ev.get("modelUsage")
+                if isinstance(mu, dict) and mu:
+                    pmu = {}
+                    for mname, st in mu.items():
+                        if not isinstance(st, dict):
+                            continue
+                        pmu[mname] = {
+                            "input": st.get("inputTokens", 0) or 0,
+                            "output": st.get("outputTokens", 0) or 0,
+                            "cache_read": st.get("cacheReadInputTokens", 0) or 0,
+                            "cache_create": st.get("cacheCreationInputTokens", 0) or 0,
+                            "cost_usd": st.get("costUSD"),
+                        }
+                    if pmu:
+                        result["per_model_usage"] = pmu
     except OSError:
         pass
     return result
@@ -96,6 +138,7 @@ def _errored_trial_record(trial_dir: Path) -> dict:
         "trial_error": reason,
         "cost_usd": None,
         "token_usage": None,
+        "per_model_usage": None,
         "num_turns": None,
         "duration_s": None,
         "agent_version": None,
@@ -148,6 +191,7 @@ def parse_trial(trial_dir: Path) -> dict | None:
         "infra_error_steps": [],
         "cost_usd": None,
         "token_usage": None,
+        "per_model_usage": None,
     }
 
     # Agent execution metrics from Harbor's trial result.json (cost/tokens).
@@ -182,6 +226,7 @@ def parse_trial(trial_dir: Path) -> dict | None:
     record["num_turns"] = extracted.get("num_turns")
     record["duration_s"] = extracted.get("duration_s")
     record["agent_version"] = extracted.get("agent_version")
+    record["per_model_usage"] = extracted.get("per_model_usage")
 
     # Richer sidecar (values + rationales) when present.
     judges_path = trial_dir / "verifier" / "judges.json"
@@ -215,6 +260,7 @@ def _parse_multi_step_trial(trial_dir: Path, steps_dir: Path) -> dict | None:
     total_turns = 0
     total_duration = 0.0
     token_totals: dict = {}
+    per_model_totals: dict = {}
     agent_version = None
 
     for step_dir in step_dirs:
@@ -284,6 +330,7 @@ def _parse_multi_step_trial(trial_dir: Path, steps_dir: Path) -> dict | None:
         for k, v in (extracted.get("token_usage") or {}).items():
             if isinstance(v, (int, float)):
                 token_totals[k] = token_totals.get(k, 0) + v
+        _merge_per_model(per_model_totals, extracted.get("per_model_usage"))
 
     mean_reward = sum(rewards) / len(rewards) if rewards else None
 
@@ -315,6 +362,7 @@ def _parse_multi_step_trial(trial_dir: Path, steps_dir: Path) -> dict | None:
         "infra_error_steps": infra_error_steps,
         "cost_usd": total_cost if total_cost > 0 else None,
         "token_usage": token_totals or None,
+        "per_model_usage": per_model_totals or None,
         "num_turns": total_turns if total_turns > 0 else None,
         "duration_s": total_duration if total_duration > 0 else None,
         "agent_version": agent_version,
@@ -371,6 +419,9 @@ def parse_job(job_dir: Path) -> dict:
         for k, v in (t.get("token_usage") or {}).items():
             if isinstance(v, (int, float)):
                 token_usage[k] = token_usage.get(k, 0) + v
+    per_model_usage: dict = {}
+    for t in trials:
+        _merge_per_model(per_model_usage, t.get("per_model_usage"))
 
     # Aggregate turns, duration, and pick agent version from trials.
     turn_values = [t["num_turns"] for t in trials
@@ -412,6 +463,7 @@ def parse_job(job_dir: Path) -> dict:
         "aggregated": aggregated,
         "cost_usd": total_cost,
         "token_usage": token_usage or None,
+        "per_model_usage": per_model_usage or None,
         "num_turns": total_turns,
         "duration_s": wall_clock_s or total_agent_duration,
         "agent_duration_s": total_agent_duration,

--- a/agent_eval/harbor/run.py
+++ b/agent_eval/harbor/run.py
@@ -304,6 +304,7 @@ def run_eval_on_harbor(
         "mean_reward": parsed["mean_reward"],
         "cost_usd": parsed.get("cost_usd"),
         "token_usage": parsed.get("token_usage"),
+        "per_model_usage": parsed.get("per_model_usage"),
         "harbor_job_dir": parsed["job_dir"],
         "n_infra_errors": parsed.get("n_infra_errors", 0),
         "infra_errors": parsed.get("infra_errors", []),

--- a/tests/test_harbor_results.py
+++ b/tests/test_harbor_results.py
@@ -203,3 +203,38 @@ def test_trial_error_reason_is_sanitized(tmp_path):
     assert "\x1b" not in reason and "\t" not in reason   # raw control chars gone
     assert "\\x1b" in reason                              # escaped form retained
     assert len(reason) <= 200
+
+
+def test_merge_per_model_accumulates():
+    acc: dict = {}
+    R._merge_per_model(acc, {"m1": {"input": 10, "output": 5, "cost_usd": 0.1}})
+    R._merge_per_model(acc, {"m1": {"input": 3, "output": 2, "cost_usd": 0.05},
+                             "m2": {"input": 7, "output": 1, "cost_usd": None}})
+    R._merge_per_model(acc, None)  # None-safe no-op
+    assert acc["m1"]["input"] == 13
+    assert acc["m1"]["output"] == 7
+    assert acc["m1"]["cache_read"] == 0 and acc["m1"]["cache_create"] == 0
+    assert abs(acc["m1"]["cost_usd"] - 0.15) < 1e-9
+    assert acc["m2"] == {"input": 7, "output": 1, "cache_read": 0,
+                         "cache_create": 0, "cost_usd": None}
+
+
+def test_extract_transcript_metrics_per_model(tmp_path):
+    tp = tmp_path / "transcript.jsonl"
+    result_ev = {
+        "type": "result", "total_cost_usd": 0.42, "num_turns": 3,
+        "usage": {"input_tokens": 100, "output_tokens": 50},
+        "modelUsage": {
+            "z-ai/glm-5.2": {
+                "inputTokens": 100, "outputTokens": 50,
+                "cacheReadInputTokens": 10, "cacheCreationInputTokens": 0,
+                "costUSD": 0.42,
+            },
+        },
+    }
+    tp.write_text(json.dumps(result_ev) + "\n")
+    m = R._extract_transcript_metrics(tp)
+    assert m["per_model_usage"] == {
+        "z-ai/glm-5.2": {"input": 100, "output": 50, "cache_read": 10,
+                         "cache_create": 0, "cost_usd": 0.42},
+    }

--- a/tests/test_stream_capture.py
+++ b/tests/test_stream_capture.py
@@ -1,9 +1,12 @@
 """Tests for agent_eval.agent.stream_capture — turn counting and deduplication."""
 
+import json
+
 from conftest import make_assistant, make_result, to_jsonl
 
 from agent_eval.agent.stream_capture import (
-    count_subagent_turns, count_subagent_turns_by_model, extract_usage,
+    _is_real_model, count_subagent_turns, count_subagent_turns_by_model,
+    extract_usage,
 )
 
 
@@ -126,3 +129,45 @@ class TestCombinedTurnCount:
         assert total == pre_2_1_108_stream["expected_total"]  # 8
         assert stream_turns == 5
         assert new_turns == 3
+
+
+class TestPlaceholderModel:
+    """`<synthetic>` (and other <bracketed> pseudo-models) are counted for
+    dedup/totals but excluded from per-model accounting."""
+
+    def test_is_real_model(self):
+        assert _is_real_model("claude-opus-4-7") is True
+        assert _is_real_model("<synthetic>") is False
+        assert _is_real_model("") is False
+        assert _is_real_model(None) is False
+
+    def test_extract_usage_excludes_placeholder(self):
+        events = [
+            make_assistant("msg_real", model="claude-opus-4-7"),
+            make_assistant("msg_synth", model="<synthetic>"),
+            make_result(cost_usd=0.10),
+        ]
+        (_tok, _cost, num_turns, seen_ids, models_seen,
+         _per_model, by_model) = extract_usage(to_jsonl(events))
+        # Placeholder turn still counts toward totals and dedup ...
+        assert num_turns == 2
+        assert "msg_synth" in seen_ids
+        # ... but never pollutes per-model accounting: both models_seen and the
+        # per-model msg-id map exclude the pseudo-model.
+        assert models_seen == {"claude-opus-4-7"}
+        assert set(by_model) == {"claude-opus-4-7"}
+
+    def test_subagent_turns_exclude_placeholder(self, tmp_path):
+        subdir = tmp_path / "subagents"
+        subdir.mkdir()
+        lines = [
+            {"message": {"id": "s1", "role": "assistant",
+                         "model": "claude-opus-4-7"}},
+            {"message": {"id": "s2", "role": "assistant",
+                         "model": "<synthetic>"}},
+        ]
+        (subdir / "agent-x.jsonl").write_text(
+            "\n".join(json.dumps(x) for x in lines) + "\n")
+        per_model = count_subagent_turns_by_model(subdir)
+        assert per_model == {"claude-opus-4-7": 1}
+        assert "<synthetic>" not in per_model


### PR DESCRIPTION
## What
- **`harbor/results.py` + `harbor/run.py`** — thread a `per_model_usage` breakdown through Harbor parsing (extract `modelUsage` per trial/step/job) and surface it in `run_result`, bringing the Harbor runner to parity with the local runner for the report's Model Usage table.
- **`stream_capture.py`** — `_is_real_model()` filters bracketed pseudo-models (e.g. `<synthetic>`) out of `models_seen` / per-model turn+token breakdowns and subagent-model detection, while still counting their turns for dedup/totals.

## Why
Harbor jobs produced no per-model breakdown (the report's Model Usage table was local-runner-only); and placeholder pseudo-models leaked into the local per-model table as a bogus model row.

## Test plan
⚠️ **No automated tests** for these paths yet (flagged for reviewers): Harbor `modelUsage` extraction and the `<synthetic>` filter are currently untested. Manual checks:
- A Harbor run's `run_result.json` includes `per_model_usage`.
- A run containing a `<synthetic>` turn shows no bogus model row in the per-model table (turns still counted in totals).
