### PR TITLE
fix(hooks): survive a hook model that rejects `temperature`

### DIFF
--- a/skills/eval-run/scripts/tools.py
+++ b/skills/eval-run/scripts/tools.py
@@ -128,9 +128,15 @@ def _handle_ask_user(tool_input, config, handler):
         if answer is None and options:
             answer = _llm_answer(text, options, prompt, model=hook_model)
 
-        # 3. Fallback
+        # 3. Fallback. Announce it: tiers 1 and 2 are the ones that answer
+        # *for this case*, so landing here means the agent under test was
+        # handed an arbitrary answer — and because the run still completes,
+        # nothing downstream distinguishes that from a real answer.
         if answer is None:
             answer = options[0]["label"] if options else "yes"
+            print(f"AskUserQuestion fallback: no case override and no LLM "
+                  f"answer for {text!r} — defaulting to {answer!r}",
+                  file=sys.stderr)
 
         answers[text] = answer
 
@@ -145,6 +151,33 @@ def _handle_ask_user(tool_input, config, handler):
         }
     }
     json.dump(output, sys.stdout)
+
+
+def _create_message(client, **kwargs):
+    """messages.create, retrying once without `temperature` if it is rejected.
+
+    Anthropic removed the sampling parameters on Opus 4.7 and later (and
+    Sonnet 5 accepts only the default), so `temperature=0` is a 400 there.
+    That matters more here than anywhere else in the harness: the caller
+    swallows every exception and falls back to the first option, so an
+    unhandled 400 would feed the agent under test an unvetted answer while
+    the eval still reported a pass.
+
+    The check is behavioral rather than a model-name allowlist on purpose —
+    `models.hook` may be a gateway alias (a LiteLLM virtual key, a vLLM
+    --served-model-name) that no substring test can classify.
+    """
+    try:
+        return client.messages.create(**kwargs)
+    except Exception as exc:
+        rejected = (getattr(exc, "status_code", None) == 400
+                    and "temperature" in str(exc).lower())
+        if not rejected or "temperature" not in kwargs:
+            raise
+        print(f"hook model {kwargs.get('model')!r} rejects 'temperature' — "
+              "retrying without it", file=sys.stderr)
+        return client.messages.create(
+            **{k: v for k, v in kwargs.items() if k != "temperature"})
 
 
 def _llm_answer(question, options, handler_prompt, model=None):
@@ -187,7 +220,8 @@ Reply with ONLY the option label text, nothing else."""
     try:
         import anthropic
         client = anthropic.Anthropic(timeout=30.0)
-        response = client.messages.create(
+        response = _create_message(
+            client,
             model=model or "claude-haiku-4-5-20251001",
             max_tokens=256,
             temperature=0,

--- a/tests/test_hook_llm_answer.py
+++ b/tests/test_hook_llm_answer.py
@@ -1,0 +1,114 @@
+"""Tests for the AskUserQuestion hook's LLM answering call.
+
+The hook is the one LLM call in the harness whose failure is *invisible*:
+`_llm_answer` swallows every exception and the caller falls through to the
+first option, so a rejected request feeds the agent under test an unvetted
+answer while the run still reports a pass. These tests pin the two behaviors
+that keep that from happening silently — the sampling-parameter retry, and the
+stderr announcement on the fallback tier.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(
+    0, str(Path(__file__).parent.parent / "skills" / "eval-run" / "scripts"))
+
+import tools as hook_tools
+
+
+class _Rejected(Exception):
+    """Stands in for anthropic.BadRequestError without importing the SDK."""
+
+    def __init__(self, message, status_code=400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class TestCreateMessage:
+
+    def test_passes_through_on_success(self):
+        client = MagicMock()
+        client.messages.create.return_value = "ok"
+        assert hook_tools._create_message(
+            client, model="m", temperature=0, max_tokens=8) == "ok"
+        assert client.messages.create.call_count == 1
+        assert client.messages.create.call_args.kwargs["temperature"] == 0
+
+    def test_retries_without_temperature_when_rejected(self, capsys):
+        """Opus 4.7+ / Sonnet 5 removed the sampling parameters."""
+        client = MagicMock()
+        client.messages.create.side_effect = [
+            _Rejected("temperature: Extra inputs are not permitted"),
+            "ok",
+        ]
+        assert hook_tools._create_message(
+            client, model="claude-opus-4-8", temperature=0, max_tokens=8) == "ok"
+        assert client.messages.create.call_count == 2
+        retry = client.messages.create.call_args_list[1].kwargs
+        assert "temperature" not in retry
+        assert retry["model"] == "claude-opus-4-8"
+        assert retry["max_tokens"] == 8
+        assert "rejects 'temperature'" in capsys.readouterr().err
+
+    def test_works_for_a_gateway_alias(self):
+        """The guard is behavioral, so an opaque model name is still covered."""
+        client = MagicMock()
+        client.messages.create.side_effect = [
+            _Rejected("temperature is not supported"), "ok"]
+        assert hook_tools._create_message(
+            client, model="my-proxy-alias", temperature=0) == "ok"
+        assert client.messages.create.call_count == 2
+
+    def test_other_400s_propagate(self):
+        client = MagicMock()
+        client.messages.create.side_effect = _Rejected("model: not found")
+        with pytest.raises(_Rejected):
+            hook_tools._create_message(client, model="m", temperature=0)
+        assert client.messages.create.call_count == 1
+
+    def test_non_400_propagates(self):
+        client = MagicMock()
+        client.messages.create.side_effect = _Rejected("temperature", 500)
+        with pytest.raises(_Rejected):
+            hook_tools._create_message(client, model="m", temperature=0)
+        assert client.messages.create.call_count == 1
+
+    def test_no_retry_when_temperature_was_not_sent(self):
+        client = MagicMock()
+        client.messages.create.side_effect = _Rejected("temperature")
+        with pytest.raises(_Rejected):
+            hook_tools._create_message(client, model="m")
+        assert client.messages.create.call_count == 1
+
+
+class TestFallbackIsAnnounced:
+
+    def test_first_option_fallback_warns(self, capsys, monkeypatch):
+        # No case override and no LLM answer -> tier 3.
+        monkeypatch.setattr(hook_tools, "_llm_answer", lambda *a, **k: None)
+        tool_input = {"questions": [
+            {"question": "Which?", "options": [
+                {"label": "Alpha"}, {"label": "Beta"}]},
+        ]}
+        hook_tools._handle_ask_user(tool_input, {}, {"prompt": "p"})
+        captured = capsys.readouterr()
+        assert "AskUserQuestion fallback" in captured.err
+        assert "'Alpha'" in captured.err
+        # The answer is still emitted — the fallback stays non-fatal.
+        assert '"Alpha"' in captured.out
+
+    def test_case_override_does_not_warn(self, capsys, monkeypatch):
+        monkeypatch.setattr(hook_tools, "_llm_answer", lambda *a, **k: None)
+        tool_input = {"questions": [
+            {"question": "Which?", "options": [{"label": "Alpha"}]},
+        ]}
+        hook_tools._handle_ask_user(
+            tool_input, {"case_overrides": {"Which?": "Beta"}}, {"prompt": "p"})
+        captured = capsys.readouterr()
+        assert "AskUserQuestion fallback" not in captured.err
+        assert '"Beta"' in captured.out


### PR DESCRIPTION
## Problem

`skills/eval-run/scripts/tools.py` hardcodes `temperature=0` on the AskUserQuestion interception call. Anthropic **removed** the sampling parameters on Opus 4.7 and later (Sonnet 5 accepts only the default), so that request is a `400` on any current model.

It fails *invisibly*. `_llm_answer` swallows every exception and the caller falls through to the first option, so:

- the agent under test receives an **unvetted answer**,
- the run completes and still reports a pass,
- nothing downstream distinguishes that from real interception.

Latent rather than live today — the built-in default is `claude-haiku-4-5-20251001` and the documented `models.hook` example is `claude-sonnet-4-6`, both of which accept the parameter. But the docs actively invite setting `models.hook`, and this file is copied **verbatim** into every Harbor task package (`agent_eval/tools/interception.py`), so it ships into every trial pod.

## Change

- `_create_message()` wrapper: on a `400` naming `temperature`, retry once without it. Every other error propagates unchanged.
- The tier-3 fallback now announces itself on stderr. Tiers 1 and 2 answer *for this case*; landing on the first option means the answer was arbitrary.

### Why behavioral detection, not a model allowlist

`models.hook` may be a gateway alias — a LiteLLM virtual key, a vLLM `--served-model-name` — that no substring check can classify. A name-based guard would silently fail to apply on exactly the deployments it targets. Detecting the rejection is alias-proof.

## Tests

`tests/test_hook_llm_answer.py` (new, 8 cases): pass-through on success, retry drops only `temperature` and preserves the other kwargs, works for an opaque alias, other 400s propagate, non-400s propagate, no retry when `temperature` was never sent, fallback warns, override does not warn.

Full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AskUserQuestion fallback handling with clearer warning messages when no answer is available.
  * Added automatic retry support for requests rejected due to unsupported temperature settings.
  * Preserved error reporting for unrelated request failures and supported gateway aliases.

* **Tests**
  * Added coverage for successful responses, retry behavior, fallback warnings, case overrides, and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->