### PR TITLE
fix(harbor): serialize multiline task descriptions

### DIFF
--- a/agent_eval/harbor/tasks.py
+++ b/agent_eval/harbor/tasks.py
@@ -32,6 +32,7 @@ at a known path and staged into the workspace by the image's entrypoint or
 """
 
 import json
+import re
 import shutil
 from pathlib import Path
 
@@ -45,9 +46,11 @@ _TEMPLATES = Path(__file__).resolve().parent / "templates"
 
 def _render(template_name: str, mapping: dict) -> str:
     text = (_TEMPLATES / template_name).read_text()
-    for key, value in mapping.items():
-        text = text.replace(f"@@{key}@@", str(value))
-    return text
+    return re.sub(
+        r"@@([A-Za-z_][A-Za-z0-9_]*)@@",
+        lambda match: str(mapping.get(match.group(1), match.group(0))),
+        text,
+    )
 
 
 def _toml_string(value: object) -> str:

--- a/agent_eval/harbor/tasks.py
+++ b/agent_eval/harbor/tasks.py
@@ -54,8 +54,15 @@ def _render(template_name: str, mapping: dict) -> str:
 
 
 def _toml_string(value: object) -> str:
-    """Serialize a value as a TOML-compatible basic string."""
-    return json.dumps(str(value), ensure_ascii=False)
+    """Serialize a value as a TOML basic string.
+
+    ``json.dumps`` produces a quoted string whose escape set (``\\"``, ``\\\\``,
+    ``\\b``, ``\\f``, ``\\n``, ``\\r``, ``\\t``, ``\\uXXXX``) is a subset of
+    TOML's, so the result parses as a TOML basic string. The lone exception is
+    U+007F (DEL): JSON emits it raw but TOML requires control characters to be
+    escaped, so escape it explicitly.
+    """
+    return json.dumps(str(value), ensure_ascii=False).replace("\x7f", "\\u007f")
 
 
 def _find_input_file(case_dir: Path):
@@ -152,16 +159,18 @@ def generate_tasks(
         env_dir = task_dir / "environment"
         env_dir.mkdir(parents=True, exist_ok=True)
 
-        # task.toml
+        # task.toml — every string-valued field is TOML-serialized so names,
+        # descriptions, and paths containing quotes, newlines, or backslashes
+        # round-trip through the parser; the numeric timeouts stay bare.
         (task_dir / "task.toml").write_text(_render("task.toml.tmpl", {
-            "TASK_NAME": f"{config.name or 'eval'}/{case_id}",
+            "TASK_NAME": _toml_string(f"{config.name or 'eval'}/{case_id}"),
             "TASK_DESC": _toml_string(
                 (config.description or config.name or "agent-eval task")[:120]
             ),
-            "EVAL_NAME": config.name,
-            "CASE_ID": case_id,
-            "IMAGE": image,
-            "WORKDIR": workdir,
+            "EVAL_NAME": _toml_string(config.name),
+            "CASE_ID": _toml_string(case_id),
+            "IMAGE": _toml_string(image),
+            "WORKDIR": _toml_string(workdir),
             "VERIFIER_TIMEOUT": verifier_timeout,
             "AGENT_TIMEOUT": agent_timeout,
         }))

--- a/agent_eval/harbor/tasks.py
+++ b/agent_eval/harbor/tasks.py
@@ -173,12 +173,12 @@ def generate_tasks(
             "WORKDIR": _toml_string(workdir),
             "VERIFIER_TIMEOUT": verifier_timeout,
             "AGENT_TIMEOUT": agent_timeout,
-        }))
+        }), encoding="utf-8")
 
         # instruction.md
         (task_dir / "instruction.md").write_text(_render("instruction.md.tmpl", {
             "COMMAND": command,
-        }))
+        }), encoding="utf-8")
 
         # tests/test.sh + bundled eval.yaml (verifier)
         copy_lines = []
@@ -193,10 +193,11 @@ def generate_tasks(
         (task_dir / "tests" / "test.sh").write_text(_render("test.sh.tmpl", {
             "WORKDIR": workdir,
             "COPY_OUTPUTS": copy_outputs,
-        }))
+        }), encoding="utf-8")
         (task_dir / "tests" / "test.sh").chmod(0o755)
         (task_dir / "tests" / "eval.yaml").write_text(
-            yaml.safe_dump(bundled_cfg, sort_keys=False, allow_unicode=True))
+            yaml.safe_dump(bundled_cfg, sort_keys=False, allow_unicode=True),
+            encoding="utf-8")
 
         # environment/ — auto-uploaded to the workspace by Harbor
         if input_file:
@@ -210,7 +211,8 @@ def generate_tasks(
         if config.execution.mode == "batch" and input_data:
             entries = input_data if isinstance(input_data, list) else [input_data]
             (env_dir / "batch.yaml").write_text(
-                yaml.safe_dump(entries, sort_keys=False, allow_unicode=True))
+                yaml.safe_dump(entries, sort_keys=False, allow_unicode=True),
+                encoding="utf-8")
 
         # Tool interception (hooks + .claude/settings.json)
         _generate_tool_interception(env_dir, config, Path(config_path), workdir)

--- a/agent_eval/harbor/tasks.py
+++ b/agent_eval/harbor/tasks.py
@@ -31,6 +31,7 @@ at a known path and staged into the workspace by the image's entrypoint or
 ``[environment].workdir`` setup — not by the agent.
 """
 
+import json
 import shutil
 from pathlib import Path
 
@@ -47,6 +48,11 @@ def _render(template_name: str, mapping: dict) -> str:
     for key, value in mapping.items():
         text = text.replace(f"@@{key}@@", str(value))
     return text
+
+
+def _toml_string(value: object) -> str:
+    """Serialize a value as a TOML-compatible basic string."""
+    return json.dumps(str(value), ensure_ascii=False)
 
 
 def _find_input_file(case_dir: Path):
@@ -146,7 +152,9 @@ def generate_tasks(
         # task.toml
         (task_dir / "task.toml").write_text(_render("task.toml.tmpl", {
             "TASK_NAME": f"{config.name or 'eval'}/{case_id}",
-            "TASK_DESC": (config.description or config.name or "agent-eval task")[:120],
+            "TASK_DESC": _toml_string(
+                (config.description or config.name or "agent-eval task")[:120]
+            ),
             "EVAL_NAME": config.name,
             "CASE_ID": case_id,
             "IMAGE": image,

--- a/agent_eval/harbor/tasks.py
+++ b/agent_eval/harbor/tasks.py
@@ -159,14 +159,20 @@ def generate_tasks(
         env_dir = task_dir / "environment"
         env_dir.mkdir(parents=True, exist_ok=True)
 
+        # task.description is a display-only label — Harbor shows the agent
+        # instruction.md and the full text stays in the bundled eval.yaml — so
+        # keep it to a single ~120-char line, marking truncation with an
+        # ellipsis instead of silently dropping characters.
+        label = config.description or config.name or "agent-eval task"
+        if len(label) > 120:
+            label = label[:119] + "…"
+
         # task.toml — every string-valued field is TOML-serialized so names,
         # descriptions, and paths containing quotes, newlines, or backslashes
         # round-trip through the parser; the numeric timeouts stay bare.
         (task_dir / "task.toml").write_text(_render("task.toml.tmpl", {
             "TASK_NAME": _toml_string(f"{config.name or 'eval'}/{case_id}"),
-            "TASK_DESC": _toml_string(
-                (config.description or config.name or "agent-eval task")[:120]
-            ),
+            "TASK_DESC": _toml_string(label),
             "EVAL_NAME": _toml_string(config.name),
             "CASE_ID": _toml_string(case_id),
             "IMAGE": _toml_string(image),

--- a/agent_eval/harbor/templates/task.toml.tmpl
+++ b/agent_eval/harbor/templates/task.toml.tmpl
@@ -5,7 +5,7 @@ schema_version = "1.3"
 
 [task]
 name = "@@TASK_NAME@@"
-description = "@@TASK_DESC@@"
+description = @@TASK_DESC@@
 
 [metadata]
 generated_by = "agent-eval-harness/eval-dataset"

--- a/agent_eval/harbor/templates/task.toml.tmpl
+++ b/agent_eval/harbor/templates/task.toml.tmpl
@@ -4,17 +4,17 @@
 schema_version = "1.3"
 
 [task]
-name = "@@TASK_NAME@@"
+name = @@TASK_NAME@@
 description = @@TASK_DESC@@
 
 [metadata]
 generated_by = "agent-eval-harness/eval-dataset"
-eval_name = "@@EVAL_NAME@@"
-case_id = "@@CASE_ID@@"
+eval_name = @@EVAL_NAME@@
+case_id = @@CASE_ID@@
 
 [environment]
-docker_image = "@@IMAGE@@"
-workdir = "@@WORKDIR@@"
+docker_image = @@IMAGE@@
+workdir = @@WORKDIR@@
 
 [verifier]
 timeout_sec = @@VERIFIER_TIMEOUT@@

--- a/tests/test_harbor_task_generation.py
+++ b/tests/test_harbor_task_generation.py
@@ -131,6 +131,9 @@ def test_generate_tasks_escapes_special_chars_in_name(tmp_path):
     assert task["task"]["name"] == f"{name}/case-001"
     assert task["metadata"]["eval_name"] == name
     assert task["metadata"]["case_id"] == "case-001"
+    # Numeric fields must stay bare (not quoted) so they parse as numbers.
+    assert isinstance(task["verifier"]["timeout_sec"], (int, float))
+    assert isinstance(task["agent"]["timeout_sec"], (int, float))
 
 
 def test_generate_tasks_escapes_del_control_char_in_description(tmp_path):
@@ -144,3 +147,16 @@ def test_generate_tasks_escapes_del_control_char_in_description(tmp_path):
 
     task = tomllib.loads((out / "case-001" / "task.toml").read_text())
     assert task["task"]["description"] == description
+
+
+def test_generate_tasks_writes_non_ascii_description_as_utf8(tmp_path):
+    # _toml_string keeps non-ASCII text raw (ensure_ascii=False), so the file
+    # must be written as UTF-8 to survive an ASCII/C-locale environment.
+    description = "deploy 🚀 café résumé"
+    cfg_path, config = _make_eval(tmp_path, description=description)
+    out = tmp_path / "harbor-tasks"
+
+    gen.generate_tasks(config, cfg_path, out, image="img:latest")
+
+    text = (out / "case-001" / "task.toml").read_text(encoding="utf-8")
+    assert tomllib.loads(text)["task"]["description"] == description

--- a/tests/test_harbor_task_generation.py
+++ b/tests/test_harbor_task_generation.py
@@ -102,3 +102,15 @@ def test_generate_tasks_escapes_multiline_description_for_toml(tmp_path):
 
     task = tomllib.loads((out / "case-001" / "task.toml").read_text())
     assert task["task"]["description"] == description
+
+
+def test_generate_tasks_preserves_placeholder_text_in_description(tmp_path):
+    description = "Use @@IMAGE@@ when documenting the Harbor image"
+    cfg_path, config = _make_eval(tmp_path, description=description)
+    out = tmp_path / "harbor-tasks"
+
+    gen.generate_tasks(config, cfg_path, out, image="img:latest")
+
+    task = tomllib.loads((out / "case-001" / "task.toml").read_text())
+    assert task["task"]["description"] == description
+    assert task["environment"]["docker_image"] == "img:latest"

--- a/tests/test_harbor_task_generation.py
+++ b/tests/test_harbor_task_generation.py
@@ -149,6 +149,26 @@ def test_generate_tasks_escapes_del_control_char_in_description(tmp_path):
     assert task["task"]["description"] == description
 
 
+def test_generate_tasks_truncates_long_description_with_ellipsis(tmp_path):
+    # task.description is a one-line label: long text is capped to 120 chars and
+    # marked with an ellipsis rather than silently dropped. The full text is
+    # still preserved in the bundled eval.yaml for judges.
+    description = "x" * 200
+    cfg_path, config = _make_eval(tmp_path, description=description)
+    out = tmp_path / "harbor-tasks"
+
+    gen.generate_tasks(config, cfg_path, out, image="img:latest")
+
+    task = tomllib.loads((out / "case-001" / "task.toml").read_text())
+    label = task["task"]["description"]
+    assert len(label) == 120
+    assert label == "x" * 119 + "…"
+
+    bundled = yaml.safe_load(
+        (out / "case-001" / "tests" / "eval.yaml").read_text())
+    assert bundled["description"] == description
+
+
 def test_generate_tasks_writes_non_ascii_description_as_utf8(tmp_path):
     # _toml_string keeps non-ASCII text raw (ensure_ascii=False), so the file
     # must be written as UTF-8 to survive an ASCII/C-locale environment.

--- a/tests/test_harbor_task_generation.py
+++ b/tests/test_harbor_task_generation.py
@@ -4,6 +4,8 @@ Verifies that dataset cases become self-contained Harbor task packages with a
 resolved per-case command, the verifier wiring, and a sanitized bundled config.
 """
 
+import tomllib
+
 import yaml
 
 from agent_eval.config import EvalConfig
@@ -17,7 +19,7 @@ def test_resolve_arguments_required_and_optional():
         '--headless --dry-run "do X" --p Critical'
 
 
-def _make_eval(tmp_path):
+def _make_eval(tmp_path, *, description=None):
     cases = tmp_path / "cases"
     (cases / "case-001").mkdir(parents=True)
     (cases / "case-001" / "input.yaml").write_text(
@@ -34,6 +36,8 @@ def _make_eval(tmp_path):
         "judges": [{"name": "files_exist", "check": "return (True, 'ok')\n"}],
         "models": {"judge": "claude-opus-4-6"},
     }
+    if description is not None:
+        raw["description"] = description
     cfg_path = tmp_path / "eval.yaml"
     cfg_path.write_text(yaml.safe_dump(raw, sort_keys=False))
     return cfg_path, EvalConfig.from_yaml(cfg_path)
@@ -87,3 +91,14 @@ def test_generate_tasks_case_subset(tmp_path):
     assert len(tasks) == 1
     assert tasks[0].name == "case-002"
     assert not (out / "case-001").exists()
+
+
+def test_generate_tasks_escapes_multiline_description_for_toml(tmp_path):
+    description = 'Line one\nLine "two" uses \\ a path'
+    cfg_path, config = _make_eval(tmp_path, description=description)
+    out = tmp_path / "harbor-tasks"
+
+    gen.generate_tasks(config, cfg_path, out, image="img:latest")
+
+    task = tomllib.loads((out / "case-001" / "task.toml").read_text())
+    assert task["task"]["description"] == description

--- a/tests/test_harbor_task_generation.py
+++ b/tests/test_harbor_task_generation.py
@@ -19,7 +19,7 @@ def test_resolve_arguments_required_and_optional():
         '--headless --dry-run "do X" --p Critical'
 
 
-def _make_eval(tmp_path, *, description=None):
+def _make_eval(tmp_path, *, name=None, description=None):
     cases = tmp_path / "cases"
     (cases / "case-001").mkdir(parents=True)
     (cases / "case-001" / "input.yaml").write_text(
@@ -36,6 +36,8 @@ def _make_eval(tmp_path, *, description=None):
         "judges": [{"name": "files_exist", "check": "return (True, 'ok')\n"}],
         "models": {"judge": "claude-opus-4-6"},
     }
+    if name is not None:
+        raw["name"] = name
     if description is not None:
         raw["description"] = description
     cfg_path = tmp_path / "eval.yaml"
@@ -114,3 +116,31 @@ def test_generate_tasks_preserves_placeholder_text_in_description(tmp_path):
     task = tomllib.loads((out / "case-001" / "task.toml").read_text())
     assert task["task"]["description"] == description
     assert task["environment"]["docker_image"] == "img:latest"
+
+
+def test_generate_tasks_escapes_special_chars_in_name(tmp_path):
+    # The name/eval_name fields share the description's quoting hazard: a name
+    # with quotes or newlines must not break the generated TOML either.
+    name = 'Acme "Pro"\nrelease'
+    cfg_path, config = _make_eval(tmp_path, name=name)
+    out = tmp_path / "harbor-tasks"
+
+    gen.generate_tasks(config, cfg_path, out, image="img:latest")
+
+    task = tomllib.loads((out / "case-001" / "task.toml").read_text())
+    assert task["task"]["name"] == f"{name}/case-001"
+    assert task["metadata"]["eval_name"] == name
+    assert task["metadata"]["case_id"] == "case-001"
+
+
+def test_generate_tasks_escapes_del_control_char_in_description(tmp_path):
+    # U+007F (DEL) is emitted raw by json.dumps but rejected by TOML parsers;
+    # _toml_string must escape it so the description still round-trips.
+    description = "before\x7fafter"
+    cfg_path, config = _make_eval(tmp_path, description=description)
+    out = tmp_path / "harbor-tasks"
+
+    gen.generate_tasks(config, cfg_path, out, image="img:latest")
+
+    task = tomllib.loads((out / "case-001" / "task.toml").read_text())
+    assert task["task"]["description"] == description


### PR DESCRIPTION
## Summary

- serialize generated Harbor task descriptions as TOML-compatible basic strings
- keep the template from wrapping an already serialized description in an extra pair of quotes
- add regression coverage for descriptions containing newlines, quotes, and backslashes

## Root cause and impact

`generate_tasks()` inserted `config.description` directly between double quotes in `task.toml`. A YAML block scalar therefore produced a literal newline inside a single-line TOML basic string, causing `tomllib` and Harbor to reject the generated task.

The description is now serialized before template substitution, so its value round-trips through `tomllib` without changing the user-authored text.

Fixes #148.

## Validation

- `uv run pytest -q tests/test_harbor_task_generation.py` — 4 passed
- `uv run pytest -q` with `all,test` extras — 755 passed, 2 skipped, 2 deselected
- `python3 -m compileall -q agent_eval/harbor/tasks.py`
- `git diff --check`

## AI assistance disclosure

AI assistance was used to help investigate, implement, and test this change. I reviewed the final diff and ran all validation commands listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Harbor task file generation for descriptions containing multiline text, Unicode characters, quotation marks, backslashes, and control characters.
  * Prevented unmatched template placeholders from being unintentionally replaced.
  * Ensured special characters are escaped correctly, preserving valid TOML and original content.
  * Preserved task metadata, including evaluation names, case IDs, container images, and working directories.

* **Tests**
  * Added coverage for complex descriptions, special characters, optional evaluation names, and generated task metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->