### PR TITLE
fix(claude-code): stop losing interception evidence (deny reason, hook import, denial telemetry)

### DIFF
--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -283,6 +283,7 @@ class ClaudeCodeRunner(EvalRunner):
             result_obj = None
             resolved_model = None
             permission_denials = 0
+            result_denials = []
 
             for line in proc.stdout:
                 if time.monotonic() > deadline:
@@ -307,6 +308,16 @@ class ClaudeCodeRunner(EvalRunner):
                                 print(f"  {self._log_prefix} | {msg}", flush=True)
                         if obj.get("type") == "result":
                             result_obj = obj
+                            # A session the CLI resumes (e.g. after background
+                            # task notifications) emits one result event PER
+                            # segment, each carrying only that segment's
+                            # denials. Keeping just the last event drops every
+                            # earlier segment's list — a real run lost 7
+                            # denials that way, hiding a workspace escape from
+                            # run_result.json.
+                            seg = obj.get("permission_denials")
+                            if isinstance(seg, list):
+                                result_denials.extend(seg)
                     except json.JSONDecodeError:
                         pass
                 stdout_lines.append(line)
@@ -330,7 +341,7 @@ class ClaudeCodeRunner(EvalRunner):
             per_model_turns = _per_model_turns(
                 workspace / "subagents", stream_ids_by_model)
             timeout_stderr = f"Timed out after {timeout_s}s"
-            denial_list = _extract_denial_list(result_obj, permission_denials)
+            denial_list = _extract_denial_list(result_obj, permission_denials, result_denials)
             if denial_list:
                 timeout_stderr += (f"\nWARNING: {len(denial_list)} permission "
                                    f"denial(s) detected during execution")
@@ -401,7 +412,7 @@ class ClaudeCodeRunner(EvalRunner):
         per_model_turns = _per_model_turns(
             workspace / "subagents", stream_ids_by_model)
 
-        denial_list = _extract_denial_list(result_obj, permission_denials)
+        denial_list = _extract_denial_list(result_obj, permission_denials, result_denials)
         if denial_list:
             denial_msg = (f"\nWARNING: {len(denial_list)} permission "
                           f"denial(s) detected during execution")
@@ -539,18 +550,34 @@ def _detect_unknown_command(result_obj) -> Optional[str]:
     return match.group(1) if match else None
 
 
-def _extract_denial_list(result_obj, streaming_count):
+def _extract_denial_list(result_obj, streaming_count, collected=None):
     """Build the permission_denials list for RunResult.
 
-    Prefers the structured ``permission_denials`` array from the CLI
-    ``result`` event (available since Claude Code 2.x).  Falls back to
-    a synthetic list derived from the streaming keyword counter when the
-    result event is absent (e.g. timeout before result is emitted).
+    Prefers the structured ``permission_denials`` arrays from the CLI
+    ``result`` events (available since Claude Code 2.x). ``collected`` is the
+    union across ALL result events of the session — a resumed session emits
+    one result event per segment, each with only that segment's denials, so
+    reading only the final event under-reports. Deduplicated by tool_use_id
+    where present, in case a CLI version ever reports cumulatively. Falls back
+    to a synthetic list derived from the streaming keyword counter when no
+    result event carried denials (e.g. timeout before a result is emitted).
     """
-    if isinstance(result_obj, dict):
-        denials = result_obj.get("permission_denials")
-        if isinstance(denials, list) and denials:
-            return denials
+    denials = list(collected) if collected else []
+    if not denials and isinstance(result_obj, dict):
+        final = result_obj.get("permission_denials")
+        if isinstance(final, list):
+            denials = list(final)
+    if denials:
+        seen = set()
+        unique = []
+        for d in denials:
+            key = d.get("tool_use_id") if isinstance(d, dict) else None
+            if key and key in seen:
+                continue
+            if key:
+                seen.add(key)
+            unique.append(d)
+        return unique
     if streaming_count:
         return [{"tool_name": "unknown"}] * streaming_count
     return None

--- a/skills/eval-run/scripts/tools.py
+++ b/skills/eval-run/scripts/tools.py
@@ -11,15 +11,32 @@ Supports:
 - Filtering Bash commands by content patterns
 """
 
-import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
-
 import json
 import os
 import re
 import sys
 from pathlib import Path
 
-import yaml
+# This script is COPIED into <workspace>/hooks/ and executed by the Claude
+# Code hook runner as a bare `python3 .../tools.py` — agent_eval is usually
+# not importable there, and a PreToolUse hook that crashes is treated as
+# pass-through by the CLI, which silently disables ALL interception (observed
+# on a real eval run). The bootstrap is only a venv-activation convenience:
+# use it when available, never require it.
+try:
+    import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+except ImportError:
+    pass
+
+try:
+    import yaml
+except ImportError:
+    print(
+        "tools.py: PyYAML unavailable and agent_eval venv not importable — "
+        "tool interception is DISABLED for this call (pass-through).",
+        file=sys.stderr,
+    )
+    sys.exit(0)
 
 
 def main():
@@ -247,11 +264,19 @@ Reply with ONLY the option label text, nothing else."""
 
 
 def _deny(reason):
-    """Deny the tool call with a reason."""
+    """Deny the tool call with a reason.
+
+    Claude Code reads ``permissionDecisionReason``; emitting only ``reason``
+    (the old key) makes the agent see the generic "Hook PreToolUse denied this
+    tool" with the handler's carefully crafted guidance silently dropped — on
+    a real eval run the agents had to reverse-engineer why the call was
+    blocked. Keep ``reason`` too for anything still reading the old key.
+    """
     output = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
             "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
             "reason": reason,
         }
     }

--- a/skills/eval-run/scripts/tools.py
+++ b/skills/eval-run/scripts/tools.py
@@ -31,9 +31,13 @@ except ImportError:
 try:
     import yaml
 except ImportError:
+    # Report only the confirmed failure: the bootstrap import above may have
+    # succeeded — what is certain here is that PyYAML cannot be imported.
     print(
-        "tools.py: PyYAML unavailable and agent_eval venv not importable — "
-        "tool interception is DISABLED for this call (pass-through).",
+        "tools.py: PyYAML is not importable — tool interception is DISABLED "
+        "for this call (pass-through). Install PyYAML for the interpreter "
+        "running hooks, or make the agent_eval venv importable so the "
+        "bootstrap can activate it.",
         file=sys.stderr,
     )
     sys.exit(0)

--- a/tests/test_extract_progress.py
+++ b/tests/test_extract_progress.py
@@ -238,3 +238,67 @@ class TestUnknownCommandFailsTheRun:
         result = self._run(tmp_path, log_prefix="test")
         assert result.exit_code == 0, result.stderr
         assert "Unknown command" not in (result.stderr or "")
+
+
+class TestDenialAggregationAcrossSegments:
+    """A CLI-resumed session emits one result event PER segment, each carrying
+    only that segment's permission_denials. Reading only the final event lost
+    7 denials on a real run (the final segment's list was empty), which hid a
+    workspace escape from run_result.json."""
+
+    def test_collected_segments_are_unioned(self):
+        seg1 = [{"tool_name": "Read", "tool_use_id": "tu_a", "tool_input": {}}]
+        seg2 = [{"tool_name": "Read", "tool_use_id": "tu_b", "tool_input": {}}]
+        final = make_result(permission_denials=[])  # last segment: empty
+        got = _extract_denial_list(final, 0, collected=seg1 + seg2)
+        assert got == seg1 + seg2
+
+    def test_collected_wins_over_empty_final_event(self):
+        collected = [{"tool_name": "Write", "tool_use_id": "tu_x", "tool_input": {}}]
+        assert _extract_denial_list(make_result(), 0, collected=collected) == collected
+
+    def test_cumulative_reporting_is_deduplicated(self):
+        """If a CLI version reports cumulatively, the same tool_use_id must
+        not be double-counted."""
+        d = {"tool_name": "Read", "tool_use_id": "tu_a", "tool_input": {}}
+        got = _extract_denial_list(None, 0, collected=[d, dict(d)])
+        assert got == [d]
+
+    def test_entries_without_ids_are_kept(self):
+        anon = [{"tool_name": "unknown"}, {"tool_name": "unknown"}]
+        assert _extract_denial_list(None, 0, collected=list(anon)) == anon
+
+    def test_no_collected_falls_back_to_final_then_streaming(self):
+        denials = [{"tool_name": "Bash", "tool_use_id": "tu_1", "tool_input": {}}]
+        assert _extract_denial_list(make_result(permission_denials=denials), 0) == denials
+        assert len(_extract_denial_list(make_result(), 4)) == 4
+
+    def test_runner_unions_denials_from_stream(self, tmp_path, monkeypatch):
+        """End-to-end: two result events in the stream, denials only in the
+        first — RunResult must still carry them."""
+        import os
+        seg1_denial = ('[{"tool_name":"Read","tool_use_id":"tu_esc",'
+                       '"tool_input":{"file_path":"/repo/secret"}}]')
+        stream = (
+            '{"type":"system","subtype":"init","session_id":"s1"}\n'
+            '{"type":"result","subtype":"success","is_error":false,"num_turns":5,'
+            f'"total_cost_usd":0.5,"result":"partial","permission_denials":{seg1_denial},'
+            '"session_id":"s1"}\n'
+            '{"type":"system","subtype":"init","session_id":"s1"}\n'
+            '{"type":"result","subtype":"success","is_error":false,"num_turns":2,'
+            '"total_cost_usd":0.6,"result":"done","permission_denials":[],'
+            '"session_id":"s1"}\n'
+        )
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        stub = bindir / "claude"
+        stub.write_text("#!/bin/sh\ncat > /dev/null\n"
+                        f"cat <<'STREAM_EOF'\n{stream}STREAM_EOF\n")
+        stub.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        result = ClaudeCodeRunner(log_prefix="test").execute(
+            target="x", args="", workspace=ws, model="m", timeout_s=60)
+        assert result.permission_denials is not None
+        assert [d["tool_use_id"] for d in result.permission_denials] == ["tu_esc"]

--- a/tests/test_tools_deny_reason.py
+++ b/tests/test_tools_deny_reason.py
@@ -1,0 +1,69 @@
+"""The PreToolUse interceptor's deny output must carry the reason in the field
+Claude Code actually reads.
+
+The hook emitted only the legacy ``reason`` key; the CLI reads
+``permissionDecisionReason``, so agents saw the generic "Hook PreToolUse denied
+this tool" and every handler's crafted guidance was silently dropped — on a
+real eval run the denied agents had to reverse-engineer why the call was
+blocked by reading tool_handlers.yaml themselves.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS_PY = REPO_ROOT / "skills" / "eval-run" / "scripts" / "tools.py"
+
+
+def _run_hook(tmp_path, tool_name, tool_input):
+    (tmp_path / "tool_handlers.yaml").write_text(yaml.safe_dump({
+        "handlers": [{
+            "match": "network fetch skipped - files are pre-provisioned; "
+                     "treat this step as successful and continue",
+            "patterns": ["Bash"],
+            "input_filters": [r"fetch_strategy\.py"],
+        }],
+    }))
+    hook_dir = tmp_path / "hooks"
+    hook_dir.mkdir()
+    hook = hook_dir / "tools.py"
+    hook.write_text(TOOLS_PY.read_text())
+    proc = subprocess.run(
+        [sys.executable, str(hook)],
+        input=json.dumps({"tool_name": tool_name, "tool_input": tool_input}),
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    return proc
+
+
+def test_deny_carries_permission_decision_reason(tmp_path):
+    proc = _run_hook(tmp_path, "Bash",
+                     {"command": "python3 scripts/fetch_strategy.py fetch-one X-1"})
+    out = json.loads(proc.stdout)
+    hso = out["hookSpecificOutput"]
+    assert hso["permissionDecision"] == "deny"
+    # The field the CLI reads:
+    assert "pre-provisioned" in hso["permissionDecisionReason"]
+    # Back-compat for consumers of the old key:
+    assert hso["permissionDecisionReason"] == hso["reason"]
+
+
+def test_unmatched_bash_passes_through_silently(tmp_path):
+    proc = _run_hook(tmp_path, "Bash", {"command": "ls -la"})
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_hook_runs_without_agent_eval_importable(tmp_path):
+    """The copied hook must work as a bare python3 script: agent_eval is not
+    importable from a workspace, and a crashing PreToolUse hook is silently
+    treated as pass-through by the CLI — which disabled ALL interception on a
+    real run."""
+    proc = _run_hook(tmp_path, "Bash",
+                     {"command": "python3 scripts/fetch_strategy.py fetch-one X-1"})
+    assert proc.returncode == 0, proc.stderr
+    assert "Traceback" not in proc.stderr

--- a/tests/test_tools_deny_reason.py
+++ b/tests/test_tools_deny_reason.py
@@ -19,7 +19,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 TOOLS_PY = REPO_ROOT / "skills" / "eval-run" / "scripts" / "tools.py"
 
 
-def _run_hook(tmp_path, tool_name, tool_input):
+def _run_hook(tmp_path, tool_name, tool_input, env=None):
     (tmp_path / "tool_handlers.yaml").write_text(yaml.safe_dump({
         "handlers": [{
             "match": "network fetch skipped - files are pre-provisioned; "
@@ -35,7 +35,7 @@ def _run_hook(tmp_path, tool_name, tool_input):
     proc = subprocess.run(
         [sys.executable, str(hook)],
         input=json.dumps({"tool_name": tool_name, "tool_input": tool_input}),
-        capture_output=True, text=True, cwd=tmp_path,
+        capture_output=True, text=True, cwd=tmp_path, env=env,
     )
     return proc
 
@@ -58,12 +58,24 @@ def test_unmatched_bash_passes_through_silently(tmp_path):
     assert proc.stdout.strip() == ""
 
 
-def test_hook_runs_without_agent_eval_importable(tmp_path):
-    """The copied hook must work as a bare python3 script: agent_eval is not
-    importable from a workspace, and a crashing PreToolUse hook is silently
-    treated as pass-through by the CLI — which disabled ALL interception on a
-    real run."""
+def test_hook_denies_even_when_bootstrap_import_fails(tmp_path):
+    """The copied hook must survive `import agent_eval._bootstrap` failing —
+    a crashing PreToolUse hook is silently treated as pass-through by the CLI,
+    which disabled ALL interception on a real run. Force the failure with an
+    import blocker so the test proves it even on machines where agent_eval is
+    pip-installed, and assert interception still WORKS (deny emitted): the
+    bootstrap is a convenience, not a dependency."""
+    import os
+    blocker = tmp_path / "blocker" / "agent_eval"
+    blocker.mkdir(parents=True)
+    (blocker / "__init__.py").write_text(
+        'raise ImportError("agent_eval blocked for test")\n')
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(tmp_path / "blocker")
     proc = _run_hook(tmp_path, "Bash",
-                     {"command": "python3 scripts/fetch_strategy.py fetch-one X-1"})
+                     {"command": "python3 scripts/fetch_strategy.py fetch-one X-1"},
+                     env=env)
     assert proc.returncode == 0, proc.stderr
     assert "Traceback" not in proc.stderr
+    out = json.loads(proc.stdout)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "deny"

--- a/tests/test_venv_activation.py
+++ b/tests/test_venv_activation.py
@@ -81,7 +81,20 @@ def _imports(nodes):
 
 
 def _toplevel_imports(tree):
-    return _imports(tree.body)
+    """Module-body imports, descending into module-level try/except blocks.
+
+    A guarded `try: import agent_eval._bootstrap / except ImportError: pass`
+    is the pattern for scripts that are COPIED out of the repo (e.g. the
+    PreToolUse interceptor lands in <workspace>/hooks/): the venv is activated
+    when reachable, and the script degrades explicitly when it is not. Such an
+    import still counts, both as the bootstrap and for ordering.
+    """
+    body = []
+    for node in tree.body:
+        body.append(node)
+        if isinstance(node, ast.Try):
+            body.extend(node.body)
+    return _imports(body)
 
 
 def _all_imports(tree):
@@ -182,7 +195,12 @@ def test_orchestrate_does_not_leak_the_sentinel_to_children():
 
 def _imports_bootstrap(tree, lineno):
     """True if the import at `lineno` is specifically agent_eval._bootstrap."""
+    body = []
     for node in tree.body:
+        body.append(node)
+        if isinstance(node, ast.Try):
+            body.extend(node.body)
+    for node in body:
         if getattr(node, "lineno", None) != lineno:
             continue
         if isinstance(node, ast.Import):


### PR DESCRIPTION
## Problem

Auditing the logs of a real 30-case eval run surfaced three related ways the tool-interception path loses evidence — each one hid a real incident from the operator:

1. **Crafted deny reasons never reach the agent.** `tools.py` emitted the deny reason only under the legacy `reason` key; Claude Code reads `hookSpecificOutput.permissionDecisionReason`. Agents saw only the generic *"Hook PreToolUse denied this tool"* — on the audited run, the denied agents had to reverse-engineer why the call was blocked by reading `tool_handlers.yaml` themselves. The handler's `match` message ("files are pre-provisioned; treat this step as successful") existed precisely to prevent that.

2. **The copied hook crashes outside the repo — and a crashed PreToolUse hook is silent pass-through.** `hooks/tools.py` is copied into the workspace and executed as a bare `python3` script, where `import agent_eval._bootstrap` raises `ModuleNotFoundError`. The CLI treats the failing hook as pass-through, disabling ALL interception with only a buried stderr line. This exact failure mode disabled interception for an entire earlier run.

3. **`run_result.json` under-reports permission denials on resumed sessions.** A CLI session resumed on background-task notifications emits one `result` event per segment, each carrying only that segment's `permission_denials`; the runner kept only the last event's (typically empty) list. On the audited run this dropped 7 denials — and with them the only run-level trace of a workspace escape.

## Change

- `_deny()` emits `permissionDecisionReason` (and keeps `reason` for anything reading the old key).
- The bootstrap import in `tools.py` is guarded — it is only a venv-activation convenience — and if PyYAML is genuinely unavailable the hook passes through **explicitly** with a stderr warning instead of crashing. The venv-activation AST test (`test_bootstrap_precedes_third_party_imports`) now recognises a module-level `try/except`-guarded bootstrap import, and ordering is still enforced.
- The runner accumulates `permission_denials` across **all** result events of the stream; `_extract_denial_list` unions them, deduplicated by `tool_use_id` in case a CLI version ever reports cumulatively. Fallback order unchanged: collected → final event → streaming counter.

## Tests

- `test_tools_deny_reason.py` (new): runs the actual hook as a subprocess in a scratch workspace — deny carries `permissionDecisionReason`, unmatched Bash passes through silently, and the hook works with `agent_eval` unimportable (no traceback, exit 0).
- `TestDenialAggregationAcrossSegments`: union across segments, collected-wins-over-empty-final, `tool_use_id` dedup, no-id entries kept, fallback order, plus an end-to-end stub-CLI test with two result events asserting `RunResult.permission_denials` keeps the first segment's denial.

`1300 passed, 7 skipped`. Ruff parity: base=head on every touched file (2/1/1 pre-existing findings, none new).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Permission denials are now consistently collected across streamed responses, deduplicated, and preserved in final results, including timeout scenarios.
  - Denial responses now include clearer guidance through `permissionDecisionReason` while retaining the existing reason information.
  - Tool processing now continues safely when optional setup components or YAML support are unavailable, instead of failing unexpectedly.
  - Improved handling of guarded setup imports ensures environment checks work reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->