### PR TITLE
fix(claude-code): fail the run when the agent does not recognise the skill

### DIFF
--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import threading
@@ -406,6 +407,21 @@ class ClaudeCodeRunner(EvalRunner):
                           f"denial(s) detected during execution")
             stderr = (stderr or "") + denial_msg
 
+        # An unrecognised slash command is reported by the CLI as a successful
+        # run. Fail the case instead of letting a never-started skill look like
+        # a skill that produced nothing.
+        exit_code = proc.returncode
+        unknown_command = _detect_unknown_command(result_obj)
+        if unknown_command and exit_code == 0:
+            exit_code = 1
+            stderr = (stderr or "") + (
+                f"\nERROR: the agent did not recognise '{unknown_command}' "
+                f"(0 turns, no work performed). The skill is not discoverable "
+                f"at runtime — check the skill name, and set runner.plugin_dirs "
+                f"if it is packaged as a plugin rather than living in "
+                f".claude/skills."
+            )
+
         # Clean up temporary settings file if created
         if cleanup_settings and cleanup_settings.exists():
             try:
@@ -414,7 +430,7 @@ class ClaudeCodeRunner(EvalRunner):
                 pass  # Best effort cleanup
 
         return RunResult(
-            exit_code=proc.returncode,
+            exit_code=exit_code,
             stdout=stdout_text,
             stderr=stderr or "",
             duration_s=duration,
@@ -481,6 +497,35 @@ class ClaudeCodeRunner(EvalRunner):
         if self._mlflow_tracking_uri:
             env["MLFLOW_TRACKING_URI"] = self._mlflow_tracking_uri
         return env
+
+
+_UNKNOWN_COMMAND_RE = re.compile(r"^Unknown command:\s*(/\S+)")
+
+
+def _detect_unknown_command(result_obj) -> Optional[str]:
+    """Return the slash command the CLI did not recognise, if that is what happened.
+
+    Claude Code answers an unrecognised slash command with plain text and still
+    reports success::
+
+        {"type": "result", "subtype": "success", "is_error": false,
+         "num_turns": 0, "total_cost_usd": 0, "result": "Unknown command: /x"}
+
+    The process exits 0, so an eval whose skill never resolves (a plugin-packaged
+    skill with no runner.plugin_dirs, a typo, a plugin that failed to load) finishes
+    in seconds with every case marked OK and no artifacts — indistinguishable from a
+    skill that ran and produced nothing.
+
+    ``num_turns`` guards the match: a real run that merely quotes the phrase has
+    turns, an unrecognised command never does.
+    """
+    if not isinstance(result_obj, dict) or result_obj.get("num_turns"):
+        return None
+    text = result_obj.get("result")
+    if not isinstance(text, str):
+        return None
+    match = _UNKNOWN_COMMAND_RE.match(text.strip())
+    return match.group(1) if match else None
 
 
 def _extract_denial_list(result_obj, streaming_count):

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -518,8 +518,19 @@ def _detect_unknown_command(result_obj) -> Optional[str]:
 
     ``num_turns`` guards the match: a real run that merely quotes the phrase has
     turns, an unrecognised command never does.
+
+    The guard suppresses only on *positive evidence of work*. A missing, null or
+    non-numeric count is deliberately not read as "zero turns", but neither does
+    it suppress — the leading-phrase match below is the actual signal. Demanding
+    a literal integer ``0`` would trade a far-fetched false positive (a partial
+    payload whose result text also begins with "Unknown command: /") for a false
+    negative that silently restores the original green-but-broken run if the
+    payload shape ever changes.
     """
-    if not isinstance(result_obj, dict) or result_obj.get("num_turns"):
+    if not isinstance(result_obj, dict):
+        return None
+    turns = result_obj.get("num_turns")
+    if isinstance(turns, (int, float)) and turns > 0:
         return None
     text = result_obj.get("result")
     if not isinstance(text, str):

--- a/tests/test_extract_progress.py
+++ b/tests/test_extract_progress.py
@@ -1,8 +1,13 @@
 """Tests for _extract_progress and _extract_denial_list in claude_code.py."""
 
+import os
+
 from conftest import make_assistant, make_result, make_user
 
-from agent_eval.agent.claude_code import _extract_denial_list, _extract_progress
+from agent_eval.agent.claude_code import (
+    ClaudeCodeRunner, _detect_unknown_command, _extract_denial_list,
+    _extract_progress,
+)
 
 
 def test_root_assistant_shows_tool():
@@ -93,3 +98,123 @@ def test_denial_list_empty_when_no_denials():
 def test_denial_list_none_when_both_absent():
     """No result_obj and no streaming count returns None."""
     assert _extract_denial_list(None, 0) is None
+
+
+class TestDetectUnknownCommand:
+    """An unrecognised slash command is reported by the CLI as a *successful*
+    run — exit 0, subtype "success", is_error false, 0 turns, $0.00 — so without
+    this detection a misconfigured skill reads as "ran, produced nothing" and a
+    whole eval completes green in seconds.
+
+    Shape pinned against a real `claude --print --output-format stream-json` run.
+    """
+
+    def _result(self, **over):
+        obj = {"type": "result", "subtype": "success", "is_error": False,
+               "num_turns": 0, "total_cost_usd": 0,
+               "result": "Unknown command: /epic-decompose"}
+        obj.update(over)
+        return obj
+
+    def test_detects_unknown_slash_command(self):
+        assert _detect_unknown_command(self._result()) == "/epic-decompose"
+
+    def test_tolerates_surrounding_whitespace(self):
+        assert _detect_unknown_command(
+            self._result(result="  Unknown command: /foo\n")) == "/foo"
+
+    def test_ignores_a_normal_successful_run(self):
+        assert _detect_unknown_command(
+            self._result(num_turns=12, result="Created 4 epics.")) is None
+
+    def test_turns_guard_prevents_false_positive(self):
+        """A real run that merely quotes the phrase must not be failed."""
+        assert _detect_unknown_command(self._result(
+            num_turns=7,
+            result="The user typed Unknown command: /foo, so I explained it.",
+        )) is None
+
+    def test_phrase_must_lead_the_message(self):
+        assert _detect_unknown_command(self._result(
+            result="Everything worked. Unknown command: /foo was not needed.",
+        )) is None
+
+    def test_requires_a_slash_command(self):
+        assert _detect_unknown_command(
+            self._result(result="Unknown command: epic-decompose")) is None
+
+    def test_handles_missing_or_odd_payloads(self):
+        assert _detect_unknown_command(None) is None
+        assert _detect_unknown_command({}) is None
+        assert _detect_unknown_command({"result": None, "num_turns": 0}) is None
+        assert _detect_unknown_command({"result": 42, "num_turns": 0}) is None
+
+
+class TestUnknownCommandFailsTheRun:
+    """End-to-end through ClaudeCodeRunner.run_skill with a stub `claude` on PATH,
+    reproducing the exact stream a real CLI emits for an unrecognised command.
+
+    execute.py derives its per-case OK/FAIL purely from RunResult.exit_code, so
+    flipping it here is what turns a silently-green run into a visible failure.
+    """
+
+    STREAM = (
+        '{"type":"system","subtype":"init","session_id":"s1"}\n'
+        '{"type":"assistant","message":{"content":[{"type":"text",'
+        '"text":"Unknown command: /epic-decompose"}]},"session_id":"s1"}\n'
+        '{"type":"result","subtype":"success","is_error":false,"num_turns":0,'
+        '"total_cost_usd":0,"result":"Unknown command: /epic-decompose",'
+        '"session_id":"s1"}\n'
+    )
+
+    OK_STREAM = (
+        '{"type":"system","subtype":"init","session_id":"s1"}\n'
+        '{"type":"result","subtype":"success","is_error":false,"num_turns":3,'
+        '"total_cost_usd":0.5,"result":"Wrote 4 epics.","session_id":"s1"}\n'
+    )
+
+    def _stub_claude(self, tmp_path, monkeypatch, stream):
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        stub = bindir / "claude"
+        stub.write_text(
+            "#!/bin/sh\ncat > /dev/null\n"
+            f"cat <<'STREAM_EOF'\n{stream}STREAM_EOF\n"
+        )
+        stub.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+
+    # Single-object payload: without a log prefix the runner asks for
+    # --output-format json and parses one object instead of a stream.
+    JSON_UNKNOWN = ('{"type":"result","subtype":"success","is_error":false,'
+                    '"num_turns":0,"total_cost_usd":0,'
+                    '"result":"Unknown command: /epic-decompose"}\n')
+
+    def _run(self, tmp_path, log_prefix=None):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        return ClaudeCodeRunner(log_prefix=log_prefix).execute(
+            target="epic-decompose", args="", workspace=ws,
+            model="m", timeout_s=60,
+        )
+
+    def test_unknown_command_fails_the_streaming_path(self, tmp_path, monkeypatch):
+        """eval-run always passes a log prefix, so this is the production path."""
+        self._stub_claude(tmp_path, monkeypatch, self.STREAM)
+        result = self._run(tmp_path, log_prefix="test")
+        assert result.exit_code != 0, "an unrecognised skill must fail the case"
+        assert "/epic-decompose" in result.stderr
+        assert "runner.plugin_dirs" in result.stderr
+
+    def test_unknown_command_fails_the_json_path(self, tmp_path, monkeypatch):
+        self._stub_claude(tmp_path, monkeypatch, self.JSON_UNKNOWN)
+        result = self._run(tmp_path)
+        assert result.exit_code != 0, "an unrecognised skill must fail the case"
+        assert "/epic-decompose" in result.stderr
+
+    def test_normal_run_still_succeeds(self, tmp_path, monkeypatch):
+        """Guard against failing healthy runs."""
+        self._stub_claude(tmp_path, monkeypatch, self.OK_STREAM)
+        result = self._run(tmp_path, log_prefix="test")
+        assert result.exit_code == 0, result.stderr
+        assert "Unknown command" not in (result.stderr or "")

--- a/tests/test_extract_progress.py
+++ b/tests/test_extract_progress.py
@@ -2,6 +2,8 @@
 
 import os
 
+import pytest
+
 from conftest import make_assistant, make_result, make_user
 
 from agent_eval.agent.claude_code import (
@@ -142,6 +144,24 @@ class TestDetectUnknownCommand:
     def test_requires_a_slash_command(self):
         assert _detect_unknown_command(
             self._result(result="Unknown command: epic-decompose")) is None
+
+    @pytest.mark.parametrize("turns", [0, None, False, "0", 0.0, [], {}])
+    def test_no_evidence_of_work_still_detects(self, turns):
+        """Absent/null/non-numeric counts must not be read as "had turns" — the
+        leading phrase is the signal, and a stricter reading would silently stop
+        detecting the bug if the payload shape changed."""
+        assert _detect_unknown_command(
+            self._result(num_turns=turns)) == "/epic-decompose"
+
+    def test_missing_turn_count_key_still_detects(self):
+        obj = self._result()
+        del obj["num_turns"]
+        assert _detect_unknown_command(obj) == "/epic-decompose"
+
+    @pytest.mark.parametrize("turns", [1, 12, 2.5, True])
+    def test_positive_turn_count_suppresses(self, turns):
+        """Any positive count is evidence real work happened."""
+        assert _detect_unknown_command(self._result(num_turns=turns)) is None
 
     def test_handles_missing_or_odd_payloads(self):
         assert _detect_unknown_command(None) is None


### PR DESCRIPTION
## Problem

Claude Code answers an unrecognised slash command with plain text and still reports success. Captured from a real `claude --print --output-format stream-json` run:

```json
{"type":"result","subtype":"success","is_error":false,
 "num_turns":0,"total_cost_usd":0,"result":"Unknown command: /definitely-not-a-real-skill"}
```

The process exits 0. So an eval whose skill never resolves — a plugin-packaged skill with no `runner.plugin_dirs`, a typo, a plugin that failed to load — finishes in seconds with every case marked `OK`:

```
  → case-001-simple-two-component: OK | 4s | $0.00
  → case-002-complex-genai-eval:   OK | 4s | $0.00
EXIT: 0
CASES: 6 (6 OK, 0 FAIL)
```

The real damage is the misdiagnosis. This is indistinguishable from a skill that ran and produced nothing, so the judges fail on missing artifacts and the report points at **skill quality** instead of at the **config**. It cost an hour of debugging on a real eval before the cause was obvious.

## Change

Detect that specific result shape in the Claude Code runner and return a non-zero exit code plus an explanatory stderr line:

```
ERROR: the agent did not recognise '/epic-decompose' (0 turns, no work performed).
The skill is not discoverable at runtime — check the skill name, and set
runner.plugin_dirs if it is packaged as a plugin rather than living in .claude/skills.
```

Placed in the runner rather than `execute.py` because the string is Claude Code-specific and `execute.py` derives per-case OK/FAIL purely from `RunResult.exit_code` — so case, batch and multi-step runs all surface it with no further changes. Harbor/EvalHub paths inherit it too.

## False positives

`num_turns` guards the match: a real run that merely quotes the phrase has turns, an unrecognised command never does. The phrase must also lead the message, and must name an actual `/command`. A normal successful run is explicitly asserted to remain exit 0.

## Tests

`TestDetectUnknownCommand` covers the helper (detection, whitespace, the turns guard, mid-message quoting, non-slash text, malformed payloads).

`TestUnknownCommandFailsTheRun` runs `ClaudeCodeRunner.execute()` end-to-end against a stub `claude` on `PATH` emitting the exact captured stream, on **both** output paths — streaming (`--output-format stream-json`, what eval-run uses since it always passes a log prefix) and single-object (`--output-format json`). Writing this caught that `result_obj` is only populated on one path, which a helper-only unit test would have missed.

`1272 passed, 7 skipped`. No new ruff findings (base and head both report 2 in the touched file); CI lint is `skillsaw`.

## Related

Companion PR, independent and separately mergeable: the config-time half that catches this before a run starts — #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown slash commands are now correctly reported as failures instead of successful runs.
  * Error results include a clear explanatory message and the appropriate failure status.
  * Detection works consistently across streaming and JSON execution paths while avoiding false positives.

* **Tests**
  * Added coverage for valid, malformed, whitespace-heavy, and successful command scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->