### PR TITLE
docs(website): add animated eval-loop hero diagram

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ extra_css:
 
 extra_javascript:
   - assets/javascripts/harbor-diagram.js
+  - assets/javascripts/loop-diagram.js
   - assets/javascripts/toc-rail.js
   - assets/javascripts/table-wrap.js
   - assets/javascripts/card-glow.js

--- a/website/assets/javascripts/loop-diagram.js
+++ b/website/assets/javascripts/loop-diagram.js
@@ -1,0 +1,240 @@
+/*
+ * Ambient "eval loop" hero diagram.
+ *
+ * Self-contained, dependency-free vanilla JS + SVG. Renders into any
+ * <div class="loop-diagram"></div>. Shows the six-stage loop as a left-to-right
+ * pipeline (Analyze -> Dataset -> Run -> Review -> Trace -> Optimize) that
+ * closes back on itself via a feedback arc from Optimize to Analyze — the
+ * "measurable AND improvable" story from the hero, made visual.
+ *
+ * A soft spotlight walks the stages; particles flow along the connector into
+ * each newly-active stage, and around the feedback arc when the loop closes.
+ *
+ * Theme-aware (colors come from CSS variables in stylesheets/diagrams.css),
+ * accessible (role="img" with a descriptive label; the page's stage cards are
+ * the textual equivalent), respects prefers-reduced-motion, pauses when
+ * off-screen, and re-initialises under MkDocs Material's instant navigation
+ * via the document$ observable.
+ */
+(function () {
+  "use strict";
+
+  var SVGNS = "http://www.w3.org/2000/svg";
+  var VW = 1120, VH = 300;
+  var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // ---- Stages -------------------------------------------------------------
+  var STAGES = [
+    { key: "analyze",  label: "Analyze",  cmd: "/eval-analyze" },
+    { key: "dataset",  label: "Dataset",  cmd: "/eval-dataset" },
+    { key: "run",      label: "Run & judge", cmd: "/eval-run" },
+    { key: "review",   label: "Review",   cmd: "/eval-review" },
+    { key: "trace",    label: "Trace",    cmd: "/eval-mlflow" },
+    { key: "optimize", label: "Optimize", cmd: "/eval-optimize" },
+  ];
+
+  // ---- Layout (in viewBox units) ------------------------------------------
+  var M = 28, BW = 156, BH = 96, BY = 60;
+  var GAP = (VW - 2 * M - STAGES.length * BW) / (STAGES.length - 1);
+  function nodeX(i) { return M + i * (BW + GAP); }
+  var MIDY = BY + BH / 2;          // connector height (box vertical center)
+  var ARC_Y = 250;                 // feedback arc low point
+
+  // ---- Small helpers ------------------------------------------------------
+  function mk(tag, attrs, parent) {
+    var e = document.createElementNS(SVGNS, tag);
+    if (attrs) for (var k in attrs) e.setAttribute(k, attrs[k]);
+    if (parent) parent.appendChild(e);
+    return e;
+  }
+  function html(tag, cls, parent) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (parent) parent.appendChild(e);
+    return e;
+  }
+
+  var _uid = 0;
+  function uid() { return (_uid++) + "-" + Math.floor(performance.now()); }
+
+  // ---- Build one diagram --------------------------------------------------
+  function build(container) {
+    container.textContent = "";
+    container.classList.add("ld-ready");
+
+    var label = "The evaluation loop: " +
+      STAGES.map(function (s) { return s.label; }).join(", then ") +
+      ", then optimize feeds back to analyze — a closed, repeatable loop.";
+
+    var svg = mk("svg", {
+      viewBox: "0 0 " + VW + " " + VH, role: "img", "aria-label": label,
+    }, container);
+
+    // defs: arrowhead marker (color follows the path stroke via context-stroke)
+    var defs = mk("defs", null, svg);
+    var mId = "ld-arrow-" + uid();
+    var marker = mk("marker", {
+      id: mId, markerWidth: 9, markerHeight: 9, refX: 6.5, refY: 3.5,
+      orient: "auto", markerUnits: "userSpaceOnUse",
+    }, defs);
+    mk("path", { d: "M0,0 L7,3.5 L0,7 Z", class: "ld-arrowhead" }, marker);
+    var markerRef = "url(#" + mId + ")";
+
+    var layers = {
+      edges: mk("g", { class: "ld-edges" }, svg),
+      particles: mk("g", { class: "ld-particles" }, svg),
+      nodes: mk("g", { class: "ld-nodes" }, svg),
+    };
+
+    // ---- feedback arc (behind the boxes): Optimize -> Analyze -----------
+    var xFirst = nodeX(0) + BW / 2;
+    var xLast = nodeX(STAGES.length - 1) + BW / 2;
+    var arcD = "M " + xLast + " " + (BY + BH) +
+               " C " + xLast + " " + ARC_Y + ", " + xFirst + " " + ARC_Y +
+               ", " + xFirst + " " + (BY + BH);
+    var arc = mk("path", {
+      d: arcD, class: "ld-arc", "marker-end": markerRef,
+    }, layers.edges);
+    var arcLabel = mk("text", {
+      x: VW / 2, y: ARC_Y + 22, "text-anchor": "middle", class: "ld-arc-label",
+    }, layers.edges);
+    arcLabel.textContent = "re-run · compare · keep only real gains";
+
+    // ---- connectors (straight, between consecutive boxes) --------------
+    var edgeEls = [];
+    for (var i = 0; i < STAGES.length - 1; i++) {
+      var x1 = nodeX(i) + BW, x2 = nodeX(i + 1);
+      var p = mk("path", {
+        d: "M " + x1 + " " + MIDY + " L " + x2 + " " + MIDY,
+        class: "ld-edge", "marker-end": markerRef,
+      }, layers.edges);
+      edgeEls.push(p);
+    }
+
+    // ---- nodes ---------------------------------------------------------
+    var nodeEls = STAGES.map(function (s, i) {
+      var x = nodeX(i);
+      var g = mk("g", { class: "ld-node ld-" + s.key, "data-stage": i }, layers.nodes);
+      mk("rect", { x: x, y: BY, width: BW, height: BH, rx: 12, class: "ld-box" }, g);
+      // number badge
+      mk("circle", { cx: x + 26, cy: BY + 30, r: 14, class: "ld-badge" }, g);
+      var bn = mk("text", {
+        x: x + 26, y: BY + 35, "text-anchor": "middle", class: "ld-badge-num",
+      }, g);
+      bn.textContent = String(i + 1);
+      // title
+      var t = mk("text", { x: x + 50, y: BY + 36, class: "ld-title" }, g);
+      t.textContent = s.label;
+      // command
+      var c = mk("text", { x: x + 20, y: BY + 70, class: "ld-cmd" }, g);
+      c.textContent = s.cmd;
+      return g;
+    });
+
+    // ---- caption (static, below the diagram) ---------------------------
+    var caption = html("p", "ld-caption", container);
+    caption.textContent =
+      "One eval.yaml drives every stage. Only analyze → dataset → run are required for a first score.";
+
+    // ---- animation -----------------------------------------------------
+    var cur = -1, gen = 0, timer = null, running = false;
+
+    function setActive(i) {
+      nodeEls.forEach(function (g, gi) { g.classList.toggle("is-active", gi === i); });
+      edgeEls.forEach(function (e) { e.classList.remove("is-active"); });
+      arc.classList.remove("is-active");
+      if (i > 0 && i < STAGES.length && edgeEls[i - 1]) edgeEls[i - 1].classList.add("is-active");
+    }
+
+    function flowAlong(path, delay, myGen) {
+      if (reduce || !path) return;
+      var len = path.getTotalLength();
+      var count = 3, dur = 900;
+      var dots = [];
+      for (var i = 0; i < count; i++) {
+        dots.push(mk("circle", { r: 2.8, class: "ld-particle", cx: -10, cy: -10, opacity: 0 }, layers.particles));
+      }
+      var start = null;
+      function frame(ts) {
+        if (myGen !== gen || !container.isConnected) { dots.forEach(function (d) { d.remove(); }); return; }
+        if (start === null) start = ts + delay;
+        var base = (ts - start) / dur;
+        if (base > 1.35) { dots.forEach(function (d) { d.remove(); }); return; }
+        dots.forEach(function (d, i) {
+          var p = base - i * 0.16;
+          if (p < 0 || p > 1) { d.setAttribute("opacity", 0); return; }
+          var pt = path.getPointAtLength(p * len);
+          d.setAttribute("cx", pt.x);
+          d.setAttribute("cy", pt.y);
+          d.setAttribute("opacity", (Math.sin(p * Math.PI) * 0.95).toFixed(3));
+        });
+        requestAnimationFrame(frame);
+      }
+      requestAnimationFrame(frame);
+    }
+
+    // A "tick" advances the spotlight. Index STAGES.length is the feedback
+    // phase: the arc lights up and a particle rides it back to Analyze.
+    function tick() {
+      gen++;
+      cur = (cur + 1) % (STAGES.length + 1);
+      if (cur < STAGES.length) {
+        setActive(cur);
+        if (cur > 0) flowAlong(edgeEls[cur - 1], 0, gen);
+      } else {
+        // feedback phase
+        nodeEls.forEach(function (g) { g.classList.remove("is-active"); });
+        edgeEls.forEach(function (e) { e.classList.remove("is-active"); });
+        arc.classList.add("is-active");
+        flowAlong(arc, 0, gen);
+      }
+    }
+
+    function start() {
+      if (running || reduce) return;
+      running = true;
+      timer = window.setInterval(tick, 1550);
+    }
+    function stop() {
+      running = false;
+      if (timer) { window.clearInterval(timer); timer = null; }
+    }
+
+    // First frame: highlight Analyze so the diagram reads even before motion.
+    setActive(0);
+    cur = 0;
+
+    if (reduce || !("IntersectionObserver" in window)) {
+      // Static: leave stage 1 highlighted, arc + connectors visible.
+      return;
+    }
+
+    // Run only while in view (perf + politeness); the interval is cheap but a
+    // perpetual hero animation off-screen is wasteful.
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (!container.isConnected) { stop(); io.disconnect(); return; }
+        if (en.isIntersecting) start(); else stop();
+      });
+    }, { threshold: 0.25 });
+    io.observe(container);
+  }
+
+  function initAll() {
+    var list = document.querySelectorAll(".loop-diagram:not(.ld-ready)");
+    for (var i = 0; i < list.length; i++) {
+      try { build(list[i]); } catch (err) { console.error("loop-diagram: build failed", err); }
+    }
+  }
+
+  // MkDocs Material instant navigation: document$ emits on every page load.
+  // DOM-ready fallback stays idempotent via the :not(.ld-ready) guard.
+  if (window.document$ && typeof window.document$.subscribe === "function") {
+    window.document$.subscribe(initAll);
+  }
+  if (document.readyState !== "loading") {
+    initAll();
+  } else {
+    document.addEventListener("DOMContentLoaded", initAll);
+  }
+})();

--- a/website/index.md
+++ b/website/index.md
@@ -47,42 +47,42 @@ optimize. Same config on your laptop, Harbor containers, or EvalHub.
 
 <div class="grid cards" markdown>
 
--   **1 · Analyze**
+-   **[1 · Analyze](guides/eval-analyze.md)**
 
     ---
 
     Point `/eval-analyze` at a skill or a prompt brief. The harness writes
     `eval.yaml` with judges, schema, and thresholds.
 
--   **2 · Dataset**
+-   **[2 · Dataset](guides/eval-dataset.md)**
 
     ---
 
     `/eval-dataset` fills cases from your schema — or bring your own
     `cases/` tree with gold references.
 
--   **3 · Run & judge**
+-   **[3 · Run & judge](guides/eval-run.md)**
 
     ---
 
     `/eval-run` executes on Claude Code (or another runner), scores with
     LLM + code judges, and emits a rich HTML report.
 
--   **4 · Review**
+-   **[4 · Review](guides/eval-review.md)**
 
     ---
 
     Optional `/eval-review` captures human feedback on scored cases before
     you change the skill or config.
 
--   **5 · Trace**
+-   **[5 · Trace](guides/eval-mlflow.md)**
 
     ---
 
     Optional `/eval-mlflow` syncs metrics, artifacts, and hierarchical
     GenAI traces for every case.
 
--   **6 · Optimize**
+-   **[6 · Optimize](guides/eval-optimize.md)**
 
     ---
 

--- a/website/index.md
+++ b/website/index.md
@@ -43,7 +43,7 @@ optimize. Same config on your laptop, Harbor containers, or EvalHub.
 
 ## How the loop works
 
-Six stages. Only analyze → dataset → run are required for a first score.
+<div class="loop-diagram"></div>
 
 <div class="grid cards" markdown>
 

--- a/website/stylesheets/diagrams.css
+++ b/website/stylesheets/diagrams.css
@@ -294,3 +294,107 @@
 @media (prefers-reduced-motion: reduce) {
   .schema-diagram .sd-card { transition: none; }
 }
+
+/*
+ * Ambient "eval loop" hero diagram (loop-diagram.js). Six stages as a
+ * left-to-right pipeline that closes back on itself. Uses the brand-red accent
+ * (unlike the blue Harbor diagram) so it reads as the product's own signature
+ * on the landing page. Same token pattern as .harbor-diagram: local tokens with
+ * a slate override, everything else from Material vars.
+ */
+.loop-diagram {
+  --ld-accent: var(--md-primary-fg-color);
+  --ld-node: #ffffff;
+  --ld-border: #dbe0e8;
+  --ld-fg: #1b1f24;
+  --ld-muted: #5c6672;
+  --ld-edge: #cdd4de;
+  --ld-badge: #f0f2f6;
+
+  margin: 1.6em 0 1.2em;
+}
+
+[data-md-color-scheme="slate"] .loop-diagram {
+  --ld-node: #151b23;
+  --ld-border: #2c3743;
+  --ld-fg: #eef2f6;
+  --ld-muted: #9aa7b6;
+  --ld-edge: #3a4653;
+  --ld-badge: #222b36;
+}
+
+.loop-diagram svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+.loop-diagram text { font-family: var(--md-text-font, inherit); }
+
+/* ---- nodes ---- */
+.loop-diagram .ld-box {
+  fill: var(--ld-node);
+  stroke: var(--ld-border);
+  stroke-width: 1.3;
+  transition: stroke 0.3s ease, filter 0.3s ease;
+}
+[data-md-color-scheme="default"] .loop-diagram .ld-box {
+  filter: drop-shadow(0 1px 2px rgba(15, 23, 42, 0.06));
+}
+.loop-diagram .ld-node.is-active .ld-box {
+  stroke: var(--ld-accent);
+  stroke-width: 2;
+  filter: drop-shadow(0 0 9px color-mix(in srgb, var(--ld-accent) 50%, transparent));
+}
+
+.loop-diagram .ld-badge {
+  fill: var(--ld-badge);
+  transition: fill 0.3s ease;
+}
+.loop-diagram .ld-node.is-active .ld-badge {
+  fill: color-mix(in srgb, var(--ld-accent) 20%, var(--ld-node));
+}
+.loop-diagram .ld-badge-num {
+  fill: var(--ld-muted);
+  font-size: 14px;
+  font-weight: 700;
+  transition: fill 0.3s ease;
+}
+.loop-diagram .ld-node.is-active .ld-badge-num { fill: var(--ld-accent); }
+
+.loop-diagram .ld-title { fill: var(--ld-fg); font-size: 17px; font-weight: 650; }
+.loop-diagram .ld-cmd {
+  fill: var(--ld-muted);
+  font-family: var(--md-code-font, monospace);
+  font-size: 13px;
+}
+.loop-diagram .ld-node.is-active .ld-cmd { fill: var(--ld-fg); }
+
+/* ---- edges + feedback arc + particles ---- */
+.loop-diagram .ld-edge,
+.loop-diagram .ld-arc {
+  fill: none;
+  stroke: var(--ld-edge);
+  stroke-width: 1.6;
+  transition: stroke 0.3s ease, stroke-width 0.3s ease;
+}
+.loop-diagram .ld-arc { stroke-dasharray: 6 6; }
+.loop-diagram .ld-edge.is-active,
+.loop-diagram .ld-arc.is-active { stroke: var(--ld-accent); stroke-width: 2.2; }
+.loop-diagram .ld-arrowhead { fill: var(--ld-edge); fill: context-stroke; }
+.loop-diagram .ld-particle { fill: var(--ld-accent); }
+
+.loop-diagram .ld-arc-label {
+  fill: var(--ld-muted);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.loop-diagram .ld-caption {
+  margin: 0.4rem 0 0;
+  text-align: center;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--md-default-fg-color--light);
+}

--- a/website/stylesheets/extra.css
+++ b/website/stylesheets/extra.css
@@ -210,6 +210,28 @@
 }
 
 /*
+ * Flatten the sticky sidebar headers. Material gives both menus' sticky headers
+ * a background-color "halo" scroll-mask — box-shadow: 0 0 .4rem .4rem
+ * var(--md-default-bg-color) — that reads as an unwanted drop shadow / bottom
+ * border, plus a hairline (inset 0 .05rem 0) on the list under a title:
+ *   - right menu: .md-nav--secondary .md-nav__title  (Table of contents)
+ *   - left menu:  .md-nav--lifted … --active > .md-nav__link  (lifted section)
+ *   - mobile drawer: .md-nav--primary .md-nav__title
+ * Drop them all. The headers keep their opaque background, so list items still
+ * don't bleed through as they scroll underneath — only the shadow/line goes.
+ * Selectors are scoped under .md-sidebar so they outrank Material's own rules by
+ * specificity (not just source order), leaving no ambiguity about which wins.
+ */
+.md-sidebar .md-nav--secondary .md-nav__title,
+.md-sidebar .md-nav--primary .md-nav__title,
+.md-sidebar .md-nav--lifted > .md-nav__list > .md-nav__item--active > .md-nav__link {
+  box-shadow: none;
+}
+.md-sidebar .md-nav--secondary .md-nav__title ~ .md-nav__list {
+  box-shadow: none;
+}
+
+/*
  * Frosted, neutral header — a translucent blurred bar instead of a solid color
  * one, so page content is faintly visible through it. The brand accent (red)
  * stays on links, active states, and the TOC rail; the chrome goes neutral.


### PR DESCRIPTION
## What

Adds an animated **eval-loop hero diagram** to the docs home page. It renders the six-stage loop (Analyze → Dataset → Run & judge → Review → Trace → Optimize) as a left-to-right pipeline that **closes back on itself** via a feedback arc — visualizing the H1's promise that agent performance is *measurable **and improvable***.

Before, the home page jumped from the hero straight to text cards with no product visual.

## How

Built to the existing `harbor-diagram.js` house standard — no new dependencies:

- **`website/assets/javascripts/loop-diagram.js`** — self-contained vanilla JS + SVG. An ambient spotlight walks the stages while particles flow into each one and around the feedback arc.
- **`website/stylesheets/diagrams.css`** — a `.loop-diagram` component keyed to the brand-red accent, with a slate (dark-mode) override, matching the `--hd-*`/`--sd-*` token pattern.
- **`website/index.md`** — mounts the diagram under "How the loop works"; its caption absorbs the previously-duplicated intro line.
- **`mkdocs.yml`** — registers the script in `extra_javascript`.

## Quality

- **Theme-aware** (follows the light/dark toggle via CSS vars).
- **Accessible** — `role="img"` with a full text label; the six numbered cards below are the equivalent legend.
- **Static under `prefers-reduced-motion`**, and **pauses when off-screen**.
- Re-initialises under Material's instant navigation (`document$`), idempotent via a `:not(.ld-ready)` guard.
- `mkdocs build --strict` passes with no warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive “evaluation loop” diagram to the documentation homepage, including animated stage flow, labels, and feedback path.
  * Automatically respects light/dark themes, accessibility labeling, reduced-motion settings, and pauses when the diagram is off-screen.
* **Documentation**
  * Updated the “How the loop works” section to use the diagram and converted stage titles into links to their corresponding guides.
* **Styling / UX**
  * Added dedicated styles for the diagram and refined sidebar visuals by removing sticky-header shadows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->