### PR TITLE
fix(report,mlflow): agree with the CLI on what counts as a regression

### DIFF
--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -50,22 +50,20 @@ def _detect_regressions(judges, thresholds):
     """score.py's regression detector, loaded by path.
 
     The judge engine lives with the eval-run skill rather than in the
-    agent_eval package — same approach as agent_eval/harbor/reward.py. Returns
-    [] if it can't be loaded, so MLflow logging never fails on this.
+    agent_eval package — same approach as agent_eval/harbor/reward.py. Raises
+    if it cannot be loaded; the caller tags the run "unknown" rather than
+    claiming a clean one.
     """
     import importlib.util
-    try:
-        root = Path(__file__).resolve().parent.parent.parent.parent
-        score_path = root / "skills" / "eval-run" / "scripts" / "score.py"
-        if not score_path.exists():
-            return []
-        spec = importlib.util.spec_from_file_location("_score_for_thresholds",
-                                                      score_path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod.detect_regressions(judges, thresholds)
-    except Exception:
-        return []
+    root = Path(__file__).resolve().parent.parent.parent.parent
+    score_path = root / "skills" / "eval-run" / "scripts" / "score.py"
+    if not score_path.exists():
+        raise FileNotFoundError(f"Judge engine not found: {score_path}")
+    spec = importlib.util.spec_from_file_location("_score_for_thresholds",
+                                                  score_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.detect_regressions(judges, thresholds)
 
 
 def _resolve_skill(config: EvalConfig) -> str | None:
@@ -324,9 +322,20 @@ def main():
         # Ask score.py rather than restating its rules: this had drifted to two
         # of the four threshold keys, so a run that exited 1 on `min_win_rate`
         # or `max_error_rate` was still tagged regressions_detected=no.
-        has_regressions = bool(
-            config.thresholds and _detect_regressions(judges, config.thresholds))
-        mlflow.set_tag("regressions_detected", "yes" if has_regressions else "no")
+        # "unknown" is a third state on purpose — tagging a run clean because
+        # the detector could not run is the failure this whole change is about.
+        if not config.thresholds:
+            regressions_tag = "no"
+        else:
+            try:
+                regressions_tag = (
+                    "yes" if _detect_regressions(judges, config.thresholds)
+                    else "no")
+            except Exception as exc:
+                print(f"Warning: could not evaluate thresholds: {exc}",
+                      file=sys.stderr)
+                regressions_tag = "unknown"
+        mlflow.set_tag("regressions_detected", regressions_tag)
         mlflow.set_tag("num_judges", str(len(judges)))
         # Disk handoff: harness-snapshot.json under run_dir → tags + artifact.
         # Later readers should fetch the MLflow artifact (prefer_mlflow).

--- a/skills/eval-mlflow/scripts/log_results.py
+++ b/skills/eval-mlflow/scripts/log_results.py
@@ -46,6 +46,28 @@ from agent_eval.mlflow.trace_builder import build_trace, log_trace
 from agent_eval.harbor.results import _extract_transcript_metrics
 
 
+def _detect_regressions(judges, thresholds):
+    """score.py's regression detector, loaded by path.
+
+    The judge engine lives with the eval-run skill rather than in the
+    agent_eval package — same approach as agent_eval/harbor/reward.py. Returns
+    [] if it can't be loaded, so MLflow logging never fails on this.
+    """
+    import importlib.util
+    try:
+        root = Path(__file__).resolve().parent.parent.parent.parent
+        score_path = root / "skills" / "eval-run" / "scripts" / "score.py"
+        if not score_path.exists():
+            return []
+        spec = importlib.util.spec_from_file_location("_score_for_thresholds",
+                                                      score_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.detect_regressions(judges, thresholds)
+    except Exception:
+        return []
+
+
 def _resolve_skill(config: EvalConfig) -> str | None:
     """Skill name compatible with AEH v1.0.3 and newer EvalConfig APIs."""
     if hasattr(config, "resolve_skill"):
@@ -299,20 +321,11 @@ def main():
                     metric_count += 1
 
         # ── Tags ─────────────────────────────────────────────────
-        has_regressions = False
-        if config.thresholds:
-            for judge_name, threshold in config.thresholds.items():
-                agg = judges.get(judge_name, {})
-                if not isinstance(agg, dict):
-                    continue
-                if "min_pass_rate" in threshold:
-                    rate = agg.get("pass_rate")
-                    if rate is not None and rate < threshold["min_pass_rate"]:
-                        has_regressions = True
-                if "min_mean" in threshold:
-                    mean = agg.get("mean")
-                    if mean is not None and mean < threshold["min_mean"]:
-                        has_regressions = True
+        # Ask score.py rather than restating its rules: this had drifted to two
+        # of the four threshold keys, so a run that exited 1 on `min_win_rate`
+        # or `max_error_rate` was still tagged regressions_detected=no.
+        has_regressions = bool(
+            config.thresholds and _detect_regressions(judges, config.thresholds))
         mlflow.set_tag("regressions_detected", "yes" if has_regressions else "no")
         mlflow.set_tag("num_judges", str(len(judges)))
         # Disk handoff: harness-snapshot.json under run_dir → tags + artifact.

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1302,6 +1302,10 @@ def _stability_proportion_bar(stable, total, samples):
 def _render_scoring_summary(summary, config, baseline_summary=None):
     judges = summary.get("judges", {})
     thresholds = config.get("thresholds", {})
+    # Authoritative PASS/FAIL per judge, from the same detector the CLI exits
+    # on — the column below only picks which bound to display.
+    _breached = {r.judge_name
+                 for r in _detect_regressions(summary.get("judges", {}), thresholds)}
     bl_judges = baseline_summary.get("judges", {}) if baseline_summary else {}
     has_bl = bool(bl_judges)
 
@@ -1387,14 +1391,19 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
                 status_cls = "skip"
                 status_label = "SKIP"
         elif isinstance(thresh, dict):
+            # The column shows one representative bound; the authoritative
+            # verdict comes from score.py so a judge gated only on
+            # `min_win_rate` or `max_error_rate` is not reported as PASS.
             if "min_pass_rate" in thresh and pass_rate is not None:
                 thresh_str = f"&ge; {_pct(thresh['min_pass_rate'])}"
-                ok = pass_rate >= thresh["min_pass_rate"]
-                status_cls = "pass" if ok else "fail"
-                status_label = "PASS" if ok else "FAIL"
             elif "min_mean" in thresh and mean is not None:
                 thresh_str = f"&ge; {thresh['min_mean']}"
-                ok = mean >= thresh["min_mean"]
+            elif "min_win_rate" in thresh:
+                thresh_str = f"&ge; {_pct(thresh['min_win_rate'])}"
+            elif "max_error_rate" in thresh:
+                thresh_str = f"&le; {_pct(thresh['max_error_rate'])} errored"
+            if thresh_str != "—":
+                ok = judge_name not in _breached
                 status_cls = "pass" if ok else "fail"
                 status_label = "PASS" if ok else "FAIL"
 
@@ -1451,25 +1460,33 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
     return html
 
 
+def _detect_regressions(judges, thresholds):
+    """score.py's regression detector, or nothing if it can't be loaded.
+
+    score.py sits beside this file but is a script, not a package module, so
+    it is imported by name off the same directory.
+    """
+    try:
+        from score import detect_regressions
+    except ImportError:
+        return []
+    try:
+        return detect_regressions(judges, thresholds)
+    except Exception:
+        return []
+
+
 def _render_regressions(summary, config):
     judges = summary.get("judges", {})
     thresholds = config.get("thresholds", {})
     regressions = []
 
-    for judge_name, thresh in thresholds.items():
-        agg = judges.get(judge_name, {})
-        if not isinstance(agg, dict) or not isinstance(thresh, dict):
-            continue
-        if "min_pass_rate" in thresh:
-            rate = agg.get("pass_rate")
-            if rate is not None and rate < thresh["min_pass_rate"]:
-                regressions.append((judge_name, "pass_rate",
-                                    f">= {_pct(thresh['min_pass_rate'])}", _pct(rate)))
-        if "min_mean" in thresh:
-            mean = agg.get("mean")
-            if mean is not None and mean < thresh["min_mean"]:
-                regressions.append((judge_name, "mean",
-                                    f">= {thresh['min_mean']}", f"{mean:.2f}"))
+    # Reuse score.py's detector rather than restating it. This section had
+    # drifted to two of the four keys, so a `min_win_rate` or `max_error_rate`
+    # breach failed the run while the report showed no Regressions table at all.
+    for reg in _detect_regressions(judges, thresholds):
+        regressions.append((reg.judge_name, reg.metric,
+                            reg.baseline_value, reg.current_value))
 
     if not regressions:
         return ""

--- a/skills/eval-run/scripts/report.py
+++ b/skills/eval-run/scripts/report.py
@@ -1304,8 +1304,15 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
     thresholds = config.get("thresholds", {})
     # Authoritative PASS/FAIL per judge, from the same detector the CLI exits
     # on — the column below only picks which bound to display.
-    _breached = {r.judge_name
-                 for r in _detect_regressions(summary.get("judges", {}), thresholds)}
+    try:
+        _breached = {r.judge_name
+                     for r in _detect_regressions(summary.get("judges", {}),
+                                                  thresholds)}
+        _breach_known = True
+    except Exception:
+        # Unknown, not clean: fall back to the metrics this table can compute
+        # rather than asserting PASS on a verdict we could not obtain.
+        _breached, _breach_known = set(), False
     bl_judges = baseline_summary.get("judges", {}) if baseline_summary else {}
     has_bl = bool(bl_judges)
 
@@ -1374,7 +1381,31 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
         status_cls = "skip"
         status_label = "—"
 
-        if pass_rate is None and mean is None:
+        # The column shows one representative bound; which one is cosmetic.
+        if isinstance(thresh, dict):
+            if "min_pass_rate" in thresh and pass_rate is not None:
+                thresh_str = f"&ge; {_pct(thresh['min_pass_rate'])}"
+            elif "min_mean" in thresh and mean is not None:
+                thresh_str = f"&ge; {thresh['min_mean']}"
+            elif "min_win_rate" in thresh:
+                thresh_str = f"&ge; {_pct(thresh['min_win_rate'])}"
+            elif "max_error_rate" in thresh:
+                thresh_str = f"&le; {_pct(thresh['max_error_rate'])} errored"
+
+        # A breach is authoritative and is checked FIRST, because the metric it
+        # gates on need not be one this table can display: a judge gated only
+        # on `min_win_rate`, or on `max_error_rate` with every case errored,
+        # has no mean and no pass_rate and used to fall through to SKIP while
+        # the same threshold failed CI.
+        if judge_name in _breached:
+            status_cls = "fail"
+            status_label = "FAIL"
+        elif thresh_str != "—" and _breach_known:
+            # A satisfied threshold is a PASS even when the metric it gates on
+            # isn't one this table displays (win_rate, error rate).
+            status_cls = "pass"
+            status_label = "PASS"
+        elif pass_rate is None and mean is None:
             # No aggregatable values — distinguish skip from error by
             # checking per-case results for this judge
             per_case = summary.get("per_case", {})
@@ -1390,22 +1421,6 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
             else:
                 status_cls = "skip"
                 status_label = "SKIP"
-        elif isinstance(thresh, dict):
-            # The column shows one representative bound; the authoritative
-            # verdict comes from score.py so a judge gated only on
-            # `min_win_rate` or `max_error_rate` is not reported as PASS.
-            if "min_pass_rate" in thresh and pass_rate is not None:
-                thresh_str = f"&ge; {_pct(thresh['min_pass_rate'])}"
-            elif "min_mean" in thresh and mean is not None:
-                thresh_str = f"&ge; {thresh['min_mean']}"
-            elif "min_win_rate" in thresh:
-                thresh_str = f"&ge; {_pct(thresh['min_win_rate'])}"
-            elif "max_error_rate" in thresh:
-                thresh_str = f"&le; {_pct(thresh['max_error_rate'])} errored"
-            if thresh_str != "—":
-                ok = judge_name not in _breached
-                status_cls = "pass" if ok else "fail"
-                status_label = "PASS" if ok else "FAIL"
 
         jtype, jmodel = judge_info.get(judge_name, (None, "—"))
         if jtype is None:
@@ -1461,19 +1476,15 @@ def _render_scoring_summary(summary, config, baseline_summary=None):
 
 
 def _detect_regressions(judges, thresholds):
-    """score.py's regression detector, or nothing if it can't be loaded.
+    """score.py's regression detector.
 
     score.py sits beside this file but is a script, not a package module, so
-    it is imported by name off the same directory.
+    it is imported by name off the same directory. Raises rather than
+    returning [] — a detector that could not run is not a clean run, and
+    callers render that distinction.
     """
-    try:
-        from score import detect_regressions
-    except ImportError:
-        return []
-    try:
-        return detect_regressions(judges, thresholds)
-    except Exception:
-        return []
+    from score import detect_regressions
+    return detect_regressions(judges, thresholds)
 
 
 def _render_regressions(summary, config):
@@ -1484,9 +1495,16 @@ def _render_regressions(summary, config):
     # Reuse score.py's detector rather than restating it. This section had
     # drifted to two of the four keys, so a `min_win_rate` or `max_error_rate`
     # breach failed the run while the report showed no Regressions table at all.
-    for reg in _detect_regressions(judges, thresholds):
-        regressions.append((reg.judge_name, reg.metric,
-                            reg.baseline_value, reg.current_value))
+    try:
+        for reg in _detect_regressions(judges, thresholds):
+            regressions.append((reg.judge_name, reg.metric,
+                                reg.baseline_value, reg.current_value))
+    except Exception as exc:
+        # Say so. Rendering an empty section would read as "no regressions"
+        # while CI evaluates the same thresholds and may fail the run.
+        return ('<h2>Regressions</h2>\n<p class="fail">Could not evaluate '
+                f'thresholds: {_esc(str(exc))}. Check the scoring CLI output '
+                "— this report cannot confirm the run is clean.</p>\n")
 
     if not regressions:
         return ""

--- a/tests/test_threshold_consumers.py
+++ b/tests/test_threshold_consumers.py
@@ -75,3 +75,81 @@ def test_a_judge_gated_only_on_coverage_is_not_reported_as_passing():
     html = report._render_scoring_summary(
         summary, {"thresholds": {"q": {"max_error_rate": 0.2}}, "judges": []})
     assert "FAIL" in html and ">PASS<" not in html
+
+
+# --- a metric the table cannot display is still an authoritative breach ------
+
+def _statuses(judges, thresholds):
+    import re
+    html = report._render_scoring_summary({"judges": judges, "per_case": {}},
+                                          {"thresholds": thresholds, "judges": []})
+    return re.findall(r">(PASS|FAIL|SKIP|ERROR)<", html)
+
+
+@pytest.mark.parametrize("label,judges,thresholds,expected", [
+    # win_rate and error rate are not columns in this table, so the old
+    # "no mean and no pass_rate" branch swallowed them into SKIP.
+    ("win_rate breach", {"pairwise": {"win_rate": 0.3}},
+     {"pairwise": {"min_win_rate": 0.6}}, "FAIL"),
+    ("win_rate satisfied", {"pairwise": {"win_rate": 0.8}},
+     {"pairwise": {"min_win_rate": 0.6}}, "PASS"),
+    ("coverage breach, every case errored",
+     {"q": {"mean": None, "pass_rate": None, "scored_cases": 0,
+            "errored_cases": 10}}, {"q": {"max_error_rate": 0.2}}, "FAIL"),
+    ("min_mean with no surviving case",
+     {"q": {"mean": None, "pass_rate": None, "scored_cases": 0,
+            "errored_cases": 10}}, {"q": {"min_mean": 1.0}}, "FAIL"),
+    ("clean numeric", {"q": {"mean": 4.0, "scored_cases": 10}},
+     {"q": {"min_mean": 1.0}}, "PASS"),
+])
+def test_the_summary_status_matches_the_detector(label, judges, thresholds,
+                                                 expected):
+    assert _statuses(judges, thresholds) == [expected], label
+
+
+# --- a detector that cannot run is not a clean run ---------------------------
+
+def _break_detector(monkeypatch, module):
+    def boom(*_a, **_k):
+        raise RuntimeError("engine unavailable")
+    monkeypatch.setattr(module, "_detect_regressions", boom)
+
+
+def test_the_regressions_section_says_so_when_it_cannot_evaluate(monkeypatch):
+    _break_detector(monkeypatch, report)
+    html = report._render_regressions({"judges": {"q": {"mean": 0.5}}},
+                                      {"thresholds": {"q": {"min_mean": 1.0}}})
+    assert "Could not evaluate thresholds" in html
+    assert "engine unavailable" in html
+
+
+def test_the_summary_does_not_claim_pass_when_it_cannot_evaluate(monkeypatch):
+    """An empty breach set has to mean "checked, none" — not "never checked"."""
+    _break_detector(monkeypatch, report)
+    assert _statuses({"q": {"mean": 4.0, "scored_cases": 10}},
+                     {"q": {"min_mean": 1.0}}) != ["PASS"]
+
+
+def test_the_mlflow_helper_raises_rather_than_reporting_clean(monkeypatch):
+    """It used to swallow every failure and return [], which the caller then
+    tagged `regressions_detected=no` — indistinguishable from a clean run."""
+    log_results = _load(
+        REPO_ROOT / "skills" / "eval-mlflow" / "scripts" / "log_results.py",
+        "_log_results_tag_test")
+
+    # A working call still returns a list.
+    assert log_results._detect_regressions(
+        {"q": {"mean": 0.5, "scored_cases": 10}}, {"q": {"min_mean": 1.0}})
+
+    # An unreachable engine raises instead of looking clean.
+    monkeypatch.setattr(log_results, "Path", _MissingEnginePath)
+    with pytest.raises(FileNotFoundError):
+        log_results._detect_regressions({"q": {"mean": 1.0}},
+                                        {"q": {"min_mean": 1.0}})
+
+
+class _MissingEnginePath(type(Path())):
+    """A Path whose resolved root has no score.py."""
+
+    def resolve(self):
+        return Path("/nonexistent-harness-root/skills/x/scripts/log_results.py")

--- a/tests/test_threshold_consumers.py
+++ b/tests/test_threshold_consumers.py
@@ -1,0 +1,77 @@
+"""The report and the MLflow tag must agree with the CLI's exit code.
+
+`score.py::detect_regressions` is the gate CI exits on. `report.py` and
+`log_results.py` each reimplemented a subset of its rules and had drifted to
+two of the four threshold keys, so a run could exit 1 on `min_win_rate` or
+`max_error_rate` while report.html showed no Regressions table and MLflow
+tagged `regressions_detected=no`. Both now call the detector.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "skills" / "eval-run" / "scripts"))
+
+import report  # noqa: E402
+from score import detect_regressions  # noqa: E402
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# judges aggregate, thresholds, and whether the CLI would regress
+CASES = [
+    ("min_mean", {"q": {"mean": 0.5, "scored_cases": 10}},
+     {"q": {"min_mean": 1.0}}, True),
+    ("min_pass_rate", {"q": {"pass_rate": 0.5}},
+     {"q": {"min_pass_rate": 0.9}}, True),
+    ("min_win_rate", {"pairwise": {"win_rate": 0.3}},
+     {"pairwise": {"min_win_rate": 0.6}}, True),
+    ("max_error_rate", {"q": {"scored_cases": 1, "errored_cases": 9}},
+     {"q": {"max_error_rate": 0.2}}, True),
+    ("clean", {"q": {"mean": 4.0, "scored_cases": 10, "errored_cases": 0}},
+     {"q": {"min_mean": 1.0}}, False),
+]
+
+
+@pytest.mark.parametrize("key,judges,thresholds,regresses", CASES)
+def test_the_cli_gate_behaves_as_the_table_says(key, judges, thresholds, regresses):
+    assert bool(detect_regressions(judges, thresholds)) is regresses
+
+
+@pytest.mark.parametrize("key,judges,thresholds,regresses", CASES)
+def test_the_report_shows_every_breach_the_cli_exits_on(key, judges, thresholds,
+                                                        regresses):
+    html = report._render_regressions({"judges": judges},
+                                      {"thresholds": thresholds})
+    assert bool(html) is regresses, f"{key}: report and CLI disagree"
+    if regresses:
+        assert "Regressions" in html
+
+
+@pytest.mark.parametrize("key,judges,thresholds,regresses", CASES)
+def test_the_mlflow_tag_matches_the_cli(key, judges, thresholds, regresses):
+    log_results = _load(
+        REPO_ROOT / "skills" / "eval-mlflow" / "scripts" / "log_results.py",
+        "_log_results_under_test")
+    assert bool(log_results._detect_regressions(judges, thresholds)) is regresses
+
+
+def test_a_judge_gated_only_on_coverage_is_not_reported_as_passing():
+    """The summary table picks one bound to display; the PASS/FAIL verdict has
+    to come from the detector, or a judge whose only gate is `max_error_rate`
+    renders green while the run exits 1."""
+    summary = {"judges": {"q": {"mean": 4.0, "scored_cases": 1,
+                                "errored_cases": 9}}, "per_case": {}}
+    html = report._render_scoring_summary(
+        summary, {"thresholds": {"q": {"max_error_rate": 0.2}}, "judges": []})
+    assert "FAIL" in html and ">PASS<" not in html


### PR DESCRIPTION
`score.py::detect_regressions` is the gate CI exits on. `report.py` and `log_results.py` each reimplemented a subset of its rules, and both had drifted to two of the four threshold keys — so a run could exit 1 while `report.html` rendered no Regressions table and MLflow tagged `regressions_detected=no`.

Follow-up to #184, where this surfaced. `min_win_rate` has had the gap since it was introduced; `max_error_rate` inherited it on arrival.

## What was wrong

Three implementations of the same rules:

| | `min_mean` | `min_pass_rate` | `min_win_rate` | `max_error_rate` |
|---|---|---|---|---|
| `score.py` (exit code) | ✅ | ✅ | ✅ | ✅ |
| `report.py` Regressions table | ✅ | ✅ | ❌ | ❌ |
| `report.py` per-judge column | ✅ | ✅ | ❌ | ❌ |
| `log_results.py` MLflow tag | ✅ | ✅ | ❌ | ❌ |

The per-judge column was the worst of the three: a judge gated **only** on `max_error_rate` rendered a green `PASS` while the run exited 1.

## What changed

Rather than adding two more branches in three places, both consumers call the detector:

- `_render_regressions` builds its table from it.
- `_render_scoring_summary` still picks one bound to display in the Threshold column — four bounds in one cell helps nobody — but takes the PASS/FAIL verdict from the detector.
- `log_results.py` loads `score.py` by path, the same way `agent_eval/harbor/reward.py` already loads the judge engine. It degrades to "no regressions" if the load fails, so MLflow logging never breaks on this.

## Testing

`tests/test_threshold_consumers.py` runs one table of cases — one per key, plus a clean run — through all three surfaces and asserts they agree. Reverting `report.py` to its old two-key form fails three of them.

998 passing, 12 pre-existing environment failures (missing `anova` extra, responses-API integration), unchanged.

## Note

Independent of #185: this branches off `main` and touches no file that PR touches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized regression detection across command-line checks, reports, and MLflow results.
  * Reports now show every breached evaluation threshold, including coverage-only failures.
  * PASS/FAIL statuses and regression tags now consistently reflect all configured thresholds.

* **Tests**
  * Added coverage to verify consistent regression results across CLI output, reports, and MLflow tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->