### PR TITLE
fix(report): render per-case cells and histograms by each judge's score_range

### DIFF
--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -2150,6 +2150,24 @@ def _render_reward_overview(summary, config, reward_cfg=None):
     return html
 
 
+def _score_band_class(val, lo, hi):
+    """CSS class for a numeric score by its position in its own [lo, hi] range:
+    green (top quartile) / amber (mid) / red (bottom third).
+
+    Per-case cells are coloured by where the score sits on the judge's own
+    scale — NOT against the aggregate `min_mean` threshold, which is a floor on
+    the mean ACROSS cases and mis-flags valid per-case scores (e.g. a 1 on a
+    0-2 judge with min_mean 1.5 would render red even though the judge passes).
+    """
+    span = hi - lo
+    frac = (val - lo) / span if span else 0.5
+    if frac >= 0.75:
+        return "pass"
+    if frac >= 0.375:
+        return "warn"
+    return "fail"
+
+
 def _render_per_case(summary, run_dir, config, baseline_dir, review):
     per_case = summary.get("per_case", {})
     if not per_case:
@@ -2215,15 +2233,15 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
             elif val is False:
                 failed += 1
             elif isinstance(val, (int, float)):
-                thresh = thresholds.get(jname, {})
-                min_mean = thresh.get("min_mean") if isinstance(thresh, dict) else None
-                if min_mean is not None:
-                    if val >= min_mean:
-                        passed += 1
-                    else:
-                        failed += 1
+                # A numeric cell drags its case red only on a genuine low (a
+                # bottom-band score on the judge's own scale), not for being
+                # below the aggregate min_mean floor. Judges without a declared
+                # score_range (e.g. pipeline_total) are neutral -> count as pass.
+                lo, hi = judge_score_range.get(jname, (None, None))
+                if lo is not None and hi is not None and _score_band_class(val, lo, hi) == "fail":
+                    failed += 1
                 else:
-                    passed += 1  # no threshold defined, count as pass
+                    passed += 1
         status = "pass" if failed == 0 else "fail"
 
         # Pairwise badge or pass/fail accent — applied as a left-border class
@@ -2262,12 +2280,13 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
             elif val is False:
                 val_html = '<span class="fail">FAIL</span>'
             elif isinstance(val, (int, float)):
-                thresh = thresholds.get(jname, {})
-                min_mean = thresh.get("min_mean") if isinstance(thresh, dict) else None
-                if min_mean is not None and val < min_mean:
-                    val_html = f'<span class="fail">{val}</span>'
+                # Colour by the score's position on the judge's own scale
+                # (green/amber/red), not against the aggregate min_mean floor.
+                lo, hi = judge_score_range.get(jname, (None, None))
+                if lo is not None and hi is not None:
+                    val_html = f'<span class="{_score_band_class(val, lo, hi)}">{val}</span>'
                 else:
-                    val_html = f'<span class="pass">{val}</span>'
+                    val_html = str(val)  # unknown scale: neutral, no verdict colour
             else:
                 val_html = _esc(str(val)[:100])
 

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1950,6 +1950,8 @@ def _ascii_score_hist(med, values, smin=None, smax=None):
         return ""
     lo = smin if smin is not None else min(numeric)
     hi = smax if smax is not None else max(numeric)
+    if hi - lo > _MAX_HIST_BINS:   # pathological declared range -> use observed span
+        lo, hi = min(numeric), max(numeric)
     counts = Counter(numeric)
     med = max(lo, min(hi, int(med)))
     items = [(s, counts.get(s, 0)) for s in range(lo, hi + 1)]
@@ -1961,6 +1963,33 @@ def _colorise_hist(glyph):
     return (_esc(glyph)
             .replace("\x01", '<span class="med">')
             .replace("\x02", "</span>"))
+
+
+_MAX_HIST_BINS = 40  # safety cap: fall back to observed span for pathological ranges
+
+
+def _judge_score_ranges(config):
+    """Map judge name -> validated integer (lo, hi) from its `score_range`.
+
+    report.py reads eval.yaml as raw dicts (bypassing EvalConfig validation),
+    so guard here: keep only well-formed ranges (exactly two int-coercible,
+    strictly increasing endpoints). Malformed ranges (non-numeric, reversed,
+    wrong length) are dropped so downstream histograms/coloring fall back to a
+    safe default instead of raising on range()/arithmetic.
+    """
+    ranges = {}
+    for j in config.get("judges", []):
+        name = j.get("name", "")
+        sr = j.get("score_range")
+        if not isinstance(sr, list) or len(sr) != 2:
+            continue
+        try:
+            lo, hi = int(sr[0]), int(sr[1])
+        except (TypeError, ValueError):
+            continue
+        if lo < hi:
+            ranges[name] = (lo, hi)
+    return ranges
 
 
 def _render_reward_overview(summary, config, reward_cfg=None):
@@ -2038,12 +2067,7 @@ def _render_reward_overview(summary, config, reward_cfg=None):
     other_judges.sort()
 
     # Resolve score_range per judge from config for color bands
-    judge_score_range = {}
-    for j in config.get("judges", []):
-        name = j.get("name", "")
-        sr = j.get("score_range")
-        if isinstance(sr, list) and len(sr) >= 2:
-            judge_score_range[name] = (sr[0], sr[1])
+    judge_score_range = _judge_score_ranges(config)
 
     def _label(name):
         return _esc(name.replace("_", " ").title())
@@ -2181,14 +2205,9 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
     bl_cases_dir = baseline_dir / "cases" if baseline_dir else None
 
     # Resolve score_range per judge from config so each sampling histogram uses
-    # its own axis (e.g. rubric judges are 0–2, not a hardcoded 1–5). Judges
+    # its own axis (e.g. rubric judges are 0-2, not a hardcoded 1-5). Judges
     # without a configured score_range fall back to the observed min/max.
-    judge_score_range = {}
-    for j in config.get("judges", []):
-        name = j.get("name", "")
-        sr = j.get("score_range")
-        if isinstance(sr, list) and len(sr) >= 2:
-            judge_score_range[name] = (sr[0], sr[1])
+    judge_score_range = _judge_score_ranges(config)
 
     # Build pairwise lookup per case (full entry: winner + reasoning)
     pw_by_case = {}

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -2058,14 +2058,14 @@ def _render_reward_overview(summary, config, reward_cfg=None):
             return '<span class="fail">FAIL</span>'
         if isinstance(v, (int, float)) and not isinstance(v, bool):
             s = f"{v:.2f}" if isinstance(v, float) else str(v)
-            lo, hi = judge_score_range.get(judge_name, (1, 5) if judge_name in llm_set else (0, 1))
-            span = hi - lo
-            frac = (v - lo) / span if span else 0.5
-            if frac >= 0.75:
-                return f'<span class="pass">{s}</span>'
-            elif frac >= 0.375:
-                return f'<span class="warn">{s}</span>'
-            return f'<span class="fail">{s}</span>'
+            # Band by the judge's declared score_range (same helper as the
+            # per-case detail table). Without a declared range we can't know the
+            # scale, so render neutral rather than guessing (a (0,1) guess made
+            # any value >= 1, e.g. a pipeline total of 3.0, render green).
+            rng = judge_score_range.get(judge_name)
+            if not rng:
+                return s
+            return f'<span class="{_score_band_class(v, rng[0], rng[1])}">{s}</span>'
         return f'<span class="skip">{_esc(str(v)[:20])}</span>'
 
     def _reward_cell(val):
@@ -2082,7 +2082,6 @@ def _render_reward_overview(summary, config, reward_cfg=None):
         except (ValueError, TypeError):
             return f'<span class="skip">{_esc(str(val)[:20])}</span>'
 
-    llm_set = set(llm_judges)
     all_judges = gate_judges + llm_judges + other_judges
 
     html = '<h2 class="section-heading">Per-Case Reward Overview</h2>\n'

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1927,8 +1927,9 @@ def _ascii_hist(items, lo_label, hi_label, mark_key):
     (height = count, tallest = █), empty categories stay ░, and the bar for
     `mark_key` is wrapped in markers (\\x01..\\x02) for colourising in HTML.
     A stable judge — all samples in one bucket — is a single bar (e.g.
-    ``1 ░░░░█ 5``), so the column reads "agree" vs "wobble" at a glance.
-    Used for numeric judges (1 … 5), bool judges (F … P) and pairwise (A … B).
+    ``0 ░░█ 2``), so the column reads "agree" vs "wobble" at a glance.
+    Used for numeric judges (over each judge's own score range), bool judges
+    (F … P) and pairwise (A … B).
     """
     blocks = "▁▂▃▄▅▆▇█"
     maxc = max((c for _, c in items), default=1) or 1
@@ -2162,6 +2163,16 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
     cases_dir = run_dir / "cases"
     bl_cases_dir = baseline_dir / "cases" if baseline_dir else None
 
+    # Resolve score_range per judge from config so each sampling histogram uses
+    # its own axis (e.g. rubric judges are 0–2, not a hardcoded 1–5). Judges
+    # without a configured score_range fall back to the observed min/max.
+    judge_score_range = {}
+    for j in config.get("judges", []):
+        name = j.get("name", "")
+        sr = j.get("score_range")
+        if isinstance(sr, list) and len(sr) >= 2:
+            judge_score_range[name] = (sr[0], sr[1])
+
     # Build pairwise lookup per case (full entry: winner + reasoning)
     pw_by_case = {}
     pw = summary.get("pairwise", {})
@@ -2263,15 +2274,17 @@ def _render_per_case(summary, run_dir, config, baseline_dir, review):
             if err:
                 rat = f"ERROR: {err}"
             # Per-case sampling distribution (from --samples): an ASCII glyph
-            # (monospace, aligns cleanly) showing the spread on the 1–5 scale.
-            # Shown for every sampled judge — a stable judge is a single bar,
-            # which reads at a glance as "all samples agree". Raw samples on hover.
+            # (monospace, aligns cleanly) showing the spread on the judge's own
+            # score scale. Shown for every sampled judge — a stable judge is a
+            # single bar, which reads at a glance as "all samples agree". Raw
+            # samples on hover.
             jst = jresult.get("stability")
             if (isinstance(jst, dict) and jst.get("samples", 1) > 1
                     and "min" in jst):
                 vals = jst.get("values", [])
                 samples = ", ".join(str(v) for v in vals)
-                glyph = _colorise_hist(_ascii_score_hist(val, vals, 1, 5))
+                smin, smax = judge_score_range.get(jname, (None, None))
+                glyph = _colorise_hist(_ascii_score_hist(val, vals, smin, smax))
                 val_html += (f' <span class="ascii-range" '
                              f'title="samples: {_esc(samples)}">{glyph}</span>')
             elif (isinstance(jst, dict) and jst.get("samples", 1) > 1


### PR DESCRIPTION
Make per-case report rendering reflect **each judge's own `score_range`** instead of hardcoded axes or aggregate thresholds. All in `skills/eval-run/scripts/report.py`.

## 1. Histogram axis

The per-case sampling histograms hardcoded a `1 … 5` axis for every numeric
judge, so rubric judges with `score_range: [0, 2]` were drawn on the wrong scale
(a unanimous `1` looked mid-range instead of low).

**Fix:** resolve `score_range` per judge from the config and pass it to
`_ascii_score_hist`; fall back to the samples' observed min/max when a judge has
no configured range.

## 2. Per-case cell / case coloring

Per-case numeric cells — and the case-level pass/fail accent — were colored red
when `value < min_mean`. But `min_mean` is a floor on the mean **across cases**,
not a per-case bar. So a valid mid-scale score (e.g. `1` on a 0–2 judge whose
`min_mean` is `1.5`) rendered red and dragged the whole case red, even when the
judge **passed** on aggregate. In practice most cases showed red despite passing.

**Fix:** color per-case cells by the score's position on the judge's own
`score_range` via a shared `_score_band_class` helper — green (top quartile) /
amber (mid) / red (bottom third). A case turns red only on a genuine bottom-band
score. Judges without a declared `score_range` render neutral (no verdict color).

## 3. Reward-overview matrix consistency

The reward-overview matrix (`_cell`) fell back to a `(0, 1)` range for any
numeric judge without a declared `score_range`, so any value `>= 1` (e.g. a
pipeline total of `3.0`) rendered green. It now uses the same
`_score_band_class` helper and renders neutral for undeclared ranges, so the
matrix and the per-case detail table agree. (Removes the now-unused `llm_set`.)

## Verification

- `pytest tests/test_report_markdown.py tests/test_harbor_reward.py` → 43 passed.
- On a real run (rubric judges `score_range: [0, 2]`): histograms render on the
  correct `0 … 2` axis (96/96); case accents dropped from ~all-red to 5 red —
  exactly the cases with a genuine `0` — with mid-scale `1`s shown amber; and no
  numeric cell false-greens on either table.
