### PR TITLE
feat(runner): add runner.permission_mode for Claude Code

### DIFF
--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -86,7 +86,10 @@ class ClaudeCodeRunner(EvalRunner):
                 f"Invalid effort '{effort}'. "
                 f"Must be one of: {sorted(self._VALID_EFFORTS)}")
         self._effort = effort
-        if permission_mode and permission_mode not in self._VALID_PERMISSION_MODES:
+        if permission_mode is not None and (
+            not isinstance(permission_mode, str)
+            or permission_mode not in self._VALID_PERMISSION_MODES
+        ):
             raise ValueError(
                 f"Invalid permission_mode '{permission_mode}'. "
                 f"Must be one of: {sorted(self._VALID_PERMISSION_MODES)}")

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -37,6 +37,9 @@ class ClaudeCodeRunner(EvalRunner):
     """Runs skills using the Claude Code CLI in non-interactive mode."""
 
     _VALID_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
+    _VALID_PERMISSION_MODES = {
+        "default", "acceptEdits", "plan", "auto", "dontAsk", "bypassPermissions",
+    }
 
     @classmethod
     def from_config(cls, config, *, log_prefix=None, **overrides):
@@ -52,6 +55,8 @@ class ClaudeCodeRunner(EvalRunner):
             mlflow_experiment=overrides.get("mlflow_experiment"),
             mlflow_tracking_uri=overrides.get("mlflow_tracking_uri"),
             effort=overrides.get("effort", config.runner.effort),
+            permission_mode=overrides.get(
+                "permission_mode", config.runner.permission_mode),
             log_prefix=log_prefix,
         )
 
@@ -66,6 +71,7 @@ class ClaudeCodeRunner(EvalRunner):
         mlflow_tracking_uri: Optional[str] = None,
         log_prefix: Optional[str] = None,
         effort: Optional[str] = None,
+        permission_mode: Optional[str] = None,
     ):
         self._permissions = permissions or {}
         self._subagent_model = subagent_model
@@ -80,6 +86,11 @@ class ClaudeCodeRunner(EvalRunner):
                 f"Invalid effort '{effort}'. "
                 f"Must be one of: {sorted(self._VALID_EFFORTS)}")
         self._effort = effort
+        if permission_mode and permission_mode not in self._VALID_PERMISSION_MODES:
+            raise ValueError(
+                f"Invalid permission_mode '{permission_mode}'. "
+                f"Must be one of: {sorted(self._VALID_PERMISSION_MODES)}")
+        self._permission_mode = permission_mode
 
     @property
     def name(self) -> str:
@@ -122,6 +133,9 @@ class ClaudeCodeRunner(EvalRunner):
 
         if self._effort:
             cmd.extend(["--effort", self._effort])
+
+        if self._permission_mode:
+            cmd.extend(["--permission-mode", self._permission_mode])
 
         for plugin_dir in self._plugin_dirs:
             cmd.extend(["--plugin-dir", str(plugin_dir)])

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -371,6 +371,10 @@ class RunnerConfig:
     env: dict = field(default_factory=dict)
     system_prompt: Optional[str] = None
     effort: Optional[str] = None  # Claude Code: low | medium | high | xhigh | max
+    # Claude Code: default | acceptEdits | plan | auto | dontAsk | bypassPermissions.
+    # Passed as --permission-mode (a CLI flag), so it applies even in untrusted
+    # isolated workspaces where settings-file permissions are trust-gated.
+    permission_mode: Optional[str] = None
 
 
 def _parse_runner_config(runner_raw, *, context="runner"):
@@ -404,6 +408,7 @@ def _parse_runner_config(runner_raw, *, context="runner"):
         env=runner_raw.get("env", {}) or {},
         system_prompt=runner_raw.get("system_prompt"),
         effort=runner_raw.get("effort"),
+        permission_mode=runner_raw.get("permission_mode"),
     )
 
 


### PR DESCRIPTION
## Motivation

In isolated (per-case) workspaces the directory is untrusted, so recent Claude
Code versions ignore the `permissions.allow` and `additionalDirectories` from
the staged `.claude/settings.json`, and in headless `--print` mode it can never
show the trust dialog to grant them. The runner had no way to select a
permission mode, so evals ran in the default mode and legitimate tool calls were
denied (then retried/worked around, inflating cost and turns).

`--permission-mode` is a CLI flag, so it applies regardless of workspace trust.
Combined with `permissions.allow` (which flows to `--allowed-tools`, also
trust-independent), `dontAsk` gives a prompt-free, deny-by-default headless run.

## Change

- `RunnerConfig.permission_mode`, parsed in `_parse_runner_config` so the
  top-level `runner:`, per-step `execution.steps[].runner:`, and judge
  `agent.runner:` blocks all honor it.
- `ClaudeCodeRunner`: validated against
  `{default, acceptEdits, plan, auto, dontAsk, bypassPermissions}`, threaded
  through `from_config` → constructor, and emitted as `--permission-mode <mode>`.
- No behavior change when unset.

## Usage

```yaml
runner:
  type: claude-code
  permission_mode: dontAsk
permissions:
  allow: [Skill, Agent, "Edit(/tmp/scratch/**)", "Bash(python3 *)"]
```

## Verification

- `pytest tests/` (excluding e2e/evalhub) → 828 passed, 2 skipped.
- Confirmed `--permission-mode dontAsk` reaches the Claude subprocess; with a
  matching `permissions.allow`, per-case permission denials on a real eval case
  dropped from 6 to 0 with identical output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable permission modes for Claude Code execution.
  * Supports modes including default, planning, edit approval, automatic, and permission-bypass options.
  * Permission mode can be set in configuration or overridden when starting a run.
  * Invalid permission modes are rejected with validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->