### PR TITLE
fix(validate): require plugin_dirs when the skill is not auto-discoverable

### DIFF
--- a/skills/eval-analyze/scripts/validate_eval.py
+++ b/skills/eval-analyze/scripts/validate_eval.py
@@ -478,8 +478,37 @@ def validate_config(path="eval.yaml"):
     # --- Skill reference check ---
     # Check execution.skill first, then fall back to top-level skill
     skill_name = execution.get("skill", "") or config.get("skill", "")
-    if skill_name and not find_skill(skill_name):
+    resolved_skill = find_skill(skill_name) if skill_name else None
+    if skill_name and not resolved_skill:
         warnings.append(f"skill '{skill_name}' not found in project")
+
+    # --- Plugin-layout check ---
+    # find_skill() searches plugin manifests and a top-level skills/ directory,
+    # but the agent runtime does not: Claude Code only auto-discovers skills under
+    # <project>/.claude/skills.  A skill packaged as a plugin (skills/ +
+    # .claude-plugin/plugin.json) is therefore invisible unless the plugin is
+    # loaded explicitly, which the runner does from runner.plugin_dirs.
+    #
+    # This fails silently and expensively: without --plugin-dir every case returns
+    # "Unknown command: /<skill>", 0 turns, $0.00 and exit code 0, so the run looks
+    # like a skill that produced no artifacts rather than one that never started.
+    if resolved_skill and not (config.get("runner") or {}).get("plugin_dirs"):
+        auto_discovered = Path.cwd() / ".claude" / "skills"
+        try:
+            resolved_skill.resolve().relative_to(auto_discovered.resolve())
+        except (ValueError, OSError):
+            try:
+                shown = resolved_skill.resolve().relative_to(Path.cwd().resolve())
+            except ValueError:
+                shown = resolved_skill
+            errors.append(
+                f"skill '{skill_name}' resolves to '{shown}', which the agent "
+                f"runtime will not auto-discover — only <project>/.claude/skills "
+                f"is searched. Set runner.plugin_dirs (e.g. ['.'] for a plugin "
+                f"rooted at the project) so the runner passes --plugin-dir; "
+                f"otherwise every case fails with 'Unknown command: /{skill_name}' "
+                f"at 0 turns and exit code 0."
+            )
 
     # --- File reference checks (resolve relative to config file location) ---
     dataset_path = dataset.get("path", "")

--- a/skills/eval-analyze/scripts/validate_eval.py
+++ b/skills/eval-analyze/scripts/validate_eval.py
@@ -49,6 +49,49 @@ def _resolve_plugin_dir(raw, project_root=None):
     return resolve_plugin_path(raw, project_root or Path.cwd())
 
 
+def _is_auto_discoverable(skill_path):
+    """True when the agent runtime finds this skill without being told to.
+
+    Claude Code searches ``<project>/.claude/skills`` only; anything else needs
+    the plugin to be loaded explicitly via --plugin-dir.
+    """
+    try:
+        skill_path.resolve().relative_to((Path.cwd() / ".claude" / "skills").resolve())
+        return True
+    except (ValueError, OSError):
+        return False
+
+
+def _plugin_dirs_export_skill(plugin_dirs, skill_name):
+    """Does any configured plugin dir actually export ``skill_name``?
+
+    Returns True/False, or None when a directory cannot be inspected (missing,
+    unreadable, or an invalid manifest). Those are real misconfigurations, but
+    the runner already fails fast on them with a more precise message, so the
+    validator stays quiet rather than guessing.
+
+    Mirrors find_skill()'s naming tolerance: "plugin:skill" also matches a
+    directory named "skill".
+    """
+    from agent_eval.config import resolve_plugin_skill_roots
+
+    candidates = [skill_name]
+    if ":" in skill_name:
+        candidates.append(skill_name.split(":", 1)[1])
+
+    unknown = False
+    for raw in plugin_dirs:
+        try:
+            roots = resolve_plugin_skill_roots(_resolve_plugin_dir(raw))
+        except Exception:
+            unknown = True
+            continue
+        for root in roots:
+            if any((root / candidate / "SKILL.md").is_file() for candidate in candidates):
+                return True
+    return None if unknown else False
+
+
 def _extract_template_variables(template_text):
     """Extract undeclared root variable names from a Jinja2 template.
 
@@ -492,22 +535,28 @@ def validate_config(path="eval.yaml"):
     # This fails silently and expensively: without --plugin-dir every case returns
     # "Unknown command: /<skill>", 0 turns, $0.00 and exit code 0, so the run looks
     # like a skill that produced no artifacts rather than one that never started.
-    if resolved_skill and not (config.get("runner") or {}).get("plugin_dirs"):
-        auto_discovered = Path.cwd() / ".claude" / "skills"
+    if resolved_skill and not _is_auto_discoverable(resolved_skill):
         try:
-            resolved_skill.resolve().relative_to(auto_discovered.resolve())
-        except (ValueError, OSError):
-            try:
-                shown = resolved_skill.resolve().relative_to(Path.cwd().resolve())
-            except ValueError:
-                shown = resolved_skill
+            shown = resolved_skill.resolve().relative_to(Path.cwd().resolve())
+        except ValueError:
+            shown = resolved_skill
+        plugin_dirs = (config.get("runner") or {}).get("plugin_dirs") or []
+        symptom = (f"every case fails with 'Unknown command: /{skill_name}' "
+                   f"at 0 turns and exit code 0")
+        if not plugin_dirs:
             errors.append(
                 f"skill '{skill_name}' resolves to '{shown}', which the agent "
                 f"runtime will not auto-discover — only <project>/.claude/skills "
                 f"is searched. Set runner.plugin_dirs (e.g. ['.'] for a plugin "
                 f"rooted at the project) so the runner passes --plugin-dir; "
-                f"otherwise every case fails with 'Unknown command: /{skill_name}' "
-                f"at 0 turns and exit code 0."
+                f"otherwise {symptom}."
+            )
+        elif _plugin_dirs_export_skill(plugin_dirs, skill_name) is False:
+            errors.append(
+                f"skill '{skill_name}' resolves to '{shown}', but none of the "
+                f"configured runner.plugin_dirs ({', '.join(map(str, plugin_dirs))}) "
+                f"export it. The runner only passes --plugin-dir for those "
+                f"directories, so the skill stays undiscoverable and {symptom}."
             )
 
     # --- File reference checks (resolve relative to config file location) ---

--- a/tests/test_validate_eval.py
+++ b/tests/test_validate_eval.py
@@ -268,7 +268,7 @@ judges:
       return (True, "ok")
 """
 
-    def _project(self, tmp_path, *, plugin_layout, plugin_dirs):
+    def _project(self, tmp_path, *, plugin_layout, plugin_dirs, unrelated_plugin=False):
         repo = tmp_path / "repo"
         if plugin_layout:
             (repo / "skills" / "myskill").mkdir(parents=True)
@@ -279,11 +279,20 @@ judges:
             (repo / ".claude" / "skills" / "myskill").mkdir(parents=True)
             (repo / ".claude" / "skills" / "myskill" / "SKILL.md").write_text(
                 "---\nname: myskill\n---\n")
+        if unrelated_plugin:
+            other = repo / "plugins" / "other"
+            (other / "skills" / "somethingelse").mkdir(parents=True)
+            (other / "skills" / "somethingelse" / "SKILL.md").write_text(
+                "---\nname: somethingelse\n---\n")
+            (other / ".claude-plugin").mkdir(parents=True)
+            (other / ".claude-plugin" / "plugin.json").write_text('{"name": "other"}')
         (repo / "cases" / "case-001").mkdir(parents=True)
         (repo / "cases" / "case-001" / "input.yaml").write_text("prompt: hi\n")
         runner = "runner:\n  type: claude-code\n"
         if plugin_dirs:
-            runner += "  plugin_dirs:\n    - \".\"\n"
+            runner += "  plugin_dirs:\n"
+            for d in (plugin_dirs if isinstance(plugin_dirs, list) else ["."]):
+                runner += f"    - \"{d}\"\n"
         (repo / "eval.yaml").write_text(self.CONFIG.replace("__RUNNER__", runner.rstrip()))
         return repo
 
@@ -326,3 +335,34 @@ judges:
         _, out = self._run(repo, monkeypatch, capsys)
         assert "not found in project" in out, out
         assert "runner.plugin_dirs" not in out, out
+
+    def test_plugin_dirs_that_do_not_export_the_skill_are_an_error(
+            self, tmp_path, monkeypatch, capsys):
+        """A non-empty plugin_dirs must not blanket-suppress the diagnostic: the
+        runner only passes --plugin-dir for those directories, so a plugin that
+        exports unrelated skills leaves this one just as undiscoverable."""
+        repo = self._project(tmp_path, plugin_layout=True,
+                             plugin_dirs=["plugins/other"], unrelated_plugin=True)
+        code, out = self._run(repo, monkeypatch, capsys)
+        assert code == 1, out
+        assert "none of the configured runner.plugin_dirs" in out, out
+        assert "plugins/other" in out, out
+
+    def test_plugin_dirs_that_export_the_skill_pass(
+            self, tmp_path, monkeypatch, capsys):
+        """The matching directory alongside an unrelated one is accepted."""
+        repo = self._project(tmp_path, plugin_layout=True,
+                             plugin_dirs=["plugins/other", "."],
+                             unrelated_plugin=True)
+        code, out = self._run(repo, monkeypatch, capsys)
+        assert code == 0, out
+        assert "plugin_dirs" not in out, out
+
+    def test_uninspectable_plugin_dir_does_not_error(
+            self, tmp_path, monkeypatch, capsys):
+        """A missing plugin dir is a real misconfiguration, but the runner fails
+        fast on it with a better message — don't guess here."""
+        repo = self._project(tmp_path, plugin_layout=True,
+                             plugin_dirs=["plugins/does-not-exist"])
+        _, out = self._run(repo, monkeypatch, capsys)
+        assert "none of the configured runner.plugin_dirs" not in out, out

--- a/tests/test_validate_eval.py
+++ b/tests/test_validate_eval.py
@@ -234,3 +234,95 @@ class TestJudgeTemplateValidation:
         hint = "\n".join(errors)
         assert "inputs" in hint
         assert "events" not in hint
+
+
+class TestPluginLayoutRequiresPluginDirs:
+    """A plugin-packaged skill is invisible to the agent runtime without
+    --plugin-dir, and the resulting run is silently green: every case returns
+    "Unknown command: /<skill>", 0 turns, $0.00 and exit code 0. find_skill()
+    resolves such a skill happily (it searches plugin manifests and a top-level
+    skills/ directory), so the config used to validate clean while being
+    unrunnable. These pin the gap shut.
+    """
+
+    CONFIG = """\
+name: t
+execution:
+  mode: case
+  skill: myskill
+  arguments: "{prompt}"
+__RUNNER__
+models:
+  skill: m
+  judge: m
+dataset:
+  path: cases
+  schema: one case dir per test
+outputs:
+  - path: out
+    schema: artifacts
+judges:
+  - name: j
+    description: d
+    check: |
+      return (True, "ok")
+"""
+
+    def _project(self, tmp_path, *, plugin_layout, plugin_dirs):
+        repo = tmp_path / "repo"
+        if plugin_layout:
+            (repo / "skills" / "myskill").mkdir(parents=True)
+            (repo / "skills" / "myskill" / "SKILL.md").write_text("---\nname: myskill\n---\n")
+            (repo / ".claude-plugin").mkdir(parents=True)
+            (repo / ".claude-plugin" / "plugin.json").write_text('{"name": "p"}')
+        else:
+            (repo / ".claude" / "skills" / "myskill").mkdir(parents=True)
+            (repo / ".claude" / "skills" / "myskill" / "SKILL.md").write_text(
+                "---\nname: myskill\n---\n")
+        (repo / "cases" / "case-001").mkdir(parents=True)
+        (repo / "cases" / "case-001" / "input.yaml").write_text("prompt: hi\n")
+        runner = "runner:\n  type: claude-code\n"
+        if plugin_dirs:
+            runner += "  plugin_dirs:\n    - \".\"\n"
+        (repo / "eval.yaml").write_text(self.CONFIG.replace("__RUNNER__", runner.rstrip()))
+        return repo
+
+    def _run(self, repo, monkeypatch, capsys):
+        monkeypatch.chdir(repo)
+        try:
+            validate_eval.validate_config("eval.yaml")
+        except SystemExit as exc:
+            return exc.code, capsys.readouterr().out
+        return 0, capsys.readouterr().out
+
+    def test_plugin_layout_without_plugin_dirs_is_an_error(
+            self, tmp_path, monkeypatch, capsys):
+        repo = self._project(tmp_path, plugin_layout=True, plugin_dirs=False)
+        code, out = self._run(repo, monkeypatch, capsys)
+        assert code == 1, out
+        assert "runner.plugin_dirs" in out, out
+        assert "Unknown command: /myskill" in out, out
+
+    def test_plugin_layout_with_plugin_dirs_passes(
+            self, tmp_path, monkeypatch, capsys):
+        repo = self._project(tmp_path, plugin_layout=True, plugin_dirs=True)
+        _, out = self._run(repo, monkeypatch, capsys)
+        assert "runner.plugin_dirs" not in out, out
+
+    def test_dot_claude_skills_layout_needs_no_plugin_dirs(
+            self, tmp_path, monkeypatch, capsys):
+        """The conventional layout is auto-discovered, so it must not be flagged."""
+        repo = self._project(tmp_path, plugin_layout=False, plugin_dirs=False)
+        _, out = self._run(repo, monkeypatch, capsys)
+        assert "runner.plugin_dirs" not in out, out
+
+    def test_unresolvable_skill_stays_a_warning(
+            self, tmp_path, monkeypatch, capsys):
+        """A skill that resolves nowhere is a different failure — don't upgrade
+        it to a plugin-layout error."""
+        repo = self._project(tmp_path, plugin_layout=False, plugin_dirs=False)
+        import shutil
+        shutil.rmtree(repo / ".claude" / "skills" / "myskill")
+        _, out = self._run(repo, monkeypatch, capsys)
+        assert "not found in project" in out, out
+        assert "runner.plugin_dirs" not in out, out


### PR DESCRIPTION
## Problem

`find_skill()` searches plugin manifests and a top-level `skills/` directory, but the agent runtime does not — Claude Code only auto-discovers skills under `<project>/.claude/skills`. A skill packaged as a plugin (`skills/` + `.claude-plugin/plugin.json`) therefore **validates clean while being unrunnable**.

The failure mode is silent-green rather than loud. Without `--plugin-dir`, every case returns:

```
Unknown command: /epic-decompose
Done (0 turns, $0.00)
  → case-001: OK | 4s | $0.00
EXIT: 0
```

A six-case run "succeeded" in 13 seconds. Nothing in `validate_eval.py` flagged it beforehand, because harness-side discovery finds the skill even though runtime discovery cannot.

Hit for real on [epic-creator](https://github.com/opendatahub-io/epic-creator), which is packaged as a plugin (1 skill under `skills/`), unlike rfe-creator and strat-creator which use `.claude/skills/` and are auto-discovered.

## Change

Error — not warn — when a resolved skill lives outside `.claude/skills` and `runner.plugin_dirs` is unset, naming both the flag to set and the symptom to expect:

```
ERROR: skill 'epic-decompose' resolves to 'skills/epic-decompose/SKILL.md', which the
agent runtime will not auto-discover — only <project>/.claude/skills is searched. Set
runner.plugin_dirs (e.g. ['.'] for a plugin rooted at the project) so the runner passes
--plugin-dir; otherwise every case fails with 'Unknown command: /epic-decompose' at 0
turns and exit code 0.
```

Error rather than warning because a run in this state produces no signal at all — it burns wall-clock, reports OK, and leaves the judges blaming skill quality for a config fault.

## Scope / false positives

- Configs already setting `runner.plugin_dirs` are untouched.
- The conventional `.claude/skills` layout is untouched.
- An unresolvable skill stays the existing warning (`not found in project`) rather than being upgraded to this error.
- Regression-checked against three real configs: rfe-creator (`INCOMPLETE`, unchanged), strat-creator (6 pre-existing errors, identical before and after), epic-creator with `plugin_dirs` (`VALID`).

One deliberate behaviour change worth calling out: if you rely on the plugin being *installed* in the operator's Claude config, this now errors. That reliance is not reproducible in CI, and setting `runner.plugin_dirs` is the portable fix.

## Tests

Four cases in `TestPluginLayoutRequiresPluginDirs` — plugin layout without `plugin_dirs` errors; with `plugin_dirs` passes; `.claude/skills` layout passes; unresolvable skill stays a warning.

`1266 passed, 7 skipped`. No new ruff findings (base and head both report 4 in the touched files); CI lint is `skillsaw`.

## Related

Companion PR, independent and separately mergeable: the runtime half of the same failure — #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill validation for skills located outside the conventional `.claude/skills` directory.
  * Added clear diagnostics when plugin directories are not configured for runtime discovery.
  * Preserved valid behavior for conventional skill layouts and unresolved skills.

* **Tests**
  * Added coverage for configured and unconfigured plugin-based skill discovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->