### PR TITLE
refactor(report): replace Markdown renderer with Mistune

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "pyyaml>=6.0",
     "jinja2>=3.1",
+    "mistune>=3.0,<4.0",
     # Verify TLS against the OS trust store (see agent_eval/_bootstrap.py) so the
     # harness reaches internal-CA endpoints (e.g. a Red Hat-issued MLflow server)
     # without REQUESTS_CA_BUNDLE. Pure-Python, requires-python>=3.11 covers it.

--- a/scripts/ensure_deps.py
+++ b/scripts/ensure_deps.py
@@ -6,6 +6,7 @@ Prefers uv for speed, falls back to stdlib venv + pip.
 
 Checks eval.yaml (if it exists) to decide which optional deps to install:
 - pyyaml: always required
+- mistune: always required for HTML report rendering
 - mlflow[genai]: if a mlflow block is present in eval.yaml
 - anthropic[vertex]: if LLM judges or pairwise comparison are configured
 
@@ -49,7 +50,7 @@ def main():
 
 def _resolve_deps(plugin_root):
     """Determine which deps are needed based on eval.yaml."""
-    deps = [("pyyaml>=6.0", "yaml")]
+    deps = [("pyyaml>=6.0", "yaml"), ("mistune>=3.0,<4.0", "mistune")]
 
     eval_yaml = _find_eval_yaml(plugin_root)
     if not eval_yaml or not eval_yaml.exists():

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1642,15 +1642,21 @@ def _render_table_cell(renderer, text, align=None, head=False):
     if not head:
         status = None
         rest = ""
-        for keyword, css_class in _STATUS_CLS.items():
+        for keyword in sorted(_STATUS_CLS, key=len, reverse=True):
+            css_class = _STATUS_CLS[keyword]
             plain = keyword
             strong = f"<strong>{keyword}</strong>"
             emphasis = f"<em>{keyword}</em>"
             for prefix in (plain, strong, emphasis):
                 if text.startswith(prefix):
-                    status = (keyword, css_class)
-                    rest = text[len(prefix):].strip()
-                    break
+                    candidate_rest = text[len(prefix):]
+                    if (
+                        not candidate_rest
+                        or not (candidate_rest[0].isalnum() or candidate_rest[0] == "_")
+                    ):
+                        status = (keyword, css_class)
+                        rest = candidate_rest.strip()
+                        break
             if status:
                 break
         if status:
@@ -1672,12 +1678,24 @@ def _normalize_report_markdown(md_text: str) -> str:
     """Preserve the legacy renderer's top-level list termination behavior."""
     lines = md_text.splitlines()
     normalized = []
-    in_fence = False
+    active_fence = None
     list_item = re.compile(r"^(?:[-+*]|\d+[.)])\s+")
     for line in lines:
+        fence = re.match(r"^ {0,3}(`{3,}|~{3,})", line)
+        closes_fence = False
+        if active_fence:
+            char, length = active_fence
+            closes_fence = bool(re.match(
+                rf"^ {{0,3}}{re.escape(char)}{{{length},}}\s*$", line
+            ))
+            in_fence = True
+        elif fence:
+            delimiter = fence.group(1)
+            active_fence = (delimiter[0], len(delimiter))
+            in_fence = True
+        else:
+            in_fence = False
         stripped = line.strip()
-        if stripped.startswith("```"):
-            in_fence = not in_fence
         if (
             not in_fence
             and normalized
@@ -1688,6 +1706,8 @@ def _normalize_report_markdown(md_text: str) -> str:
         ):
             normalized.append("")
         normalized.append(line)
+        if closes_fence:
+            active_fence = None
     return "\n".join(normalized)
 
 

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -22,12 +22,15 @@ import hashlib
 import json
 import os
 import platform
+import re
 import subprocess
 import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlsplit
 
+import mistune
 import yaml
 
 
@@ -1581,10 +1584,15 @@ def _normalize_escapes(text: str) -> str:
                 .replace("\\t", "\t"))
 
 
-import re as _re
-from urllib.parse import urlsplit as _urlsplit
-
 _SAFE_LINK_SCHEMES = {"http", "https", "mailto"}
+_STATUS_CLS = {
+    "PASS": "pass",
+    "FIXED": "pass",
+    "FAIL": "fail",
+    "REGRESSION": "fail",
+    "SKIP": "skip",
+    "SKIPPED": "skip",
+}
 
 
 def _safe_href(raw: str) -> str | None:
@@ -1594,13 +1602,13 @@ def _safe_href(raw: str) -> str | None:
     `[click](javascript:alert(1))` or attribute-injection via stray quotes.
     Allows http/https/mailto URLs and relative paths/anchors only.
 
-    `raw` is expected to already be HTML-escaped (since `_md_inline` escapes
-    the full text before running the link regex), so we do not re-escape.
+    The caller must HTML-escape the returned value before using it in an
+    attribute.
     """
     href = raw.strip()
     if not href:
         return None
-    parsed = _urlsplit(href)
+    parsed = urlsplit(href)
     if parsed.scheme:
         if parsed.scheme.lower() not in _SAFE_LINK_SCHEMES:
             return None
@@ -1609,203 +1617,83 @@ def _safe_href(raw: str) -> str | None:
     return href
 
 
-def _md_inline(text: str) -> str:
-    """Apply inline markdown formatting (bold, italic, code, links) to text.
-    Always HTML-escapes first."""
-    text = _esc(text)
-    text = _re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', text)
-    text = _re.sub(r'(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)', r'<em>\1</em>', text)
-    text = _re.sub(r'`(.+?)`', r'<code>\1</code>', text)
+class _ReportHTMLRenderer(mistune.HTMLRenderer):
+    """HTML renderer preserving the report's styling and safety contracts."""
 
-    def _link_sub(match):
-        label = match.group(1)
-        href = _safe_href(match.group(2))
+    def block_code(self, code: str, info: str | None = None) -> str:
+        return f'<pre class="output">{_esc(code.rstrip(chr(10)))}</pre>\n'
+
+    def link(self, text: str, url: str, title: str | None = None) -> str:
+        href = _safe_href(url)
         if href is None:
-            return label
-        return f'<a href="{href}" rel="noopener noreferrer">{label}</a>'
+            return text
+        return (
+            f'<a href="{mistune.escape(href, quote=True)}" '
+            f'rel="noopener noreferrer">{text}</a>'
+        )
 
-    text = _re.sub(r'\[([^\]]+)\]\(([^)]+)\)', _link_sub, text)
-    return text
+    def softbreak(self) -> str:
+        return " "
+
+
+def _render_table_cell(renderer, text, align=None, head=False):
+    tag = "th" if head else "td"
+    style = f' style="text-align:{align}"' if align else ""
+    if not head:
+        status = None
+        rest = ""
+        for keyword, css_class in _STATUS_CLS.items():
+            plain = keyword
+            strong = f"<strong>{keyword}</strong>"
+            emphasis = f"<em>{keyword}</em>"
+            for prefix in (plain, strong, emphasis):
+                if text.startswith(prefix):
+                    status = (keyword, css_class)
+                    rest = text[len(prefix):].strip()
+                    break
+            if status:
+                break
+        if status:
+            keyword, css_class = status
+            pill = f'<span class="{css_class}">{keyword}</span>'
+            text = f"{pill} {rest}" if rest else pill
+    return f"  <{tag}{style}>{text}</{tag}>\n"
+
+
+_report_renderer = _ReportHTMLRenderer(escape=True)
+_markdown = mistune.create_markdown(
+    renderer=_report_renderer,
+    plugins=["table"],
+)
+_report_renderer.register("table_cell", _render_table_cell)
+
+
+def _normalize_report_markdown(md_text: str) -> str:
+    """Preserve the legacy renderer's top-level list termination behavior."""
+    lines = md_text.splitlines()
+    normalized = []
+    in_fence = False
+    list_item = re.compile(r"^(?:[-+*]|\d+[.)])\s+")
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+        if (
+            not in_fence
+            and normalized
+            and list_item.match(normalized[-1])
+            and stripped
+            and line == line.lstrip()
+            and not list_item.match(line)
+        ):
+            normalized.append("")
+        normalized.append(line)
+    return "\n".join(normalized)
 
 
 def _md_to_html(md_text):
-    """Convert markdown to HTML. Handles headers, lists, tables, code blocks,
-    bold, italic, inline code, and links."""
-    import re
-
-    lines = md_text.splitlines()
-    out = []
-    i = 0
-    list_stack = []  # stack of "ul" or "ol"
-
-    def _close_lists():
-        while list_stack:
-            out.append(f"</{list_stack.pop()}>")
-
-    _inline = _md_inline
-
-    while i < len(lines):
-        line = lines[i]
-        stripped = line.strip()
-
-        # Fenced code block
-        if stripped.startswith("```"):
-            _close_lists()
-            lang = stripped[3:].strip()
-            code_lines = []
-            i += 1
-            while i < len(lines) and not lines[i].strip().startswith("```"):
-                code_lines.append(lines[i])
-                i += 1
-            out.append(f'<pre class="output">{_esc(chr(10).join(code_lines))}</pre>')
-            i += 1
-            continue
-
-        # Table (line starts with |)
-        if stripped.startswith("|") and "|" in stripped[1:]:
-            _close_lists()
-            table_lines = []
-            while i < len(lines) and lines[i].strip().startswith("|"):
-                table_lines.append(lines[i].strip())
-                i += 1
-            out.append(_md_table_to_html(table_lines))
-            continue
-
-        # Headers — # maps to h1, ## to h2, ### to h3
-        if stripped.startswith("### "):
-            _close_lists()
-            out.append(f"<h3>{_inline(stripped[4:])}</h3>")
-            i += 1
-            continue
-        if stripped.startswith("## "):
-            _close_lists()
-            out.append(f"<h2>{_inline(stripped[3:])}</h2>")
-            i += 1
-            continue
-        if stripped.startswith("# "):
-            _close_lists()
-            out.append(f"<h1>{_inline(stripped[2:])}</h1>")
-            i += 1
-            continue
-
-        # Unordered list
-        if stripped.startswith("- "):
-            if not list_stack or list_stack[-1] != "ul":
-                if list_stack and list_stack[-1] == "ol":
-                    out.append(f"</{list_stack.pop()}>")
-                list_stack.append("ul")
-                out.append("<ul>")
-            out.append(f"<li>{_inline(stripped[2:])}</li>")
-            i += 1
-            continue
-
-        # Ordered list
-        m = re.match(r'^(\d+)\.\s(.+)', stripped)
-        if m:
-            if not list_stack or list_stack[-1] != "ol":
-                if list_stack and list_stack[-1] == "ul":
-                    out.append(f"</{list_stack.pop()}>")
-                list_stack.append("ol")
-                out.append("<ol>")
-            out.append(f"<li>{_inline(m.group(2))}</li>")
-            i += 1
-            continue
-
-        # Horizontal rule
-        if stripped in ("---", "***", "___"):
-            _close_lists()
-            out.append("<hr>")
-            i += 1
-            continue
-
-        # Blank line — only close lists if the next content line isn't a
-        # continuation of the same list type (LLM rationales commonly use
-        # paragraph-spaced list items like "1. ...\n\n2. ...").
-        if not stripped:
-            if list_stack:
-                j = i + 1
-                while j < len(lines) and not lines[j].strip():
-                    j += 1
-                next_stripped = lines[j].strip() if j < len(lines) else ""
-                continues_ol = list_stack[-1] == "ol" and re.match(r'^\d+\.\s', next_stripped)
-                continues_ul = list_stack[-1] == "ul" and next_stripped.startswith("- ")
-                if not (continues_ol or continues_ul):
-                    _close_lists()
-            i += 1
-            continue
-
-        # Paragraph — accumulate consecutive non-blank lines into a single
-        # <p> so that soft-wrapped source lines reflow to the container width
-        # instead of each becoming its own (artificially narrow) paragraph.
-        _close_lists()
-        para_lines = [stripped]
-        i += 1
-        while i < len(lines):
-            nxt = lines[i].strip()
-            if not nxt:
-                break
-            # Stop at anything that begins a different block-level construct.
-            if (nxt.startswith("```")
-                    or (nxt.startswith("|") and "|" in nxt[1:])
-                    or nxt.startswith(("### ", "## ", "# ", "- "))
-                    or re.match(r'^(\d+)\.\s(.+)', nxt)
-                    or nxt in ("---", "***", "___")):
-                break
-            para_lines.append(nxt)
-            i += 1
-        out.append(f"<p>{_inline(' '.join(para_lines))}</p>")
-
-    _close_lists()
-    return "\n".join(out)
-
-
-def _md_table_to_html(table_lines):
-    """Convert markdown table lines to an HTML table."""
-    if len(table_lines) < 2:
-        return ""
-
-    def _parse_row(line):
-        cells = [c.strip() for c in line.strip().strip("|").split("|")]
-        return cells
-
-    headers = _parse_row(table_lines[0])
-
-    # Skip separator row (line with dashes/colons)
-    data_start = 1
-    if len(table_lines) > 1 and all(
-            c.strip().replace("-", "").replace(":", "").replace(" ", "") == ""
-            for c in table_lines[1].strip().strip("|").split("|")):
-        data_start = 2
-
-    html = "<table>\n<tr>"
-    for h in headers:
-        html += f"<th>{_md_inline(h)}</th>"
-    html += "</tr>\n"
-
-    for row_line in table_lines[data_start:]:
-        cells = _parse_row(row_line)
-        html += "<tr>"
-        for c in cells:
-            # Color-code PASS/FAIL keywords as pills, leaving the rest
-            # of the cell as plain text.
-            import re as _re
-            stripped = c.strip()
-            bare = stripped.strip("*_")
-            _STATUS_CLS = {"PASS": "pass", "FIXED": "pass", "FAIL": "fail",
-                           "REGRESSION": "fail", "SKIP": "skip", "SKIPPED": "skip"}
-            match = _re.match(r'^(\*{0,2}_?)(PASS|FIXED|FAIL|REGRESSION|SKIP|SKIPPED)(_?\*{0,2})(.*)', bare)
-            if match:
-                kw = match.group(2)
-                rest = match.group(4).strip()
-                pill = f'<span class="{_STATUS_CLS[kw]}">{kw}</span>'
-                rest_html = f" {_md_inline(rest)}" if rest else ""
-                html += f"<td>{pill}{rest_html}</td>"
-            else:
-                html += f"<td>{_md_inline(c)}</td>"
-        html += "</tr>\n"
-
-    html += "</table>"
-    return html
+    """Convert untrusted Markdown to escaped, report-styled HTML."""
+    return _markdown(_normalize_report_markdown(md_text)).rstrip("\n")
 
 
 _img_compare_counter = 0

--- a/tests/test_report_markdown.py
+++ b/tests/test_report_markdown.py
@@ -63,3 +63,41 @@ def test_paragraph_stops_at_fenced_code():
     assert "<p>Some prose that wraps.</p>" in html
     assert "code line" in html
     assert html.count("<p>") == 1
+
+
+def test_untrusted_html_and_harmful_links_are_not_rendered():
+    html = _md_to_html('<script>alert(1)</script>\n\n[bad](javascript:evil)')
+    assert "<script>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "javascript:" not in html
+    assert "bad" in html
+
+
+def test_safe_links_are_escaped_and_hardened():
+    html = _md_to_html("[docs](https://example.com/a?x=1&y=2)")
+    assert 'href="https://example.com/a?x=1&amp;y=2"' in html
+    assert 'rel="noopener noreferrer"' in html
+
+
+def test_code_blocks_keep_output_style_and_escape_html():
+    html = _md_to_html("```html\n<script>x</script>\n```")
+    assert html == (
+        '<pre class="output">&lt;script&gt;x&lt;/script&gt;</pre>'
+    )
+
+
+def test_table_statuses_keep_report_pill_classes():
+    html = _md_to_html(
+        "| Result | Detail |\n"
+        "|---|---|\n"
+        "| **PASS** | all good |\n"
+        "| REGRESSION details | bad |\n"
+    )
+    assert '<span class="pass">PASS</span>' in html
+    assert '<span class="fail">REGRESSION</span> details' in html
+
+
+def test_nested_lists_use_commonmark_structure():
+    html = _md_to_html("- parent\n  - child\n")
+    assert html.count("<ul>") == 2
+    assert "<li>child</li>" in html

--- a/tests/test_report_markdown.py
+++ b/tests/test_report_markdown.py
@@ -92,12 +92,27 @@ def test_table_statuses_keep_report_pill_classes():
         "|---|---|\n"
         "| **PASS** | all good |\n"
         "| REGRESSION details | bad |\n"
+        "| SKIPPED | not run |\n"
+        "| PASSING | ordinary text |\n"
     )
     assert '<span class="pass">PASS</span>' in html
     assert '<span class="fail">REGRESSION</span> details' in html
+    assert '<span class="skip">SKIPPED</span>' in html
+    assert '<span class="pass">PASS</span>ING' not in html
+    assert "<td>PASSING</td>" in html
 
 
 def test_nested_lists_use_commonmark_structure():
     html = _md_to_html("- parent\n  - child\n")
     assert html.count("<ul>") == 2
     assert "<li>child</li>" in html
+
+
+def test_tilde_fenced_code_is_not_normalized():
+    html = _md_to_html("~~~\n- literal\nplain\n~~~")
+    assert html == '<pre class="output">- literal\nplain</pre>'
+
+
+def test_extended_backtick_fence_is_not_normalized():
+    html = _md_to_html("````\n- literal\nplain\n````")
+    assert html == '<pre class="output">- literal\nplain</pre>'


### PR DESCRIPTION
Closes #93.

## Summary

- replace the hand-written Markdown block and inline parser with Mistune 3
- keep report-specific code block styling and PASS/FAIL/SKIP table badges through a custom renderer
- preserve soft-wrapped paragraph and top-level list behavior used by generated rationales
- keep raw HTML escaped and retain the existing safe-link allowlist
- install Mistune in both package and standalone skill dependency paths

## Validation

- `uv run pytest -q tests/test_report_markdown.py` (10 passed)
- `uv run pytest -q` (759 passed, 2 skipped, 2 deselected)
- `uv lock --check`
- `python -m py_compile skills/eval-run/scripts/report.py scripts/ensure_deps.py`
- `git diff --check`

## Compatibility

This keeps the report's existing CSS hooks and link-safety behavior while adding CommonMark parsing, including nested lists. Mistune is constrained to `>=3.0,<4.0` as a base dependency because report rendering is always available.

## AI assistance disclosure

OpenAI Codex assisted with issue investigation, implementation, test authoring, and validation. I reviewed the resulting diff and test results before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved HTML report rendering with broader Markdown support, including nested lists, fenced code blocks, and table status indicators.
  * Preserved report styling for status pills and code blocks.

* **Bug Fixes**
  * Improved handling of special characters in Markdown, links, and code samples.
  * Blocked unsafe links and strengthened link escaping to help prevent harmful content from appearing in reports.

* **Tests**
  * Added coverage for Markdown formatting, link safety, HTML escaping, code blocks, status indicators, and nested lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->