### PR TITLE
fix: resolve bootstrap venv via realpath; sync validate_eval Jinja vars

### DIFF
--- a/agent_eval/_bootstrap.py
+++ b/agent_eval/_bootstrap.py
@@ -89,7 +89,7 @@ def _activate():
     if os.environ.get(_SENTINEL):
         return
 
-    pkg_dir = os.path.dirname(os.path.abspath(__file__))
+    pkg_dir = os.path.dirname(os.path.realpath(__file__))
     plugin_root = os.path.dirname(pkg_dir)
     venv_python, site_dirs = _venv_python_and_site(plugin_root)
 

--- a/skills/eval-analyze/scripts/validate_eval.py
+++ b/skills/eval-analyze/scripts/validate_eval.py
@@ -18,6 +18,25 @@ import yaml
 sys.path.insert(0, str(Path(__file__).parent))
 from find_skills import find_skill
 
+# Variables the scoring renderer always injects into a judge template. Must stay
+# equal to the kwargs of the render() call at the end of
+# skills/eval-run/scripts/score.py::_render_jinja2_template — accepting a name
+# score.py doesn't pass means a judge prompt validates here and then renders as a
+# blank section at scoring time (score.py uses a logging Undefined, not
+# StrictUndefined, so nothing errors). tests/test_validate_eval.py pins the two
+# together so the lists can't drift again.
+STANDARD_TEMPLATE_VARS = {
+    "inputs",           # case input.yaml, pre-rendered as text
+    "annotations",      # dataset annotations (dict + formatted __str__)
+    "annotations_text", # formatted annotation text for display
+    "conversation",     # root-level assistant text from events
+    "tool_trace",       # chronological trace of tool calls (Read, Bash, etc.)
+    "outputs",          # collected output files/events proxy
+    "arguments",        # judge arguments from eval.yaml
+    "reasoning",        # conversation including extended thinking
+    "evidence",         # lazily extracted verifiable evidence
+}
+
 
 def _extract_template_variables(template_text):
     """Extract undeclared root variable names from a Jinja2 template.
@@ -48,20 +67,7 @@ def _validate_template_variables(judges, outputs, dataset_schema, errors, warnin
     # Build set of available output names
     output_names = {o.get("name", "") for o in outputs if o.get("name")}
 
-    # Standard variables the scoring renderer (score._render_jinja2_template)
-    # always injects. Keep in sync with that render() call.
-    standard_vars = {
-        "inputs",           # Loaded from dataset input.yaml
-        "annotations",      # dataset annotations (dict + formatted __str__)
-        "annotations_text", # formatted annotation text for display
-        "conversation",     # root-level assistant text from events
-        "tool_trace",       # chronological trace of tool calls (Read, Bash, etc.)
-        "events",           # tool call log
-        "outputs",          # collected output files/events proxy
-        "arguments",        # judge arguments from eval.yaml
-        "reasoning",        # model reasoning content
-        "evidence",         # extracted judge evidence
-    }
+    standard_vars = STANDARD_TEMPLATE_VARS
 
     had_undefined_vars = False
 
@@ -119,8 +125,8 @@ def _validate_template_variables(judges, outputs, dataset_schema, errors, warnin
         errors.append(
             "\n💡 Template variable errors detected. Common fixes:\n"
             "   • Ensure all {{ variable }} references match output names or standard variables\n"
-            "   • Standard variables (always available): inputs, annotations, annotations_text, "
-            "conversation, tool_trace, events, outputs, arguments, reasoning, evidence\n"
+            f"   • Standard variables (always available): "
+            f"{', '.join(sorted(STANDARD_TEMPLATE_VARS))}\n"
             "   • For custom variables, add them to outputs section in eval.yaml\n"
             "   • Check dataset.schema documents expected structure of input.yaml and annotations.yaml"
         )
@@ -141,9 +147,11 @@ def _test_render_judge_templates(judges, outputs, errors, warnings):
     env.filters["tojson"] = lambda v: _json.dumps(v, indent=2, default=str)
 
     output_names = {o.get("name", "") for o in outputs if o.get("name")}
+    # One entry per STANDARD_TEMPLATE_VARS name (pinned by tests/test_validate_eval.py),
+    # each shaped like what score.py actually injects — `inputs` is pre-rendered
+    # text, not a dict, so `{{ inputs.field }}` is a mistake the render surfaces.
     mock_data = {
         "conversation": "Mock conversation",
-        "events": [],
         "inputs": "**prompt**: Mock prompt",
         "annotations": {"category": "test", "expected_files": []},
         "annotations_text": "- **category**: test",
@@ -195,8 +203,7 @@ def _test_render_judge_templates(judges, outputs, errors, warnings):
             "  1. Ensure all {{ variable }} references match output names\n"
             "  2. For dataset files (input.yaml, annotations.yaml), verify they're loaded by scoring\n"
             "  3. Check dataset.schema documents the expected structure\n"
-            "  4. Standard variables: inputs, annotations, annotations_text, "
-            "conversation, events, outputs, arguments, reasoning, evidence, tool_trace"
+            f"  4. Standard variables: {', '.join(sorted(STANDARD_TEMPLATE_VARS))}"
         )
 
 

--- a/skills/eval-analyze/scripts/validate_eval.py
+++ b/skills/eval-analyze/scripts/validate_eval.py
@@ -51,7 +51,7 @@ def _validate_template_variables(judges, outputs, dataset_schema, errors, warnin
     # Standard variables the scoring renderer (score._render_jinja2_template)
     # always injects. Keep in sync with that render() call.
     standard_vars = {
-        "input",            # Loaded from dataset input.yaml
+        "inputs",           # Loaded from dataset input.yaml
         "annotations",      # dataset annotations (dict + formatted __str__)
         "annotations_text", # formatted annotation text for display
         "conversation",     # root-level assistant text from events
@@ -59,6 +59,8 @@ def _validate_template_variables(judges, outputs, dataset_schema, errors, warnin
         "events",           # tool call log
         "outputs",          # collected output files/events proxy
         "arguments",        # judge arguments from eval.yaml
+        "reasoning",        # model reasoning content
+        "evidence",         # extracted judge evidence
     }
 
     had_undefined_vars = False
@@ -96,11 +98,11 @@ def _validate_template_variables(judges, outputs, dataset_schema, errors, warnin
             )
 
         # Check for common mistakes with input/annotations
-        if "input" in vars_used:
+        if "inputs" in vars_used:
             # Warn if input.yaml expected fields aren't documented
             if not dataset_schema or "input.yaml" not in dataset_schema:
                 warnings.append(
-                    f"judges.{name} uses {{{{ input }}}} but dataset.schema doesn't document input.yaml structure. "
+                    f"judges.{name} uses {{{{ inputs }}}} but dataset.schema doesn't document input.yaml structure. "
                     f"Document expected fields (prompt, expected_api, expected_documentation, etc.)"
                 )
 
@@ -117,8 +119,8 @@ def _validate_template_variables(judges, outputs, dataset_schema, errors, warnin
         errors.append(
             "\n💡 Template variable errors detected. Common fixes:\n"
             "   • Ensure all {{ variable }} references match output names or standard variables\n"
-            "   • Standard variables (always available): input, annotations, annotations_text, "
-            "conversation, tool_trace, events, outputs, arguments\n"
+            "   • Standard variables (always available): inputs, annotations, annotations_text, "
+            "conversation, tool_trace, events, outputs, arguments, reasoning, evidence\n"
             "   • For custom variables, add them to outputs section in eval.yaml\n"
             "   • Check dataset.schema documents expected structure of input.yaml and annotations.yaml"
         )
@@ -142,11 +144,14 @@ def _test_render_judge_templates(judges, outputs, errors, warnings):
     mock_data = {
         "conversation": "Mock conversation",
         "events": [],
-        "input": {"prompt": "Mock prompt", "expected_documentation": []},
+        "inputs": "**prompt**: Mock prompt",
         "annotations": {"category": "test", "expected_files": []},
         "annotations_text": "- **category**: test",
         "arguments": {},
         "outputs": {"files": {}, "events": [], "conversation": ""},
+        "reasoning": "Mock reasoning",
+        "evidence": "Mock evidence",
+        "tool_trace": "",
     }
     # Add all declared outputs
     for name in output_names:
@@ -190,8 +195,8 @@ def _test_render_judge_templates(judges, outputs, errors, warnings):
             "  1. Ensure all {{ variable }} references match output names\n"
             "  2. For dataset files (input.yaml, annotations.yaml), verify they're loaded by scoring\n"
             "  3. Check dataset.schema documents the expected structure\n"
-            "  4. Standard variables: input, annotations, annotations_text, "
-            "conversation, events, outputs, arguments"
+            "  4. Standard variables: inputs, annotations, annotations_text, "
+            "conversation, events, outputs, arguments, reasoning, evidence, tool_trace"
         )
 
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -233,19 +233,25 @@ def test_bootstrap_symlink_realpath(tmp_path):
     symlink_path = skills_dir / "agent_eval"
     os.symlink(root / "agent_eval", symlink_path, target_is_directory=True)
     
-    code = textwrap.dedent("""
+    site = str(root / ".eval-venv" / "lib" / f"python{_RUNNING}" / "site-packages")
+    code = textwrap.dedent(f"""
         import sys
         import os
         # Insert scripts dir at front so we import the symlink, not the real package
         sys.path.insert(0, os.path.dirname(__file__))
         import agent_eval._bootstrap as b
-        
-        # Verify it was loaded via the symlink
-        assert 'skills' in b.__file__ or 'eval-analyze' in b.__file__
-        
-        # _bootstrap already ran on import, check if it successfully found .eval-venv
-        # by verifying that the venv's site-packages was appended to sys.path
-        print("VENV_ON_PATH=" + str(any('.eval-venv' in p for p in sys.path)))
+
+        # Loaded through the symlink, not the real package dir.
+        assert os.path.join("skills", "eval-analyze", "scripts") in b.__file__, b.__file__
+
+        # Only realpath resolution reaches <root>/.eval-venv from the symlinked
+        # package dir, so its site-packages landing on sys.path is the whole
+        # discriminator. Compare the EXACT path: a substring test for
+        # '.eval-venv' also matches the *runner's* own venv when the suite is run
+        # with .eval-venv/bin/python3, and would pass under abspath too.
+        want = {site!r}
+        print("VENV_ON_PATH=" + str(any(
+            os.path.realpath(p) == os.path.realpath(want) for p in sys.path)))
     """)
     script = skills_dir / "test_symlink.py"
     script.write_text(code)
@@ -258,4 +264,6 @@ def test_bootstrap_symlink_realpath(tmp_path):
                           capture_output=True, text=True, timeout=120)
     
     assert proc.returncode == 0, f"child failed:\n{proc.stdout}\n{proc.stderr}"
-    assert "VENV_ON_PATH=True" in proc.stdout, f"Venv was not activated (.eval-venv not in sys.path)\\nstdout: {proc.stdout}"
+    assert "VENV_ON_PATH=True" in proc.stdout, (
+        f"venv site-packages not on the child's sys.path — plugin_root was resolved "
+        f"through the symlink instead of to the real tree\nstdout: {proc.stdout}")

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -244,8 +244,8 @@ def test_bootstrap_symlink_realpath(tmp_path):
         assert 'skills' in b.__file__ or 'eval-analyze' in b.__file__
         
         # _bootstrap already ran on import, check if it successfully found .eval-venv
-        # by verifying the sentinel was set
-        print("DONE=" + str(os.environ.get('_AGENT_EVAL_BOOTSTRAP_DONE')))
+        # by verifying that the venv's site-packages was appended to sys.path
+        print("VENV_ON_PATH=" + str(any('.eval-venv' in p for p in sys.path)))
     """)
     script = skills_dir / "test_symlink.py"
     script.write_text(code)
@@ -258,4 +258,4 @@ def test_bootstrap_symlink_realpath(tmp_path):
                           capture_output=True, text=True, timeout=120)
     
     assert proc.returncode == 0, f"child failed:\n{proc.stdout}\n{proc.stderr}"
-    assert "DONE=1" in proc.stdout, "Venv was not activated (SENTINEL not set)"
+    assert "VENV_ON_PATH=True" in proc.stdout, f"Venv was not activated (.eval-venv not in sys.path)\\nstdout: {proc.stdout}"

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -223,3 +223,39 @@ def test_true_script_under_abi_mismatch_execs(tmp_path):
     code = _EXECV_SPY + "import agent_eval._bootstrap\nprint('NO EXEC')\n"
     proc, execd = _run_child(root, code)  # plain `python child_script.py`
     assert execd, f"expected execv on true-script ABI mismatch:\n{proc.stdout}\n{proc.stderr}"
+
+
+def test_bootstrap_symlink_realpath(tmp_path):
+    # Setup designed layout where agent_eval is imported via a symlink
+    root = _make_fake_plugin(tmp_path, _RUNNING)
+    skills_dir = root / "skills" / "eval-analyze" / "scripts"
+    skills_dir.mkdir(parents=True)
+    symlink_path = skills_dir / "agent_eval"
+    os.symlink(root / "agent_eval", symlink_path, target_is_directory=True)
+    
+    code = textwrap.dedent("""
+        import sys
+        import os
+        # Insert scripts dir at front so we import the symlink, not the real package
+        sys.path.insert(0, os.path.dirname(__file__))
+        import agent_eval._bootstrap as b
+        
+        # Verify it was loaded via the symlink
+        assert 'skills' in b.__file__ or 'eval-analyze' in b.__file__
+        
+        # _bootstrap already ran on import, check if it successfully found .eval-venv
+        # by verifying the sentinel was set
+        print("DONE=" + str(os.environ.get('_AGENT_EVAL_BOOTSTRAP_DONE')))
+    """)
+    script = skills_dir / "test_symlink.py"
+    script.write_text(code)
+    
+    env = dict(os.environ)
+    env.pop("_AGENT_EVAL_BOOTSTRAP_DONE", None)
+    env.pop("PYTHONPATH", None)  # Ensure it doesn't bypass the symlink
+    
+    proc = subprocess.run([sys.executable, str(script)], cwd=str(skills_dir), env=env,
+                          capture_output=True, text=True, timeout=120)
+    
+    assert proc.returncode == 0, f"child failed:\n{proc.stdout}\n{proc.stderr}"
+    assert "DONE=1" in proc.stdout, "Venv was not activated (SENTINEL not set)"

--- a/tests/test_validate_eval.py
+++ b/tests/test_validate_eval.py
@@ -1,0 +1,134 @@
+"""Tests for skills/eval-analyze/scripts/validate_eval.py judge-template checks.
+
+The validator hard-rejects a judge prompt that references a variable the scoring
+renderer won't inject, so its idea of the "standard variables" has to match
+score.py exactly. That list has drifted before in both directions — it once
+carried a phantom `input` (rejecting the only correct spelling, `inputs`) and a
+phantom `events` (accepting a name score.py never passes, which then renders as a
+blank section because score.py uses a logging Undefined, not StrictUndefined).
+
+test_standard_vars_match_score_renderer pins the two together so neither can move
+without the other.
+"""
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VALIDATE_EVAL = REPO_ROOT / "skills" / "eval-analyze" / "scripts" / "validate_eval.py"
+SCORE_PY = REPO_ROOT / "skills" / "eval-run" / "scripts" / "score.py"
+
+
+def _load(path, name):
+    sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+validate_eval = _load(VALIDATE_EVAL, "_validate_eval_under_test")
+
+
+def _score_render_kwargs():
+    """Keyword names of the `template.render(...)` call in _render_jinja2_template.
+
+    Parsed rather than imported: score.py pulls in the whole scoring stack, and
+    this only needs the contract at the bottom of one function.
+    """
+    tree = ast.parse(SCORE_PY.read_text(), filename=str(SCORE_PY))
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.FunctionDef)
+                and node.name == "_render_jinja2_template"):
+            continue
+        for call in ast.walk(node):
+            if (isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "render"):
+                return {kw.arg for kw in call.keywords if kw.arg}
+    pytest.fail("could not find template.render(...) in _render_jinja2_template")
+
+
+class TestStandardVarsContract:
+    def test_standard_vars_match_score_renderer(self):
+        assert validate_eval.STANDARD_TEMPLATE_VARS == _score_render_kwargs(), (
+            "validate_eval.STANDARD_TEMPLATE_VARS has drifted from the kwargs "
+            "score._render_jinja2_template actually injects. Accepting a name "
+            "score.py doesn't pass makes a judge prompt render a blank section; "
+            "rejecting one it does pass blocks a valid eval.yaml."
+        )
+
+    def test_inputs_is_standard_and_input_is_not(self):
+        """`input` is the execution.arguments variable (config.resolve_arguments),
+        never a judge one — the two namespaces are distinct."""
+        assert "inputs" in validate_eval.STANDARD_TEMPLATE_VARS
+        assert "input" not in validate_eval.STANDARD_TEMPLATE_VARS
+
+    def test_events_is_not_standard(self):
+        """Only reachable as `outputs.events`; score.py injects no root-level name."""
+        assert "events" not in validate_eval.STANDARD_TEMPLATE_VARS
+
+    def test_mock_render_data_covers_every_standard_var(self):
+        """_test_render_judge_templates must be able to render anything the
+        variable check accepts, or valid configs fail at the render step."""
+        errors, warnings = [], []
+        judge = {"name": "probe", "prompt": " ".join(
+            "{{ %s }}" % v for v in sorted(validate_eval.STANDARD_TEMPLATE_VARS))}
+        validate_eval._test_render_judge_templates([judge], [], errors, warnings)
+        assert errors == [], errors
+
+
+def _check(prompt):
+    """Run the variable check over a single LLM judge; return (errors, warnings)."""
+    errors, warnings = [], []
+    validate_eval._validate_template_variables(
+        [{"name": "quality", "prompt": prompt}],
+        [],                       # no declared outputs
+        "input.yaml: {prompt}",   # dataset schema documents input.yaml
+        errors, warnings,
+    )
+    return errors, warnings
+
+
+class TestJudgeTemplateValidation:
+    def test_inputs_validates_clean(self):
+        errors, _ = _check("Rate this: {{ inputs }}")
+        assert errors == [], errors
+
+    def test_reasoning_and_evidence_validate_clean(self):
+        errors, _ = _check("{{ reasoning }} {{ evidence }} {{ tool_trace }}")
+        assert errors == [], errors
+
+    def test_phantom_input_is_rejected(self):
+        errors, _ = _check("Rate this: {{ input.prompt }}")
+        assert any("input" in e for e in errors), errors
+
+    def test_events_is_rejected(self):
+        errors, _ = _check("Look at {{ events }}")
+        assert any("events" in e for e in errors), errors
+
+    def test_unknown_variable_is_rejected(self):
+        errors, _ = _check("Rate {{ definitely_not_a_variable }}")
+        assert any("definitely_not_a_variable" in e for e in errors), errors
+
+    def test_declared_output_is_accepted(self):
+        errors, warnings = [], []
+        validate_eval._validate_template_variables(
+            [{"name": "quality", "prompt": "Check {{ report }}"}],
+            [{"name": "report", "path": "out/"}],
+            "input.yaml: {prompt}",
+            errors, warnings,
+        )
+        assert errors == [], errors
+
+    def test_guidance_lists_the_real_variable_set(self):
+        """The 'Standard variables:' hint is generated from the same constant, so
+        it can't advertise a name the validator rejects."""
+        errors, _ = _check("{{ nope }}")
+        hint = "\n".join(errors)
+        assert "inputs" in hint
+        assert "events" not in hint


### PR DESCRIPTION
Skill scripts import agent_eval via scripts/agent_eval symlink. 
abspath kept the symlink path, so plugin_root became skills/.../scripts and .eval-venv was never found.
 Resolving via realpath fixes this.

Also sync validate_eval Jinja vars with score renderer. 
Replace phantom {{ input }} with {{ inputs }}; allow {{ reasoning }} and {{ evidence }} 
which score._render_jinja2_template always injects.

## Description
Two small harness bugs were found while running skill scripts via the designed `${CLAUDE_SKILL_DIR}/scripts/` path (import of `agent_eval` through the per-skill `scripts/agent_eval` symlink):

1. **`agent_eval/_bootstrap.py`** used `os.path.abspath(__file__)`, 
   which does not resolve that symlink. Plugin root was computed as `skills/<skill>/scripts`, so `.eval-venv` was not found and third-party deps looked missing under system `python3`.
3. **`skills/eval-analyze/scripts/validate_eval.py`** listed a phantom `{{ input }}` 
   standard variable and omitted `inputs` / `reasoning` / `evidence`, rejecting valid LLM judge templates that match `score._render_jinja2_template`.

## How Has This Been Tested?
The fix was tested locally with both a full skill run to ensure the `.eval-venv` is properly discovered and activated, and by running the unit tests using `pytest tests/ -v`, verifying that the behavior of `validate_eval` correctly allows `{{ inputs }}`, `{{ reasoning }}`, and `{{ evidence }}`. The `test_bootstrap.py` suite includes a new unit test for the symlink path validation.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability when evaluation tools are accessed through symbolic links.
  * Corrected template validation to recognize the `inputs` variable.
* **New Features**
  * Added support for `reasoning` and `evidence` as standard template variables.
* **Documentation**
  * Updated validation guidance, warnings, and sample rendering data to reflect the expanded set of supported template variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->