### PR TITLE
docs: document runner.permission_mode and score_range on numeric judges

### DIFF
--- a/website/reference/config/judges.md
+++ b/website/reference/config/judges.md
@@ -82,7 +82,7 @@ flowchart TD
 | `feedback_type` | string | LLM, agent | `bool` selects a `passed` verdict; any other value selects a numeric `score` (bounds from `score_range`). Inferred if omitted. |
 | `model` | string | LLM, agent | Per-judge model override (highest precedence). |
 | `samples` | int | LLM, agent | Run N times per case and reduce (median/majority). Default `1`. |
-| `score_range` | `[min, max]` | numeric (LLM, agent) | Numeric bounds + report-color scale. Default `[1, 5]` for LLM/agent, `[0, 1]` for other numeric judges; agent judges use it in the `score.json` contract. |
+| `score_range` | `[min, max]` | numeric | Numeric bounds + report-color scale. LLM/agent default `[1, 5]`; agent judges use it in the `score.json` contract. Also honored on numeric `check`/`builtin` judges to band their per-case report cells (e.g. `score_range: [0, 8]` for a 0-8 total). A numeric judge with no `score_range` renders neutral (uncolored) in per-case cells. |
 
 !!! note "Boolean vs numeric aggregation"
     A judge whose values are all booleans aggregates into a **pass rate**; all-numeric

--- a/website/reference/config/runner.md
+++ b/website/reference/config/runner.md
@@ -35,6 +35,7 @@ Not every runner reads every field. The matrix below shows where each field land
 | --- | --- | :---: | :---: | :---: |
 | `type` | `str` | discriminator | discriminator | discriminator |
 | `effort` | `str` (enum) | `--effort` flag | `{effort}` placeholder | — |
+| `permission_mode` | `str` (enum) | `--permission-mode` flag | — | — |
 | `settings` | `dict` | merged into workspace `.claude/settings.json` | — | connection settings (see below) |
 | `plugin_dirs` | `list[str]` | one `--plugin-dir` per entry | — | — |
 | `env` | `dict` | injected on the safe allowlist | — (uses `execution.env`) | — |
@@ -69,6 +70,30 @@ overrides this field. For the `cli` runner it is exposed as the `{effort}` place
 runner:
   type: claude-code
   effort: high        # low | medium | high | xhigh | max
+```
+
+### `permission_mode`
+
+Claude Code permission mode, passed as the `--permission-mode` CLI flag. Because
+it is a CLI flag (not a settings-file key), it applies even in the untrusted,
+isolated per-case workspaces where `.claude/settings.json` `permissions.allow` /
+`additionalDirectories` are trust-gated and the trust dialog can't appear in
+headless mode. One of:
+
+| Value | `default` | `acceptEdits` | `plan` | `auto` | `dontAsk` | `bypassPermissions` |
+| --- | --- | --- | --- | --- | --- | --- |
+
+An invalid value raises at construction time for `claude-code`; `cli` and
+`responses-api` ignore the field. For a prompt-free, deny-by-default headless
+run, pair `dontAsk` (allows only what's pre-approved) with a complete
+[`permissions.allow`](permissions.md) list (fed to `--allowed-tools`, also
+trust-independent). `bypassPermissions` skips all prompts — isolated
+environments (containers/VMs) only.
+
+```yaml
+runner:
+  type: claude-code
+  permission_mode: dontAsk   # default | acceptEdits | plan | auto | dontAsk | bypassPermissions
 ```
 
 ### `settings`

--- a/website/reference/eval-yaml.md
+++ b/website/reference/eval-yaml.md
@@ -348,7 +348,7 @@ thresholds:
 <div class="grid cards" markdown>
 
 - [**execution**](config/execution.md) — mode, skill/prompt, arguments, timeout, budget, parallelism, env
-- [**runner**](config/runner.md) — type, effort, settings, plugin_dirs, env, system_prompt, command, workspace_mode
+- [**runner**](config/runner.md) — type, effort, permission_mode, settings, plugin_dirs, env, system_prompt, command, workspace_mode
 - [**models**](config/models.md) — skill, subagent, judge, hook roles and precedence
 - [**permissions**](config/permissions.md) — allow/deny patterns and the path-based compiler
 - [**mlflow**](config/mlflow.md) — experiment, tracking_uri, tags


### PR DESCRIPTION
Documentation catch-up for two config knobs that are in the code but missing from the reference docs.

## `runner.permission_mode` (shipped in #175, undocumented)

- `config/runner.md`: add `permission_mode` to the field matrix and a dedicated section — the enum values, that it's passed as the `--permission-mode` CLI flag (so it applies in the untrusted isolated per-case workspaces where settings-file permissions are trust-gated), and guidance (`dontAsk` + a complete `permissions.allow` for prompt-free deny-by-default runs; `bypassPermissions` for isolated envs only).
- `eval-yaml.md`: list `permission_mode` in the runner per-key reference.

## `score_range` on numeric judges (report banding)

- `config/judges.md`: clarify `score_range` is also honored on numeric `check`/`builtin` judges to band their per-case report cells (e.g. `score_range: [0, 8]` for a 0-8 total), and that a numeric judge with no `score_range` now renders neutral (uncolored) in per-case cells.

Docs-only; no code changes.
