### PR TITLE
fix(deps): resolve venv deps from every eval.yaml, not just the first

### DIFF
--- a/scripts/ensure_deps.py
+++ b/scripts/ensure_deps.py
@@ -48,12 +48,29 @@ def main():
 
 
 def _resolve_deps(plugin_root):
-    """Determine which deps are needed based on eval.yaml."""
-    deps = [("pyyaml>=6.0", "yaml")]
+    """Determine which deps are needed, as the union over every eval.yaml.
 
-    eval_yaml = _find_eval_yaml(plugin_root)
-    if not eval_yaml or not eval_yaml.exists():
-        return deps
+    A project can hold several evals (``eval/<name>/eval.yaml`` is a supported
+    layout), and they don't need the same packages — one may log to MLflow while
+    another uses LLM judges. Resolving against a single config left the others
+    importing packages that were never installed, with the outcome depending on
+    discovery order.
+    """
+    deps = [("pyyaml>=6.0", "yaml")]
+    seen = {spec for spec, _ in deps}
+
+    for eval_yaml in _find_eval_yamls(plugin_root):
+        for spec, module in _deps_for_config(eval_yaml):
+            if spec not in seen:
+                seen.add(spec)
+                deps.append((spec, module))
+    return deps
+
+
+def _deps_for_config(eval_yaml):
+    """Optional deps implied by one eval.yaml. Never raises — an unparseable or
+    unreadable config contributes nothing rather than sinking the whole scan."""
+    deps = []
 
     try:
         import yaml
@@ -178,20 +195,28 @@ def _all_importable(venv_python, deps):
     return result.returncode == 0
 
 
-def _find_eval_yaml(plugin_root):
+def _find_eval_yamls(plugin_root):
+    """Every eval.yaml in the project, in discovery order.
+
+    Deliberately *all* of them, not ``configs[0]``: deps are the union across the
+    project, so which config happens to sort first must not decide what gets
+    installed. The fallback stays first-match — it only runs when discovery itself
+    failed, and cwd/eval.yaml vs plugin_root/eval.yaml are alternatives rather
+    than siblings.
+    """
     cwd = Path.cwd()
     try:
         sys.path.insert(0, str(Path(__file__).parent.parent))
         from agent_eval.config import discover_configs
         configs = discover_configs(cwd)
         if configs:
-            return configs[0].path
+            return [c.path for c in configs]
     except Exception:
         pass
     for candidate in [cwd / "eval.yaml", plugin_root / "eval.yaml"]:
         if candidate.exists():
-            return candidate
-    return None
+            return [candidate]
+    return []
 
 
 def _compute_stamp(deps):

--- a/scripts/ensure_deps.py
+++ b/scripts/ensure_deps.py
@@ -211,8 +211,13 @@ def _find_eval_yamls(plugin_root):
         configs = discover_configs(cwd)
         if configs:
             return [c.path for c in configs]
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001 - SessionStart must never hard-fail
+        # Broad on purpose: a discovery bug must not block the session. But the
+        # fallback below sees one config at most, so staying silent here is the
+        # very under-installation this function exists to prevent — say so.
+        print(f"Warning: eval.yaml discovery failed ({exc}); falling back to a "
+              f"single config. .eval-venv may be missing deps required by other "
+              f"evals in this project.", file=sys.stderr)
     for candidate in [cwd / "eval.yaml", plugin_root / "eval.yaml"]:
         if candidate.exists():
             return [candidate]

--- a/tests/test_ensure_deps.py
+++ b/tests/test_ensure_deps.py
@@ -1,0 +1,175 @@
+"""Tests for scripts/ensure_deps.py dependency resolution.
+
+The SessionStart hook installs into .eval-venv whatever the project's eval.yaml
+files imply. Resolving against a single config silently under-installed for
+projects holding several evals, so the union behaviour is what these pin down.
+"""
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_ensure_deps():
+    """Load scripts/ensure_deps.py by path — scripts/ is not a package."""
+    path = REPO_ROOT / "scripts" / "ensure_deps.py"
+    spec = importlib.util.spec_from_file_location("_ensure_deps_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ensure_deps = _load_ensure_deps()
+
+
+def _write(path, body):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body))
+    return path
+
+
+MLFLOW_EVAL = """
+    name: with-mlflow
+    execution:
+      skill: a
+    dataset:
+      path: cases
+    mlflow:
+      experiment: exp
+    """
+
+JUDGE_EVAL = """
+    name: with-judge
+    execution:
+      skill: b
+    dataset:
+      path: cases
+    judges:
+      - name: quality
+        prompt: "Rate {{ inputs }}"
+    """
+
+PLAIN_EVAL = """
+    name: plain
+    execution:
+      skill: c
+    dataset:
+      path: cases
+    judges:
+      - name: exists
+        check: "True"
+    """
+
+
+def _specs(deps):
+    return [spec for spec, _ in deps]
+
+
+class TestDepsForSingleConfig:
+    def test_pyyaml_is_always_present(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert "pyyaml>=6.0" in _specs(ensure_deps._resolve_deps(tmp_path))
+
+    def test_no_config_yields_only_pyyaml(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert _specs(ensure_deps._resolve_deps(tmp_path)) == ["pyyaml>=6.0"]
+
+    def test_mlflow_block_pulls_mlflow(self, tmp_path):
+        specs = _specs(ensure_deps._deps_for_config(
+            _write(tmp_path / "eval.yaml", MLFLOW_EVAL)))
+        assert "mlflow[genai]>=3.5" in specs
+        assert "anthropic[vertex]>=0.40" not in specs
+
+    def test_llm_judge_pulls_anthropic_and_jinja2(self, tmp_path):
+        specs = _specs(ensure_deps._deps_for_config(
+            _write(tmp_path / "eval.yaml", JUDGE_EVAL)))
+        assert "anthropic[vertex]>=0.40" in specs
+        assert "jinja2>=3.0" in specs
+        assert "mlflow[genai]>=3.5" not in specs
+
+    def test_check_only_judge_pulls_neither(self, tmp_path):
+        assert ensure_deps._deps_for_config(
+            _write(tmp_path / "eval.yaml", PLAIN_EVAL)) == []
+
+    def test_unparseable_config_contributes_nothing(self, tmp_path):
+        bad = _write(tmp_path / "eval.yaml", "{{{ not yaml at all\n")
+        assert ensure_deps._deps_for_config(bad) == []
+
+    def test_missing_file_contributes_nothing(self, tmp_path):
+        assert ensure_deps._deps_for_config(tmp_path / "nope.yaml") == []
+
+
+class TestUnionAcrossConfigs:
+    """The regression: a project with several evals under eval/<name>/eval.yaml."""
+
+    @pytest.fixture
+    def multi_config_project(self, tmp_path, monkeypatch):
+        # Named so that the mlflow one does NOT sort first — under the old
+        # configs[0] behaviour whichever landed first decided the whole dep set.
+        _write(tmp_path / "eval" / "aaa-judge" / "eval.yaml", JUDGE_EVAL)
+        _write(tmp_path / "eval" / "zzz-mlflow" / "eval.yaml", MLFLOW_EVAL)
+        monkeypatch.chdir(tmp_path)
+        return tmp_path
+
+    def test_deps_are_the_union_not_the_first_config(self, multi_config_project):
+        specs = _specs(ensure_deps._resolve_deps(multi_config_project))
+        assert "anthropic[vertex]>=0.40" in specs, "LLM-judge config's deps missing"
+        assert "jinja2>=3.0" in specs
+        assert "mlflow[genai]>=3.5" in specs, (
+            "mlflow config was ignored — deps resolved from one config only")
+
+    def test_discovery_finds_every_config(self, multi_config_project):
+        found = ensure_deps._find_eval_yamls(multi_config_project)
+        assert len(found) == 2, f"expected both configs, got {found}"
+
+    def test_shared_deps_are_not_duplicated(self, tmp_path, monkeypatch):
+        _write(tmp_path / "eval" / "one" / "eval.yaml", MLFLOW_EVAL)
+        _write(tmp_path / "eval" / "two" / "eval.yaml", MLFLOW_EVAL)
+        monkeypatch.chdir(tmp_path)
+        specs = _specs(ensure_deps._resolve_deps(tmp_path))
+        assert specs.count("mlflow[genai]>=3.5") == 1
+        assert specs.count("pyyaml>=6.0") == 1
+
+    def test_one_broken_config_does_not_sink_the_others(self, tmp_path, monkeypatch):
+        _write(tmp_path / "eval" / "broken" / "eval.yaml", "{{{ not yaml\n")
+        _write(tmp_path / "eval" / "good" / "eval.yaml", MLFLOW_EVAL)
+        monkeypatch.chdir(tmp_path)
+        assert "mlflow[genai]>=3.5" in _specs(ensure_deps._resolve_deps(tmp_path))
+
+    def test_stamp_is_order_independent(self, tmp_path):
+        """The install cache keys on the dep set; discovery order must not churn it."""
+        a = [("pyyaml>=6.0", "yaml"), ("mlflow[genai]>=3.5", "mlflow")]
+        assert ensure_deps._compute_stamp(a) == ensure_deps._compute_stamp(a[::-1])
+
+
+class TestFallbackWhenDiscoveryFails:
+    def test_root_eval_yaml_is_found(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path / "eval.yaml", MLFLOW_EVAL)
+        assert "mlflow[genai]>=3.5" in _specs(ensure_deps._resolve_deps(tmp_path))
+
+    def test_falls_back_to_a_single_candidate(self, tmp_path, monkeypatch):
+        """cwd/eval.yaml and plugin_root/eval.yaml are alternatives, not siblings.
+
+        Discovery is forced to fail so the fallback is what answers; the nested
+        config exists purely to prove the fallback ran (discovery would have
+        returned it too, so a one-element result can only come from the fallback).
+        """
+        monkeypatch.setitem(sys.modules, "agent_eval.config", None)  # import raises
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path / "eval.yaml", MLFLOW_EVAL)
+        _write(tmp_path / "eval" / "nested" / "eval.yaml", JUDGE_EVAL)
+        plugin_root = tmp_path / "plugin"
+        _write(plugin_root / "eval.yaml", JUDGE_EVAL)
+
+        assert ensure_deps._find_eval_yamls(plugin_root) == [tmp_path / "eval.yaml"]
+
+        # Control: with discovery working, both configs are returned.
+        monkeypatch.undo()
+        monkeypatch.chdir(tmp_path)
+        assert len(ensure_deps._find_eval_yamls(plugin_root)) == 2

--- a/tests/test_ensure_deps.py
+++ b/tests/test_ensure_deps.py
@@ -173,3 +173,22 @@ class TestFallbackWhenDiscoveryFails:
         monkeypatch.undo()
         monkeypatch.chdir(tmp_path)
         assert len(ensure_deps._find_eval_yamls(plugin_root)) == 2
+
+    def test_discovery_failure_is_reported(self, tmp_path, monkeypatch, capsys):
+        """Degrading to one config is the exact under-installation this function
+        exists to prevent, so it must not happen silently."""
+        monkeypatch.setitem(sys.modules, "agent_eval.config", None)
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path / "eval.yaml", MLFLOW_EVAL)
+
+        ensure_deps._find_eval_yamls(tmp_path)
+
+        err = capsys.readouterr().err
+        assert "discovery failed" in err
+        assert "missing deps" in err
+
+    def test_no_warning_when_discovery_works(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path / "eval" / "one" / "eval.yaml", MLFLOW_EVAL)
+        ensure_deps._find_eval_yamls(tmp_path)
+        assert "discovery failed" not in capsys.readouterr().err


### PR DESCRIPTION
## Description

`scripts/ensure_deps.py` (the SessionStart hook that provisions `.eval-venv`) resolved its dependency set from **one** eval.yaml:

```python
configs = discover_configs(cwd)
if configs:
    return configs[0].path      # <- only the first
```

But `eval/<name>/eval.yaml` — several evals in one project — is a supported layout (spec 005), and sibling evals rarely need the same packages: one may log to MLflow while another uses LLM judges. Whichever config happened to sort first silently decided what got installed; the others then failed on an import of something that was never there.

**Reproduced** — a project with `eval/aaa-judge/` (LLM judge) and `eval/zzz-mlflow/` (mlflow block) resolves to:

```
['pyyaml>=6.0', 'anthropic[vertex]>=0.40', 'jinja2>=3.0']
```

mlflow dropped, purely because of the directory name.

### What changed

- **`_find_eval_yamls`** (renamed, plural) returns every discovered config.
- **`_resolve_deps`** unions the per-config deps, de-duplicating by spec. `_compute_stamp` already sorts, so discovery order doesn't churn the install cache.
- **`_deps_for_config`** extracts the per-config logic and never raises. Previously a single unparseable eval.yaml hit an early `return deps` that also dropped every config after it; now it contributes nothing and the scan continues.

The fallback stays first-match on purpose: it only runs when discovery itself failed, and `cwd/eval.yaml` vs `plugin_root/eval.yaml` are alternatives rather than siblings.

## How Has This Been Tested?

`tests/test_ensure_deps.py` is new — `ensure_deps.py` had **no test coverage at all**, which is largely why this went unnoticed. 14 tests covering per-config resolution, the union behaviour, de-duplication, parse-failure isolation, stamp order-independence, and the discovery fallback.

The union test fails on the parent commit for the right reason:

```
AssertionError: mlflow config was ignored — deps resolved from one config only
assert 'mlflow[genai]>=3.5' in ['pyyaml>=6.0', 'anthropic[vertex]>=0.40', 'jinja2>=3.0']
```

Full suite: `867 passed, 2 skipped`.

## Context

Came out of the discussion on #180 about whether to auto-install the `[anova]` extra gated on a `matrix:` block. That gate is defensible only once dep resolution stops depending on which config sorts first — a 272MB install that silently no-ops for half the projects that need it would be worse than no gate. This PR is that prerequisite; it does **not** add the anova gate, which remains an open design question (an explicit `dependencies:` opt-in may be the better shape).

Independent of #180 — no overlapping files.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body.
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dependency setup now detects requirements across all available evaluation configurations.
  * Duplicate dependencies are removed automatically.
  * Invalid, unreadable, or missing configurations no longer interrupt dependency resolution.
  * Discovery retains fallback behavior when configuration scanning is unavailable and warns when dependencies may be missing.

* **Tests**
  * Added coverage for multi-configuration resolution, error handling, deduplication, caching, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->