### PR TITLE
docs(website): add eval-compare guide

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -168,6 +168,7 @@ nav:
     - "Generate a config (/eval-analyze)": guides/eval-analyze.md
     - "Build a dataset (/eval-dataset)": guides/eval-dataset.md
     - "Run an eval (/eval-run)": guides/eval-run.md
+    - "Compare models/runs (/eval-compare)": guides/eval-compare.md
     - "Review results (/eval-review)": guides/eval-review.md
     - "Optimize a skill (/eval-optimize)": guides/eval-optimize.md
     - "Log to MLflow (/eval-mlflow)": guides/eval-mlflow.md

--- a/website/guides/eval-compare.md
+++ b/website/guides/eval-compare.md
@@ -1,0 +1,150 @@
+# Compare models and runs (/eval-compare)
+
+`/eval-compare` takes a directory of eval run artifacts and produces a single,
+self-contained HTML report that puts models (or repeated runs) side by side. It
+does **not** run evaluations or modify your source data — it reads the outputs
+you already have from [`/eval-run`](eval-run.md) (`summary.yaml`,
+`run_result.json`, and each run's `report.html`) and turns them into one
+comparison view with LLM-written analysis.
+
+!!! abstract "What you'll produce"
+    A self-contained `index.html` (plus copied per-run reports) with a
+    **Comparison** tab — model cards, cost/efficiency and quality tables, and
+    per-case breakdowns — and one tab per model embedding its original report.
+    The agent then fills in the analysis sections (Bottom Line, Where Each Model
+    Shined, Shared Weaknesses, Recommendations) and model-card badges.
+
+## When to use it
+
+- You ran the same eval on **multiple models** (e.g. Opus vs Sonnet) and want a
+  cost-vs-quality verdict.
+- You ran the **same model multiple times** and want to see variance across runs.
+- You want a shareable, offline artifact that bundles every run's report behind
+  one set of tabs.
+
+## Run it
+
+```bash
+/eval-compare <input-dir>
+```
+
+| Flag | Default | Effect |
+| --- | --- | --- |
+| `<input-dir>` | — (required) | Scanned **recursively** for any subdirectory containing a `summary.yaml`. |
+| `--output <path>` | `<input-dir>/comparison-report` | Where the report is written. |
+| `--title <text>` | `Model Comparison` | Report title shown in the header. |
+| `--overview <text>` | omitted | Optional context paragraph shown at the top. When absent, the section is omitted. |
+
+!!! note "Read-only on your runs"
+    `/eval-compare` never modifies input files. It only writes to the output
+    directory (the `index.html` and copies of each run's `report.html`).
+
+## How it works
+
+```mermaid
+flowchart TD
+    A[Step 1: Discover<br/>compare.py discover] --> B[Step 2: Generate<br/>compare.py generate]
+    B --> C[Step 3: Write analysis<br/>agent edits index.html]
+    C --> D[Step 4: Present summary]
+```
+
+### Step 1 — Discover runs
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/compare.py discover <input-dir>
+```
+
+The scanner walks `<input-dir>` recursively, treating **every directory that
+contains a `summary.yaml`** as a run. It prints a JSON manifest with each run's
+directory, resolved model, cost, judge scores, and whether an HTML report is
+present. Runs are grouped by model (from `run_result.json`, falling back to the
+`run_id`), so several runs of one model aggregate together.
+
+### Step 2 — Generate the report
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/scripts/compare.py generate <input-dir> \
+    --output <output-dir> --title "<title>"
+```
+
+This builds `index.html` and copies each run's `report.html` into a unique
+per-run subdirectory for iframe embedding. Tables highlight the best value
+green and the worst red per metric; when a model has more than one run, cells
+show the average with its `(min–max)` range. The comparison tab picks the most
+discriminating judges (highest variance across models) for the model cards.
+
+### Step 3 — Write analysis sections
+
+Using the discovery manifest and each run's `summary.yaml`, the agent replaces
+the placeholders in `index.html`:
+
+- **Bottom Line** — a 3-sentence verdict: which model to pick and the key
+  tradeoff.
+- **Where Each Model Shined** — per-model strengths.
+- **Shared Weaknesses** — cross-cutting, skill-level issues (cases where every
+  model struggled).
+- **Recommendations** — actionable next steps.
+
+It also adds model-card **badges** where they clearly apply:
+
+| Badge | Meaning |
+| --- | --- |
+| **Best Value** | Best quality-for-cost, and consistent across runs. |
+| **Highly Variable** | Multiple runs whose scores diverge significantly (disqualifies Best Value). |
+| **Not Viable** | Fundamentally fails the task — very low scores or missing outputs. |
+
+### Step 4 — Present summary
+
+The skill reports how many runs were discovered (grouped by model), the best-value
+model and why, and where the report was saved. Open it with:
+
+```bash
+open <output-dir>/index.html
+```
+
+## The report
+
+- **Comparison tab** — an optional overview paragraph, the Bottom Line verdict,
+  model cards (top judges + cost, wall clock, tokens, turns), a Cost &
+  Efficiency table, a Quality Scores table, and per-case tables for judges that
+  vary across models.
+- **One tab per model** — embeds that run's original `report.html`; models with
+  several runs get a sub-bar to switch between individual runs. A run missing its
+  `report.html` shows a "No HTML report available" message instead of an iframe.
+- **Light/dark theme** — a header toggle mirrors the per-run reports and
+  remembers your choice.
+
+!!! tip "Aggregating repeated models"
+    When multiple runs share a model, the cards and tables show averages with
+    `(min–max)` ranges, and each run still gets its own embedded report tab — so
+    you can see both the aggregate and the individual runs.
+
+## Where to go next
+
+<div class="grid cards" markdown>
+
+-   :material-play: **Produce runs to compare**
+
+    ---
+
+    Execute the suite on each model or run you want in the comparison.
+
+    [:octicons-arrow-right-24: /eval-run](eval-run.md)
+
+-   :material-account-check: **Review a single run**
+
+    ---
+
+    Dig into one run's outputs and give human feedback.
+
+    [:octicons-arrow-right-24: /eval-review](eval-review.md)
+
+-   :material-sitemap: **See the full pipeline**
+
+    ---
+
+    How the skills fit together end to end.
+
+    [:octicons-arrow-right-24: The pipeline](pipeline.md)
+
+</div>

--- a/website/guides/index.md
+++ b/website/guides/index.md
@@ -62,6 +62,14 @@ The `/eval-*` slash commands drive the workflow in order. Each maps to a skill u
 
     [:octicons-arrow-right-24: Run an eval](eval-run.md)
 
+-   :material-compare: **/eval-compare**
+
+    ---
+
+    Compare models or runs side-by-side into one self-contained HTML report.
+
+    [:octicons-arrow-right-24: Compare models/runs](eval-compare.md)
+
 -   :material-account-check: **/eval-review**
 
     ---

--- a/website/guides/pipeline.md
+++ b/website/guides/pipeline.md
@@ -17,6 +17,7 @@ same runs directory, so you can stop, edit, and resume anywhere.
 | 4b | [`/eval-optimize`](eval-optimize.md) | Automated refine-and-rerun loop (composes with `/eval-run`) | Optional |
 | ⟳ | [`/eval-mlflow`](eval-mlflow.md) | Sync dataset, log run results, push/pull trace feedback | Optional — any time **after** a run |
 | ✓ | [`/eval-check`](eval-check.md) | Whole-harness health check (overlap between skills, hooks, CLAUDE.md) | Optional |
+| ⇄ | [`/eval-compare`](eval-compare.md) | Compare results across models/runs into one HTML report | Optional — after ≥2 runs |
 
 !!! note "`/eval-setup` is genuinely optional"
     Dependencies live in an isolated venv that the plugin's SessionStart hook creates

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -20,6 +20,7 @@ flowchart TD
     subgraph SC["Slash commands (inside Claude Code)"]
         A["/eval-setup → /eval-analyze → /eval-dataset →<br/>/eval-run → /eval-review → /eval-optimize → /eval-mlflow"]
         C["/eval-check"]
+        C2["/eval-compare"]
     end
     subgraph CS["Console script (pip-installed)"]
         T["claude-trace"]
@@ -35,7 +36,7 @@ flowchart TD
 
 ## Slash commands
 
-Eight skills ship as slash commands. Each one is a stage in the pipeline; run them in
+Nine skills ship as slash commands. Each one is a stage in the pipeline; run them in
 order for a first eval, or invoke individually.
 
 | Command | Purpose | Guide |
@@ -44,6 +45,7 @@ order for a first eval, or invoke individually.
 | `/eval-analyze` | Analyze a skill or docs, generate `eval.yaml` + `eval.md` | [eval-analyze](../guides/eval-analyze.md) |
 | `/eval-dataset` | Generate or expand test cases (and Harbor task packages) | [eval-dataset](../guides/eval-dataset.md) |
 | `/eval-run` | Execute the suite, collect artifacts, score, report | [eval-run](../guides/eval-run.md) |
+| `/eval-compare` | Compare results across models/runs into one HTML report | [eval-compare](../guides/eval-compare.md) |
 | `/eval-review` | Interactive human review of a run; propose config changes | [eval-review](../guides/eval-review.md) |
 | `/eval-optimize` | Automated refinement loop (composes with `/eval-run`) | [eval-optimize](../guides/eval-optimize.md) |
 | `/eval-mlflow` | Dataset sync, result logging, trace feedback | [eval-mlflow](../guides/eval-mlflow.md) |


### PR DESCRIPTION
## Description

Follow-up documentation for the **eval-compare** skill (added in #110). The skill itself is not on `main` yet — this PR adds the website docs so they're ready to publish alongside/after #110 merges.

Adds:
- **New guide page** `website/guides/eval-compare.md` — mirrors the `eval-check` guide structure: what it produces, when to use it, flags, the discover → generate → analysis flow, the report structure, and next steps.
- **Guides nav** entry in `mkdocs.yml` (after `/eval-run`).
- **`reference/cli.md`** — adds the `/eval-compare` row, bumps the skill count to nine, and adds it to the surface-at-a-glance diagram.
- **`guides/index.md`** — adds an `/eval-compare` card.
- **`guides/pipeline.md`** — adds an `/eval-compare` row to the steps table.

## How Has This Been Tested?

`mkdocs build --strict` passes (validates nav, internal links, and markdown).

## Note

Best merged together with or just after #110 so the documented skill exists in the tree.