### PR TITLE
feat(claude-code): stage plugin dirs into the workspace

### DIFF
--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -16,9 +16,82 @@ from .stream_capture import (
     count_subagent_turns, count_subagent_turns_by_model, setup_subagent_hook,
 )
 from agent_eval.tools.permissions import compile_permission_rules
-from agent_eval.config import resolve_plugin_dir
+from agent_eval.config import resolve_plugin_dir, resolve_plugin_skill_roots
 
 _print_lock = threading.Lock()
+
+# Conventional directories plugin discovery reads besides the manifest and
+# the manifest-declared skill roots. Copied only when present.
+_PLUGIN_OPTIONAL_DIRS = ("commands", "agents", "hooks")
+
+# Bulk plugin discovery never reads — keeps the staged copy small.
+_PLUGIN_IGNORE = shutil.ignore_patterns(".git", "node_modules", "__pycache__")
+
+
+def stage_plugin_dir(plugin_dir: Path, workspace: Path) -> Path:
+    """Copy one plugin's discoverable content into the case workspace.
+
+    WHY: ``--plugin-dir <real path>`` lands verbatim in every session's
+    system context — the stream-json init event registers the plugin under
+    that path. In the 2026-08-19 eval run on the epic-creator project, two
+    of 30 case dispatchers followed that leaked path, cd'd into the real
+    project repo, and ran pipeline phases there: one delivered an incomplete
+    artifact (unscored epics), the other left mid-pipeline state files in
+    the repo. The workspace's per-case staging hook gates the Read tool via
+    additionalDirectories, but Bash is not path-gated, so the leaked path is
+    a standing escape vector. Staging the plugin inside the throwaway
+    workspace and passing THAT path keeps the real path out of the session.
+
+    Copies only what plugin discovery needs: the ``.claude-plugin/``
+    manifest, every skill root declared by the manifest (via
+    ``resolve_plugin_skill_roots``, which validates containment), and the
+    conventional ``commands/``, ``agents/`` and ``hooks/`` directories when
+    they exist at the plugin root. Symlinks are not reproduced — their
+    content is copied and dangling ones are skipped — so the staged tree
+    cannot point back outside the workspace. Idempotent per workspace: an
+    existing destination is reused; a partial copy never becomes the
+    destination (copy into a temp sibling, then rename).
+    """
+    plugin = Path(plugin_dir).resolve()
+    dest = workspace / ".staged-plugins" / plugin.name
+    if dest.exists():
+        return dest
+
+    sources = [plugin / ".claude-plugin"]
+    try:
+        sources.extend(resolve_plugin_skill_roots(plugin))
+    except (ValueError, FileNotFoundError):
+        # A Claude plugin may legitimately export no skills (commands,
+        # agents or hooks only) — same tolerance as Harbor's skill-root
+        # forwarding. Without staging, Claude Code would receive the real
+        # directory and load whatever is discoverable; mirror that.
+        pass
+    sources.extend(plugin / name for name in _PLUGIN_OPTIONAL_DIRS)
+
+    staging = dest.parent / f".{plugin.name}.partial"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True)
+    try:
+        for source in sources:
+            if not source.is_dir():
+                continue
+            shutil.copytree(
+                source, staging / source.relative_to(plugin),
+                symlinks=False, ignore=_PLUGIN_IGNORE,
+                ignore_dangling_symlinks=True, dirs_exist_ok=True)
+        try:
+            staging.replace(dest)
+        except OSError:
+            # Another stager won the rename race; its complete copy stands.
+            if dest.is_dir():
+                shutil.rmtree(staging, ignore_errors=True)
+                return dest
+            raise
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return dest
 
 
 def _per_model_turns(subagent_dir, stream_ids_by_model):
@@ -57,6 +130,7 @@ class ClaudeCodeRunner(EvalRunner):
         return cls(
             permissions=overrides.get("permissions", config.permissions),
             plugin_dirs=resolved_plugin_dirs,
+            stage_plugins=config.runner.stage_plugins,
             env=config.runner.env,
             system_prompt=config.runner.system_prompt,
             subagent_model=overrides.get("subagent_model"),
@@ -73,6 +147,7 @@ class ClaudeCodeRunner(EvalRunner):
         permissions: Optional[dict] = None,
         subagent_model: Optional[str] = None,
         plugin_dirs: Optional[list] = None,
+        stage_plugins: bool = False,
         env: Optional[dict] = None,
         system_prompt: Optional[str] = None,
         mlflow_experiment: Optional[str] = None,
@@ -84,6 +159,7 @@ class ClaudeCodeRunner(EvalRunner):
         self._permissions = permissions or {}
         self._subagent_model = subagent_model
         self._plugin_dirs = plugin_dirs or []
+        self._stage_plugins = stage_plugins
         self._env = env or {}
         self._system_prompt = system_prompt
         self._mlflow_experiment = mlflow_experiment
@@ -148,7 +224,18 @@ class ClaudeCodeRunner(EvalRunner):
         if self._permission_mode:
             cmd.extend(["--permission-mode", self._permission_mode])
 
-        for plugin_dir in self._plugin_dirs:
+        plugin_dirs = self._plugin_dirs
+        if self._stage_plugins and plugin_dirs:
+            # Pass a workspace-local copy so the real plugin path never
+            # enters the session context (see stage_plugin_dir).
+            try:
+                plugin_dirs = self._staged_plugin_dirs(workspace)
+            except (OSError, ValueError, FileNotFoundError) as e:
+                return RunResult(
+                    exit_code=-1, stdout="",
+                    stderr=f"Plugin staging failed: {e}", duration_s=0.0,
+                )
+        for plugin_dir in plugin_dirs:
             cmd.extend(["--plugin-dir", str(plugin_dir)])
 
         effective_prompt = system_prompt or self._system_prompt
@@ -455,6 +542,25 @@ class ClaudeCodeRunner(EvalRunner):
             permission_denials=denial_list,
             raw_output=raw_output,
         )
+
+    def _staged_plugin_dirs(self, workspace: Path) -> list:
+        """Stage every configured plugin into the workspace; return the copies.
+
+        The staged path is keyed by the plugin's directory name, so two
+        different plugins sharing a basename would silently collapse into
+        one copy — fail loud instead.
+        """
+        staged = []
+        seen: dict = {}
+        for configured in self._plugin_dirs:
+            plugin = Path(configured).resolve()
+            previous = seen.setdefault(plugin.name, plugin)
+            if previous != plugin:
+                raise ValueError(
+                    "stage_plugins cannot stage two different plugins with "
+                    f"the same directory name: {previous} and {plugin}")
+            staged.append(str(stage_plugin_dir(plugin, workspace)))
+        return staged
 
     @staticmethod
     def _cleanup_session(workspace: Path) -> None:

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -47,8 +47,11 @@ def _plugin_ignore(plugin: Path):
             if entry.is_symlink():
                 try:
                     resolved = entry.resolve(strict=True)
-                except OSError:
-                    continue  # dangling — copytree already skips these
+                except (OSError, RuntimeError):
+                    # Dangling or looping (loops raise RuntimeError on
+                    # Python 3.11/3.12, OSError after) — not stageable.
+                    ignored.add(name)
+                    continue
                 if not resolved.is_relative_to(plugin):
                     ignored.add(name)
         return ignored
@@ -115,6 +118,17 @@ def stage_plugin_dir(plugin_dir: Path, workspace: Path) -> Path:
     try:
         for source in sources:
             if not source.is_dir():
+                continue
+            # copytree with symlinks=False follows a source dir that is
+            # ITSELF a symlink, and the ignore callback only sees entries
+            # inside walked directories — an escaping link at the copy root
+            # (e.g. scripts -> ~/.secrets) would be materialized wholesale.
+            # Apply the same containment rule to the roots.
+            try:
+                resolved = source.resolve(strict=True)
+            except (OSError, RuntimeError):
+                continue
+            if not resolved.is_relative_to(plugin):
                 continue
             shutil.copytree(
                 source, staging / source.relative_to(plugin),

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -31,6 +31,30 @@ _PLUGIN_OPTIONAL_DIRS = ("commands", "agents", "hooks", "scripts")
 _PLUGIN_IGNORE = shutil.ignore_patterns(".git", "node_modules", "__pycache__")
 
 
+def _plugin_ignore(plugin: Path):
+    """copytree ignore callback: bulk dirs, plus any symlink whose resolved
+    target escapes the plugin. ``symlinks=False`` MATERIALIZES link targets,
+    so a third-party plugin could otherwise plant a link to a host file
+    (credentials, source data) and have staging copy it into the workspace
+    where the agent can read it (CWE-59 -> CWE-200).
+    """
+    def ignore(src, names):
+        ignored = set(_PLUGIN_IGNORE(src, names))
+        for name in names:
+            if name in ignored:
+                continue
+            entry = Path(src) / name
+            if entry.is_symlink():
+                try:
+                    resolved = entry.resolve(strict=True)
+                except OSError:
+                    continue  # dangling — copytree already skips these
+                if not resolved.is_relative_to(plugin):
+                    ignored.add(name)
+        return ignored
+    return ignore
+
+
 def stage_plugin_dir(plugin_dir: Path, workspace: Path) -> Path:
     """Copy one plugin's discoverable content into the case workspace.
 
@@ -61,14 +85,27 @@ def stage_plugin_dir(plugin_dir: Path, workspace: Path) -> Path:
         return dest
 
     sources = [plugin / ".claude-plugin"]
-    try:
+    # A Claude plugin may legitimately export no skills (commands, agents or
+    # hooks only). Tolerate exactly that layout — no 'skills' declaration in
+    # the manifest AND no conventional skills/ directory — and let every
+    # other error from resolve_plugin_skill_roots propagate: a malformed
+    # manifest or a declared-but-missing root staged "successfully" would
+    # only resurface later as an undiscoverable slash command, the silent
+    # failure mode this staging exists to prevent.
+    declares_skills = False
+    manifest_path = plugin / ".claude-plugin" / "plugin.json"
+    if manifest_path.is_file():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+            # Malformed manifest: let the authoritative resolver raise its
+            # own, clearer error below.
+            manifest = None
+            declares_skills = True
+        if isinstance(manifest, dict) and manifest.get("skills") is not None:
+            declares_skills = True
+    if declares_skills or (plugin / "skills").is_dir():
         sources.extend(resolve_plugin_skill_roots(plugin))
-    except (ValueError, FileNotFoundError):
-        # A Claude plugin may legitimately export no skills (commands,
-        # agents or hooks only) — same tolerance as Harbor's skill-root
-        # forwarding. Without staging, Claude Code would receive the real
-        # directory and load whatever is discoverable; mirror that.
-        pass
     sources.extend(plugin / name for name in _PLUGIN_OPTIONAL_DIRS)
 
     staging = dest.parent / f".{plugin.name}.partial"
@@ -81,7 +118,7 @@ def stage_plugin_dir(plugin_dir: Path, workspace: Path) -> Path:
                 continue
             shutil.copytree(
                 source, staging / source.relative_to(plugin),
-                symlinks=False, ignore=_PLUGIN_IGNORE,
+                symlinks=False, ignore=_plugin_ignore(plugin),
                 ignore_dangling_symlinks=True, dirs_exist_ok=True)
         try:
             staging.replace(dest)

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -58,26 +58,26 @@ def _plugin_ignore(plugin: Path):
 def stage_plugin_dir(plugin_dir: Path, workspace: Path) -> Path:
     """Copy one plugin's discoverable content into the case workspace.
 
-    WHY: ``--plugin-dir <real path>`` lands verbatim in every session's
-    system context — the stream-json init event registers the plugin under
-    that path. In the 2026-08-19 eval run on the epic-creator project, two
-    of 30 case dispatchers followed that leaked path, cd'd into the real
-    project repo, and ran pipeline phases there: one delivered an incomplete
-    artifact (unscored epics), the other left mid-pipeline state files in
-    the repo. The workspace's per-case staging hook gates the Read tool via
-    additionalDirectories, but Bash is not path-gated, so the leaked path is
-    a standing escape vector. Staging the plugin inside the throwaway
-    workspace and passing THAT path keeps the real path out of the session.
+    WHY: ``--plugin-dir <path>`` lands verbatim in the session's system
+    context — the stream-json init event registers the plugin under that
+    path. When the configured path points outside the workspace (typically
+    at the project repo under evaluation), the agent can follow it and
+    read or write the real project: ``additionalDirectories`` gates the
+    file tools, but Bash is not path-scoped, so a disclosed path is a
+    standing escape vector out of the isolated workspace. Staging the
+    plugin inside the throwaway workspace and passing THAT path keeps the
+    real location out of the session entirely.
 
-    Copies only what plugin discovery needs: the ``.claude-plugin/``
-    manifest, every skill root declared by the manifest (via
-    ``resolve_plugin_skill_roots``, which validates containment), and the
-    conventional ``commands/``, ``agents/`` and ``hooks/`` directories when
-    they exist at the plugin root. Symlinks are not reproduced — their
-    content is copied and dangling ones are skipped — so the staged tree
-    cannot point back outside the workspace. Idempotent per workspace: an
-    existing destination is reused; a partial copy never becomes the
-    destination (copy into a temp sibling, then rename).
+    Copies only what plugin discovery and execution need: the
+    ``.claude-plugin/`` manifest, every skill root declared by the
+    manifest (via ``resolve_plugin_skill_roots``, which validates
+    containment), and the conventional ``_PLUGIN_OPTIONAL_DIRS`` when they
+    exist at the plugin root. Symlinks are not reproduced — in-plugin
+    targets are copied as content, dangling ones are skipped, and links
+    escaping the plugin are refused — so the staged tree cannot point back
+    outside the workspace. Idempotent per workspace: an existing
+    destination is reused; a partial copy never becomes the destination
+    (copy into a temp sibling, then rename).
     """
     plugin = Path(plugin_dir).resolve()
     dest = workspace / ".staged-plugins" / plugin.name

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -170,6 +170,7 @@ class ClaudeCodeRunner(EvalRunner):
         return cls(
             permissions=overrides.get("permissions", config.permissions),
             plugin_dirs=resolved_plugin_dirs,
+            workspace_mode=config.runner.workspace_mode,
             env=config.runner.env,
             system_prompt=config.runner.system_prompt,
             subagent_model=overrides.get("subagent_model"),
@@ -186,6 +187,7 @@ class ClaudeCodeRunner(EvalRunner):
         permissions: Optional[dict] = None,
         subagent_model: Optional[str] = None,
         plugin_dirs: Optional[list] = None,
+        workspace_mode: Optional[str] = None,
         env: Optional[dict] = None,
         system_prompt: Optional[str] = None,
         mlflow_experiment: Optional[str] = None,
@@ -197,6 +199,7 @@ class ClaudeCodeRunner(EvalRunner):
         self._permissions = permissions or {}
         self._subagent_model = subagent_model
         self._plugin_dirs = plugin_dirs or []
+        self._workspace_mode = workspace_mode
         self._env = env or {}
         self._system_prompt = system_prompt
         self._mlflow_experiment = mlflow_experiment
@@ -265,9 +268,10 @@ class ClaudeCodeRunner(EvalRunner):
         if plugin_dirs:
             # Always pass a workspace-local copy so the real plugin path never
             # enters the session context (see stage_plugin_dir). A plugin that
-            # already lives inside the workspace is passed through unchanged —
-            # which also covers workspace_mode: repo, where the workspace IS
-            # the project and staging would write junk into the user's repo.
+            # already lives inside the workspace is passed through unchanged,
+            # and workspace_mode: repo skips staging entirely — the workspace
+            # IS the project there, so there is nothing to isolate and staging
+            # would write junk into the user's repo.
             try:
                 plugin_dirs = self._staged_plugin_dirs(workspace)
             except (OSError, ValueError, FileNotFoundError) as e:
@@ -590,6 +594,13 @@ class ClaudeCodeRunner(EvalRunner):
         different plugins sharing a basename would silently collapse into
         one copy — fail loud instead.
         """
+        # workspace_mode: repo runs in the user's real repository: there is
+        # no isolation boundary for staging to defend (the session already
+        # has the project), and staging an external plugin would write
+        # .staged-plugins/ into the repo — polluting it and reading back as
+        # a spurious repo modification. Pass every configured path through.
+        if self._workspace_mode == "repo":
+            return [str(Path(p).resolve()) for p in self._plugin_dirs]
         staged = []
         seen: dict = {}
         ws = Path(workspace).resolve()
@@ -597,9 +608,7 @@ class ClaudeCodeRunner(EvalRunner):
             plugin = Path(configured).resolve()
             # A plugin already inside the workspace is passed through: its
             # path discloses nothing outside the sandbox, and re-staging it
-            # would be pointless. This also covers workspace_mode: repo,
-            # where the workspace IS the project — staging there would write
-            # .staged-plugins/ into the user's repo.
+            # would be pointless.
             if plugin == ws or plugin.is_relative_to(ws):
                 staged.append(str(plugin))
                 continue

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -130,8 +130,11 @@ def stage_plugin_dir(plugin_dir: Path, workspace: Path) -> Path:
                 continue
             if not resolved.is_relative_to(plugin):
                 continue
+            # Copy from the CHECKED canonical path, not the symlink: copying
+            # from `source` would re-follow the link at copy time, letting a
+            # concurrent writer swap it between check and use (CWE-367).
             shutil.copytree(
-                source, staging / source.relative_to(plugin),
+                resolved, staging / source.relative_to(plugin),
                 symlinks=False, ignore=_plugin_ignore(plugin),
                 ignore_dangling_symlinks=True, dirs_exist_ok=True)
         try:

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -22,7 +22,10 @@ _print_lock = threading.Lock()
 
 # Conventional directories plugin discovery reads besides the manifest and
 # the manifest-declared skill roots. Copied only when present.
-_PLUGIN_OPTIONAL_DIRS = ("commands", "agents", "hooks")
+# scripts/ is included because skills commonly invoke
+# ${CLAUDE_PLUGIN_ROOT}/scripts/... or ${CLAUDE_SKILL_DIR}/../../scripts/...
+# at runtime; a staged copy without it would break those plugins.
+_PLUGIN_OPTIONAL_DIRS = ("commands", "agents", "hooks", "scripts")
 
 # Bulk plugin discovery never reads — keeps the staged copy small.
 _PLUGIN_IGNORE = shutil.ignore_patterns(".git", "node_modules", "__pycache__")
@@ -130,7 +133,6 @@ class ClaudeCodeRunner(EvalRunner):
         return cls(
             permissions=overrides.get("permissions", config.permissions),
             plugin_dirs=resolved_plugin_dirs,
-            stage_plugins=config.runner.stage_plugins,
             env=config.runner.env,
             system_prompt=config.runner.system_prompt,
             subagent_model=overrides.get("subagent_model"),
@@ -147,7 +149,6 @@ class ClaudeCodeRunner(EvalRunner):
         permissions: Optional[dict] = None,
         subagent_model: Optional[str] = None,
         plugin_dirs: Optional[list] = None,
-        stage_plugins: bool = False,
         env: Optional[dict] = None,
         system_prompt: Optional[str] = None,
         mlflow_experiment: Optional[str] = None,
@@ -159,7 +160,6 @@ class ClaudeCodeRunner(EvalRunner):
         self._permissions = permissions or {}
         self._subagent_model = subagent_model
         self._plugin_dirs = plugin_dirs or []
-        self._stage_plugins = stage_plugins
         self._env = env or {}
         self._system_prompt = system_prompt
         self._mlflow_experiment = mlflow_experiment
@@ -225,9 +225,12 @@ class ClaudeCodeRunner(EvalRunner):
             cmd.extend(["--permission-mode", self._permission_mode])
 
         plugin_dirs = self._plugin_dirs
-        if self._stage_plugins and plugin_dirs:
-            # Pass a workspace-local copy so the real plugin path never
-            # enters the session context (see stage_plugin_dir).
+        if plugin_dirs:
+            # Always pass a workspace-local copy so the real plugin path never
+            # enters the session context (see stage_plugin_dir). A plugin that
+            # already lives inside the workspace is passed through unchanged —
+            # which also covers workspace_mode: repo, where the workspace IS
+            # the project and staging would write junk into the user's repo.
             try:
                 plugin_dirs = self._staged_plugin_dirs(workspace)
             except (OSError, ValueError, FileNotFoundError) as e:
@@ -552,12 +555,21 @@ class ClaudeCodeRunner(EvalRunner):
         """
         staged = []
         seen: dict = {}
+        ws = Path(workspace).resolve()
         for configured in self._plugin_dirs:
             plugin = Path(configured).resolve()
+            # A plugin already inside the workspace is passed through: its
+            # path discloses nothing outside the sandbox, and re-staging it
+            # would be pointless. This also covers workspace_mode: repo,
+            # where the workspace IS the project — staging there would write
+            # .staged-plugins/ into the user's repo.
+            if plugin == ws or plugin.is_relative_to(ws):
+                staged.append(str(plugin))
+                continue
             previous = seen.setdefault(plugin.name, plugin)
             if previous != plugin:
                 raise ValueError(
-                    "stage_plugins cannot stage two different plugins with "
+                    "plugin staging cannot stage two different plugins with "
                     f"the same directory name: {previous} and {plugin}")
             staged.append(str(stage_plugin_dir(plugin, workspace)))
         return staged

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -466,14 +466,11 @@ class RunnerConfig:
     command: Optional[Union[str, list]] = None  # CLI runner: command template
     workspace_mode: Optional[str] = None  # repo | None (default: isolated workspace)
     settings: dict = field(default_factory=dict)
+    # Claude Code stages each entry's discoverable content into the case
+    # workspace and passes the staged copy to --plugin-dir (see
+    # agent.claude_code.stage_plugin_dir); Codex copies each entry's skills
+    # into the workspace's .agents/skills.
     plugin_dirs: list = field(default_factory=list)
-    # Claude Code: stage each plugin's discoverable content inside the
-    # throwaway case workspace and pass the staged copy to --plugin-dir.
-    # Without this the real plugin path appears verbatim in every session's
-    # context (the stream-json init event registers the plugin under that
-    # path), and Bash — which is not path-gated by the workspace's
-    # additionalDirectories read gate — can follow it out of the workspace.
-    # Opt-in so existing configurations see no behavior change.
     env: dict = field(default_factory=dict)
     system_prompt: Optional[str] = None
     # Claude Code: low..max; Codex: minimal..xhigh (runner validates precisely).

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -467,6 +467,14 @@ class RunnerConfig:
     workspace_mode: Optional[str] = None  # repo | None (default: isolated workspace)
     settings: dict = field(default_factory=dict)
     plugin_dirs: list = field(default_factory=list)
+    # Claude Code: stage each plugin's discoverable content inside the
+    # throwaway case workspace and pass the staged copy to --plugin-dir.
+    # Without this the real plugin path appears verbatim in every session's
+    # context (the stream-json init event registers the plugin under that
+    # path), and Bash — which is not path-gated by the workspace's
+    # additionalDirectories read gate — can follow it out of the workspace.
+    # Opt-in so existing configurations see no behavior change.
+    stage_plugins: bool = False
     env: dict = field(default_factory=dict)
     system_prompt: Optional[str] = None
     # Claude Code: low..max; Codex: minimal..xhigh (runner validates precisely).
@@ -499,12 +507,19 @@ def _parse_runner_config(runner_raw, *, context="runner"):
     if workspace_mode is not None and workspace_mode not in ("repo",):
         raise ValueError(
             f"{context}.workspace_mode must be None or 'repo', got: {workspace_mode!r}")
+    # Strict boolean so a quoted "true" fails loud instead of staying truthy
+    # forever (or a quoted "false" silently enabling staging).
+    stage_plugins = runner_raw.get("stage_plugins", False)
+    if not isinstance(stage_plugins, bool):
+        raise ValueError(
+            f"{context}.stage_plugins must be a boolean, got: {stage_plugins!r}")
     return RunnerConfig(
         type=runner_raw.get("type", "claude-code"),
         command=command,
         workspace_mode=workspace_mode,
         settings=runner_raw.get("settings", {}) or {},
         plugin_dirs=runner_raw.get("plugin_dirs", []) or [],
+        stage_plugins=stage_plugins,
         env=runner_raw.get("env", {}) or {},
         system_prompt=runner_raw.get("system_prompt"),
         effort=runner_raw.get("effort"),

--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -474,7 +474,6 @@ class RunnerConfig:
     # path), and Bash — which is not path-gated by the workspace's
     # additionalDirectories read gate — can follow it out of the workspace.
     # Opt-in so existing configurations see no behavior change.
-    stage_plugins: bool = False
     env: dict = field(default_factory=dict)
     system_prompt: Optional[str] = None
     # Claude Code: low..max; Codex: minimal..xhigh (runner validates precisely).
@@ -507,19 +506,12 @@ def _parse_runner_config(runner_raw, *, context="runner"):
     if workspace_mode is not None and workspace_mode not in ("repo",):
         raise ValueError(
             f"{context}.workspace_mode must be None or 'repo', got: {workspace_mode!r}")
-    # Strict boolean so a quoted "true" fails loud instead of staying truthy
-    # forever (or a quoted "false" silently enabling staging).
-    stage_plugins = runner_raw.get("stage_plugins", False)
-    if not isinstance(stage_plugins, bool):
-        raise ValueError(
-            f"{context}.stage_plugins must be a boolean, got: {stage_plugins!r}")
     return RunnerConfig(
         type=runner_raw.get("type", "claude-code"),
         command=command,
         workspace_mode=workspace_mode,
         settings=runner_raw.get("settings", {}) or {},
         plugin_dirs=runner_raw.get("plugin_dirs", []) or [],
-        stage_plugins=stage_plugins,
         env=runner_raw.get("env", {}) or {},
         system_prompt=runner_raw.get("system_prompt"),
         effort=runner_raw.get("effort"),

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -105,8 +105,9 @@ runner:
   # workspace_mode: repo    # Set ONLY when testing requires full repo access (see above)
   # settings: {}            # Runner-specific settings overrides
   # plugin_dirs: []         # Plugin dirs the evaluated skill needs
-  # Plugin dirs listed above are ALWAYS staged into the case workspace and the
-  # staged copy is what --plugin-dir receives: the real project path otherwise
+  # Plugin dirs outside the case workspace are staged into it (no opt-out
+  # flag) and the staged copy is what --plugin-dir receives: the real project
+  # path otherwise
   # lands in session context, where non-path-gated Bash can follow it out of
   # the sandbox. Plugins already inside the workspace are passed through
   # unchanged, and workspace_mode: repo skips staging entirely (the workspace

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -110,6 +110,10 @@ runner:
   # lands in session context, where non-path-gated Bash can follow it out of
   # the sandbox. Plugins already inside the workspace (incl. workspace_mode:
   # repo) are passed through unchanged.
+  # env:                    # Extra env vars for the runner ($VAR resolves from caller)
+  #   CUSTOM_AUTH_TOKEN: "$CUSTOM_AUTH_TOKEN"
+  # system_prompt: ""       # Appended to harness system prompt
+  # effort: high            # Claude: low..max; Codex: minimal..xhigh
 
 # Models — defaults for each role (CLI flags override)
 models:

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -108,8 +108,9 @@ runner:
   # Plugin dirs listed above are ALWAYS staged into the case workspace and the
   # staged copy is what --plugin-dir receives: the real project path otherwise
   # lands in session context, where non-path-gated Bash can follow it out of
-  # the sandbox. Plugins already inside the workspace (incl. workspace_mode:
-  # repo) are passed through unchanged.
+  # the sandbox. Plugins already inside the workspace are passed through
+  # unchanged, and workspace_mode: repo skips staging entirely (the workspace
+  # IS the real project there — nothing to isolate).
   # env:                    # Extra env vars for the runner ($VAR resolves from caller)
   #   CUSTOM_AUTH_TOKEN: "$CUSTOM_AUTH_TOKEN"
   # system_prompt: ""       # Appended to harness system prompt

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -105,14 +105,11 @@ runner:
   # workspace_mode: repo    # Set ONLY when testing requires full repo access (see above)
   # settings: {}            # Runner-specific settings overrides
   # plugin_dirs: []         # Plugin dirs the evaluated skill needs
-  # stage_plugins: true     # claude-code: copy plugin content into the throwaway
-  #                         # workspace and pass that path — otherwise the real
-  #                         # plugin path leaks into the session context, where
-  #                         # Bash (not path-gated) can follow it out of the workspace
-  # env:                     # Extra env vars for the runner ($VAR resolves from caller)
-  #   CUSTOM_AUTH_TOKEN: "$CUSTOM_AUTH_TOKEN"
-  # system_prompt: ""       # Appended to harness system prompt
-  # effort: high            # Claude: low..max; Codex: minimal..xhigh
+  # Plugin dirs listed above are ALWAYS staged into the case workspace and the
+  # staged copy is what --plugin-dir receives: the real project path otherwise
+  # lands in session context, where non-path-gated Bash can follow it out of
+  # the sandbox. Plugins already inside the workspace (incl. workspace_mode:
+  # repo) are passed through unchanged.
 
 # Models — defaults for each role (CLI flags override)
 models:

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -105,6 +105,10 @@ runner:
   # workspace_mode: repo    # Set ONLY when testing requires full repo access (see above)
   # settings: {}            # Runner-specific settings overrides
   # plugin_dirs: []         # Plugin dirs the evaluated skill needs
+  # stage_plugins: true     # claude-code: copy plugin content into the throwaway
+  #                         # workspace and pass that path — otherwise the real
+  #                         # plugin path leaks into the session context, where
+  #                         # Bash (not path-gated) can follow it out of the workspace
   # env:                     # Extra env vars for the runner ($VAR resolves from caller)
   #   CUSTOM_AUTH_TOKEN: "$CUSTOM_AUTH_TOKEN"
   # system_prompt: ""       # Appended to harness system prompt

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -27,6 +27,8 @@ How data flows from dataset cases through execution, collection, and scoring.
   .claude/ → symlink (or generated)
   CLAUDE.md → symlink
   skills/ → symlink
+  .staged-plugins/        # Staged copies of out-of-workspace runner.plugin_dirs
+                          # (claude-code runner; skipped in workspace_mode: repo)
 ```
 
 ### Case Mode (execution.mode: case)
@@ -44,6 +46,7 @@ When `execution.mode` is `case` (default), workspace.py creates a separate works
       {output_dirs}/      # Empty dirs for skill outputs
       .claude/settings.json  # Generated (hooks + permissions)
       subagents/           # SubagentStop hook target
+      .staged-plugins/     # Staged copies of out-of-workspace runner.plugin_dirs
       scripts/ → symlink
       CLAUDE.md → symlink
       skills/ → symlink
@@ -115,7 +118,7 @@ $AGENT_EVAL_RUNS_DIR/{id}/
 
 ### In-place file edits
 
-Skills that modify input files using the Edit tool (rather than writing to an output directory) are handled automatically. `workspace.py` creates a git commit of the initial workspace state before execution. After execution, `collect.py` runs `git diff HEAD` to detect modified files and copies them to a `_modified/` directory under each case's run output. No extra `outputs` config is needed.
+Skills that modify input files using the Edit tool (rather than writing to an output directory) are handled automatically. `workspace.py` creates a git commit of the initial workspace state before execution. After execution, `collect.py` runs `git diff HEAD` (plus `git ls-files --others` for new files) to detect modified files and copies them to a `_modified/` directory under each case's run output. No extra `outputs` config is needed. Harness-created paths (`.claude/`, `.git/`, `.work/`, `.staged-plugins/`, `subagents/`, `hooks/`, logs) and directories declared in `outputs[].path` are excluded, so only files the skill itself modified or created appear in `_modified/`.
 
 ## 4. Collection → Scoring
 

--- a/skills/eval-run/scripts/collect.py
+++ b/skills/eval-run/scripts/collect.py
@@ -32,7 +32,7 @@ from agent_eval.events import (
 
 # Files/dirs created by the harness infrastructure, not by the skill
 _HARNESS_PATHS = {
-    ".claude", ".git", ".work", "subagents", "hooks",
+    ".claude", ".git", ".work", ".staged-plugins", "subagents", "hooks",
     "stdout.log", "stderr.log",
     "run_result.json", "batch.yaml", "case_order.yaml",
 }

--- a/tests/test_stage_plugins.py
+++ b/tests/test_stage_plugins.py
@@ -110,20 +110,26 @@ class TestStagePluginDir:
         assert again == staged
         assert sentinel.read_text() == "kept", "second call must not recopy"
 
-    def test_symlinks_are_materialized_not_reproduced(self, tmp_path):
+    def test_internal_symlinks_materialized_external_rejected(self, tmp_path):
+        """Symlinks resolving inside the plugin are materialized (the staged
+        copy must be self-contained); symlinks escaping the plugin are
+        REFUSED — symlinks=False would otherwise copy the host target into
+        the workspace where the agent can read it (CWE-59 -> CWE-200)."""
         plugin = make_plugin(tmp_path / "plugins")
-        outside = tmp_path / "outside.txt"
-        outside.write_text("content")
-        (plugin / "skills" / "my-skill" / "link.txt").symlink_to(outside)
-        (plugin / "skills" / "my-skill" / "dangling.txt").symlink_to(
-            tmp_path / "does-not-exist")
+        real = plugin / "skills" / "my-skill" / "real.md"
+        real.write_text("content")
+        (plugin / "skills" / "my-skill" / "link.md").symlink_to(real)
+        secret = tmp_path / "outside-secret.txt"
+        secret.write_text("hostcreds")
+        (plugin / "skills" / "my-skill" / "leak.md").symlink_to(secret)
         ws = tmp_path / "ws"
         ws.mkdir()
-        staged = stage_plugin_dir(plugin, ws)
-        copied = staged / "skills" / "my-skill" / "link.txt"
-        assert copied.is_file() and not copied.is_symlink()
-        assert copied.read_text() == "content"
-        assert not (staged / "skills" / "my-skill" / "dangling.txt").exists()
+        dest = stage_plugin_dir(plugin, ws)
+        staged_skill = dest / "skills" / "my-skill"
+        assert (staged_skill / "link.md").is_file()
+        assert not (staged_skill / "link.md").is_symlink()
+        assert not (staged_skill / "leak.md").exists(), (
+            "a symlink escaping the plugin must not be staged")
 
     def test_plugin_without_skills_is_tolerated(self, tmp_path):
         # A Claude plugin may ship only commands/agents/hooks; staging must
@@ -136,6 +142,27 @@ class TestStagePluginDir:
         staged = stage_plugin_dir(plugin, ws)
         assert (staged / ".claude-plugin" / "plugin.json").is_file()
         assert (staged / "commands" / "go.md").is_file()
+
+
+    def test_declared_missing_skill_root_propagates(self, tmp_path):
+        """A manifest that DECLARES skills must not be silently tolerated when
+        the declaration is broken — staging it would only resurface later as
+        an undiscoverable slash command."""
+        plugin = make_plugin(tmp_path / "plugins")
+        (plugin / ".claude-plugin" / "plugin.json").write_text(
+            '{"name": "p", "skills": "does-not-exist"}')
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        with pytest.raises(FileNotFoundError):
+            stage_plugin_dir(plugin, ws)
+
+    def test_malformed_manifest_propagates(self, tmp_path):
+        plugin = make_plugin(tmp_path / "plugins")
+        (plugin / ".claude-plugin" / "plugin.json").write_text("{not json")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        with pytest.raises(ValueError):
+            stage_plugin_dir(plugin, ws)
 
 
 class TestClaudeCodeRunnerStaging:

--- a/tests/test_stage_plugins.py
+++ b/tests/test_stage_plugins.py
@@ -269,3 +269,63 @@ class TestClaudeCodeRunnerStaging:
             model="m", timeout_s=60)
         assert result.exit_code == -1
         assert "same directory name" in result.stderr
+
+    def test_repo_mode_skips_staging_entirely(self, tmp_path, monkeypatch):
+        """workspace_mode: repo runs in the user's real repository — there is
+        no isolation boundary for staging to defend, and staging an external
+        plugin there would write .staged-plugins/ into the repo, polluting it
+        and reading back as a spurious repo modification."""
+        self._stub_claude(tmp_path, monkeypatch)
+        plugin = make_plugin(tmp_path / "plugins")
+        ws = tmp_path / "repo"
+        ws.mkdir()
+        runner = ClaudeCodeRunner(
+            plugin_dirs=[str(plugin)], workspace_mode="repo")
+        result = runner.execute(
+            target="epic-decompose", args="", workspace=ws,
+            model="m", timeout_s=60)
+        assert result.exit_code == 0, result.stderr
+        assert self._plugin_dir_args(self._argv(ws)) == [str(plugin.resolve())]
+        assert not (ws / ".staged-plugins").exists(), (
+            "repo mode must never write .staged-plugins/ into the user's repo")
+
+
+class TestCollectIgnoresStagedPlugins:
+    """collect.py diffs the case workspace against its initial commit to find
+    agent-modified files; the staged plugin copy lands after that commit and
+    must not be reported (it would flood judge context with plugin content)."""
+
+    def _load_collect(self):
+        import importlib.util
+        path = (Path(__file__).parent.parent
+                / "skills" / "eval-run" / "scripts" / "collect.py")
+        spec = importlib.util.spec_from_file_location("eval_run_collect", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_staged_plugins_excluded_from_modified_files(self, tmp_path):
+        import subprocess
+        from types import SimpleNamespace
+        collect = self._load_collect()
+        case = tmp_path / "case-001"
+        case.mkdir()
+        (case / "input.yaml").write_text("prompt: x\n")
+        env = {**os.environ,
+               "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+               "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+        for cmd in (["git", "init", "-q"], ["git", "add", "-A"],
+                    ["git", "commit", "-q", "-m", "initial"]):
+            subprocess.run(cmd, cwd=case, env=env, check=True)
+        staged = case / ".staged-plugins" / "demo" / "skills" / "my-skill"
+        staged.mkdir(parents=True)
+        (staged / "SKILL.md").write_text("---\nname: my-skill\n---\n")
+        (case / "artifacts").mkdir()
+        (case / "artifacts" / "out.md").write_text("real agent output\n")
+
+        modified = collect._collect_modified_files(
+            case, SimpleNamespace(outputs=[]))
+        rels = [rel for rel, _ in modified]
+        assert "artifacts/out.md" in rels
+        assert not any(r.startswith(".staged-plugins") for r in rels), (
+            "staged plugin content must never surface as agent-modified files")

--- a/tests/test_stage_plugins.py
+++ b/tests/test_stage_plugins.py
@@ -169,8 +169,7 @@ class TestClaudeCodeRunnerStaging:
         plugin = make_plugin(tmp_path / "plugins")
         ws = tmp_path / "ws"
         ws.mkdir()
-        runner = ClaudeCodeRunner(
-            plugin_dirs=[str(plugin)], stage_plugins=True)
+        runner = ClaudeCodeRunner(plugin_dirs=[str(plugin)])
         result = runner.execute(
             target="epic-decompose", args="", workspace=ws,
             model="m", timeout_s=60)
@@ -183,8 +182,9 @@ class TestClaudeCodeRunnerStaging:
             "the real plugin path must never enter the session")
         assert (Path(staged) / "skills" / "my-skill" / "SKILL.md").is_file()
 
-    def test_default_passes_real_path_through(self, tmp_path, monkeypatch):
-        """Opt-in: without stage_plugins existing users see no change."""
+    def test_staging_is_the_default_behavior(self, tmp_path, monkeypatch):
+        """No opt-in flag: isolation is the harness's contract, so any plugin
+        living outside the workspace is always staged."""
         self._stub_claude(tmp_path, monkeypatch)
         plugin = make_plugin(tmp_path / "plugins")
         ws = tmp_path / "ws"
@@ -194,8 +194,43 @@ class TestClaudeCodeRunnerStaging:
             target="epic-decompose", args="", workspace=ws,
             model="m", timeout_s=60)
         assert result.exit_code == 0, result.stderr
-        assert self._plugin_dir_args(self._argv(ws)) == [str(plugin)]
+        [staged] = self._plugin_dir_args(self._argv(ws))
+        assert staged.startswith(str(ws))
+        assert (ws / ".staged-plugins").exists()
+
+    def test_plugin_inside_workspace_passes_through(self, tmp_path, monkeypatch):
+        """A plugin already inside the workspace discloses nothing outside the
+        sandbox and is passed through unchanged — this is also what makes
+        workspace_mode: repo safe (the workspace IS the project there, and
+        staging would write .staged-plugins/ into the user's repo)."""
+        self._stub_claude(tmp_path, monkeypatch)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        plugin = make_plugin(ws / "vendored")
+        runner = ClaudeCodeRunner(plugin_dirs=[str(plugin)])
+        result = runner.execute(
+            target="epic-decompose", args="", workspace=ws,
+            model="m", timeout_s=60)
+        assert result.exit_code == 0, result.stderr
+        assert self._plugin_dir_args(self._argv(ws)) == [str(plugin.resolve())]
         assert not (ws / ".staged-plugins").exists()
+
+    def test_plugin_root_scripts_are_staged(self, tmp_path, monkeypatch):
+        """Skills commonly run ${CLAUDE_PLUGIN_ROOT}/scripts/... at runtime; a
+        staged copy without scripts/ would break them."""
+        self._stub_claude(tmp_path, monkeypatch)
+        plugin = make_plugin(tmp_path / "plugins")
+        (plugin / "scripts").mkdir()
+        (plugin / "scripts" / "helper.py").write_text("print('hi')\n")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        runner = ClaudeCodeRunner(plugin_dirs=[str(plugin)])
+        result = runner.execute(
+            target="epic-decompose", args="", workspace=ws,
+            model="m", timeout_s=60)
+        assert result.exit_code == 0, result.stderr
+        [staged] = self._plugin_dir_args(self._argv(ws))
+        assert (Path(staged) / "scripts" / "helper.py").is_file()
 
     def test_duplicate_plugin_basenames_fail_loud(self, tmp_path, monkeypatch):
         self._stub_claude(tmp_path, monkeypatch)
@@ -203,67 +238,9 @@ class TestClaudeCodeRunnerStaging:
         second = make_plugin(tmp_path / "b", name="pkg")
         ws = tmp_path / "ws"
         ws.mkdir()
-        runner = ClaudeCodeRunner(
-            plugin_dirs=[str(first), str(second)], stage_plugins=True)
+        runner = ClaudeCodeRunner(plugin_dirs=[str(first), str(second)])
         result = runner.execute(
             target="epic-decompose", args="", workspace=ws,
             model="m", timeout_s=60)
         assert result.exit_code == -1
         assert "same directory name" in result.stderr
-
-
-class TestStagePluginsConfig:
-    """Config parsing and from_config plumbing."""
-
-    def _write(self, tmp_path, body):
-        p = tmp_path / "eval.yaml"
-        p.write_text(body)
-        return p
-
-    def test_defaults_to_false(self, tmp_path):
-        cfg = EvalConfig.from_yaml(self._write(tmp_path, """
-name: t
-execution:
-  skill: s
-runner:
-  type: claude-code
-"""))
-        assert cfg.runner.stage_plugins is False
-
-    def test_parses_true(self, tmp_path):
-        cfg = EvalConfig.from_yaml(self._write(tmp_path, """
-name: t
-execution:
-  skill: s
-runner:
-  type: claude-code
-  stage_plugins: true
-"""))
-        assert cfg.runner.stage_plugins is True
-
-    def test_rejects_non_boolean(self, tmp_path):
-        with pytest.raises(ValueError, match="stage_plugins"):
-            EvalConfig.from_yaml(self._write(tmp_path, """
-name: t
-execution:
-  skill: s
-runner:
-  type: claude-code
-  stage_plugins: "yes please"
-"""))
-
-    def test_from_config_plumbs_to_runner(self, tmp_path):
-        plugin = make_plugin(tmp_path / "plugins")
-        cfg = EvalConfig.from_yaml(self._write(tmp_path, f"""
-name: t
-execution:
-  skill: s
-runner:
-  type: claude-code
-  stage_plugins: true
-  plugin_dirs:
-    - {plugin}
-"""))
-        runner = ClaudeCodeRunner.from_config(cfg)
-        assert runner._stage_plugins is True
-        assert runner._plugin_dirs == [str(plugin)]

--- a/tests/test_stage_plugins.py
+++ b/tests/test_stage_plugins.py
@@ -129,6 +129,44 @@ class TestStagePluginDir:
         assert not (staged_skill / "leak.md").exists(), (
             "a symlink escaping the plugin must not be staged")
 
+    def test_escaping_symlinked_copy_root_is_refused(self, tmp_path):
+        """copytree(symlinks=False) follows a source dir that is ITSELF a
+        symlink, and the ignore callback only sees entries inside walked
+        directories — an escaping link at the copy root (scripts ->
+        external dir) would otherwise materialize the external tree
+        wholesale (CWE-59 -> CWE-200)."""
+        plugin = make_plugin(tmp_path / "plugins")
+        external = tmp_path / "outside"
+        external.mkdir()
+        (external / "secret.txt").write_text("hostcreds")
+        (plugin / "scripts").symlink_to(external)
+        internal = plugin / "tools"
+        internal.mkdir()
+        (internal / "helper.py").write_text("print('ok')\n")
+        (plugin / "hooks").symlink_to(internal)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        dest = stage_plugin_dir(plugin, ws)
+        assert not (dest / "scripts").exists(), (
+            "a copy root symlinked outside the plugin must not be staged")
+        assert "hostcreds" not in "".join(
+            p.read_text() for p in dest.rglob("*") if p.is_file())
+        assert (dest / "hooks" / "helper.py").is_file(), (
+            "a copy root symlinked WITHIN the plugin is materialized")
+
+    def test_symlink_loop_is_skipped_not_fatal(self, tmp_path):
+        """A self-referential link raises RuntimeError from resolve() on
+        Python 3.11/3.12 and OSError(ELOOP) later — either way staging must
+        skip it, not crash the case."""
+        plugin = make_plugin(tmp_path / "plugins")
+        loop = plugin / "skills" / "my-skill" / "loop"
+        loop.symlink_to(loop)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        dest = stage_plugin_dir(plugin, ws)
+        assert (dest / "skills" / "my-skill" / "SKILL.md").is_file()
+        assert not (dest / "skills" / "my-skill" / "loop").exists()
+
     def test_plugin_without_skills_is_tolerated(self, tmp_path):
         # A Claude plugin may ship only commands/agents/hooks; staging must
         # not fail a configuration the unstaged path would have accepted.

--- a/tests/test_stage_plugins.py
+++ b/tests/test_stage_plugins.py
@@ -1,13 +1,11 @@
-"""Tests for staging plugin dirs inside the case workspace (stage_plugins).
+"""Tests for staging plugin dirs inside the case workspace.
 
-Passing ``--plugin-dir <real project path>`` puts that path verbatim in every
-session's system context (the stream-json init event registers the plugin
-under it). Bash is not path-gated in isolated workspaces, so a case agent can
-follow the leaked path out of its throwaway workspace and into the real repo
-— observed in the 2026-08-19 epic-creator eval run, where two of 30 case
-dispatchers ran pipeline phases inside the real project. ``stage_plugins``
-copies the plugin's discoverable content into the workspace and passes THAT
-path instead.
+Passing ``--plugin-dir <path>`` puts that path verbatim in the session's
+system context (the stream-json init event registers the plugin under it).
+Bash is not path-gated in isolated workspaces, so a path pointing outside the
+workspace lets a case agent follow it out of its throwaway workspace and into
+the real project. ``stage_plugin_dir`` copies the plugin's discoverable
+content into the workspace so the runner can pass THAT path instead.
 """
 
 import json
@@ -23,7 +21,7 @@ from agent_eval.agent.claude_code import ClaudeCodeRunner, stage_plugin_dir
 from agent_eval.config import EvalConfig
 
 
-def make_plugin(root, name="epic-creator", manifest=..., skills=("my-skill",)):
+def make_plugin(root, name="demo-plugin", manifest=..., skills=("my-skill",)):
     """Create a minimal plugin: manifest + skills/<name>/SKILL.md."""
     plugin = root / name
     (plugin / ".claude-plugin").mkdir(parents=True)
@@ -45,7 +43,7 @@ class TestStagePluginDir:
         ws = tmp_path / "ws"
         ws.mkdir()
         staged = stage_plugin_dir(plugin, ws)
-        assert staged == ws / ".staged-plugins" / "epic-creator"
+        assert staged == ws / ".staged-plugins" / "demo-plugin"
         assert (staged / ".claude-plugin" / "plugin.json").is_file()
         # The staged tree must remain discoverable: a SKILL.md under the
         # staged skill root is what Claude Code's plugin loader looks for.

--- a/tests/test_stage_plugins.py
+++ b/tests/test_stage_plugins.py
@@ -154,6 +154,44 @@ class TestStagePluginDir:
         assert (dest / "hooks" / "helper.py").is_file(), (
             "a copy root symlinked WITHIN the plugin is materialized")
 
+    def test_copy_reads_from_checked_canonical_path(self, tmp_path, monkeypatch):
+        """The containment check resolves each copy root; the copy must read
+        from that SAME canonical path. Copying from the symlink would
+        re-follow it at copy time — a check/use race (CWE-367) where a
+        concurrent writer swaps the link between resolve() and copytree()."""
+        import shutil as shutil_mod
+
+        import agent_eval.agent.claude_code as claude_code_mod
+
+        plugin = make_plugin(tmp_path / "plugins")
+        internal = plugin / "tools"
+        internal.mkdir()
+        (internal / "helper.py").write_text("print('ok')\n")
+        (plugin / "scripts").symlink_to(internal)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        seen = []
+
+        # Proxy only the module-under-test's shutil reference: copytree
+        # recurses into itself positionally, so patching the global would
+        # intercept (and break) its internal recursive calls too.
+        class ShutilProxy:
+            def __getattr__(self, name):
+                return getattr(shutil_mod, name)
+
+            @staticmethod
+            def copytree(src, dst, **kwargs):
+                seen.append(Path(src))
+                return shutil_mod.copytree(src, dst, **kwargs)
+
+        monkeypatch.setattr(claude_code_mod, "shutil", ShutilProxy())
+        dest = stage_plugin_dir(plugin, ws)
+        assert (dest / "scripts" / "helper.py").is_file()
+        assert seen, "copytree was not invoked"
+        for src in seen:
+            assert not src.is_symlink(), (
+                f"copy must read the checked canonical path, not a symlink: {src}")
+
     def test_symlink_loop_is_skipped_not_fatal(self, tmp_path):
         """A self-referential link raises RuntimeError from resolve() on
         Python 3.11/3.12 and OSError(ELOOP) later — either way staging must

--- a/tests/test_stage_plugins.py
+++ b/tests/test_stage_plugins.py
@@ -1,0 +1,269 @@
+"""Tests for staging plugin dirs inside the case workspace (stage_plugins).
+
+Passing ``--plugin-dir <real project path>`` puts that path verbatim in every
+session's system context (the stream-json init event registers the plugin
+under it). Bash is not path-gated in isolated workspaces, so a case agent can
+follow the leaked path out of its throwaway workspace and into the real repo
+— observed in the 2026-08-19 epic-creator eval run, where two of 30 case
+dispatchers ran pipeline phases inside the real project. ``stage_plugins``
+copies the plugin's discoverable content into the workspace and passes THAT
+path instead.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.agent.claude_code import ClaudeCodeRunner, stage_plugin_dir
+from agent_eval.config import EvalConfig
+
+
+def make_plugin(root, name="epic-creator", manifest=..., skills=("my-skill",)):
+    """Create a minimal plugin: manifest + skills/<name>/SKILL.md."""
+    plugin = root / name
+    (plugin / ".claude-plugin").mkdir(parents=True)
+    if manifest is ...:
+        manifest = {"name": name}
+    (plugin / ".claude-plugin" / "plugin.json").write_text(json.dumps(manifest))
+    for skill in skills:
+        skill_dir = plugin / "skills" / skill
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(f"# {skill}\n")
+    return plugin
+
+
+class TestStagePluginDir:
+    """Unit tests for the staging helper."""
+
+    def test_copies_manifest_and_skill_root(self, tmp_path):
+        plugin = make_plugin(tmp_path / "plugins")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        staged = stage_plugin_dir(plugin, ws)
+        assert staged == ws / ".staged-plugins" / "epic-creator"
+        assert (staged / ".claude-plugin" / "plugin.json").is_file()
+        # The staged tree must remain discoverable: a SKILL.md under the
+        # staged skill root is what Claude Code's plugin loader looks for.
+        assert (staged / "skills" / "my-skill" / "SKILL.md").is_file()
+
+    def test_copies_optional_dirs(self, tmp_path):
+        plugin = make_plugin(tmp_path / "plugins")
+        (plugin / "commands").mkdir()
+        (plugin / "commands" / "go.md").write_text("cmd")
+        (plugin / "agents").mkdir()
+        (plugin / "agents" / "helper.md").write_text("agent")
+        (plugin / "hooks").mkdir()
+        (plugin / "hooks" / "hooks.json").write_text("{}")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        staged = stage_plugin_dir(plugin, ws)
+        assert (staged / "commands" / "go.md").is_file()
+        assert (staged / "agents" / "helper.md").is_file()
+        assert (staged / "hooks" / "hooks.json").is_file()
+
+    def test_skips_git_node_modules_and_unlisted_files(self, tmp_path):
+        plugin = make_plugin(tmp_path / "plugins")
+        # Bulk inside a copied tree is pruned by ignore patterns...
+        (plugin / "skills" / ".git").mkdir()
+        (plugin / "skills" / ".git" / "config").write_text("x")
+        (plugin / "skills" / "node_modules" / "pkg").mkdir(parents=True)
+        (plugin / "skills" / "node_modules" / "pkg" / "i.js").write_text("x")
+        # ...and content outside the discovery set is never copied at all.
+        (plugin / ".git").mkdir()
+        (plugin / ".git" / "config").write_text("x")
+        (plugin / "README.md").write_text("readme")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        staged = stage_plugin_dir(plugin, ws)
+        assert not (staged / "skills" / ".git").exists()
+        assert not (staged / "skills" / "node_modules").exists()
+        assert not (staged / ".git").exists()
+        assert not (staged / "README.md").exists()
+
+    def test_manifest_declared_skill_root(self, tmp_path):
+        plugin = make_plugin(
+            tmp_path / "plugins",
+            manifest={"name": "p", "skills": "custom-skills"},
+            skills=(),
+        )
+        alpha = plugin / "custom-skills" / "alpha"
+        alpha.mkdir(parents=True)
+        (alpha / "SKILL.md").write_text("# alpha\n")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        staged = stage_plugin_dir(plugin, ws)
+        assert (staged / "custom-skills" / "alpha" / "SKILL.md").is_file()
+
+    def test_idempotent_per_workspace(self, tmp_path):
+        plugin = make_plugin(tmp_path / "plugins")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        staged = stage_plugin_dir(plugin, ws)
+        sentinel = staged / "sentinel.txt"
+        sentinel.write_text("kept")
+        again = stage_plugin_dir(plugin, ws)
+        assert again == staged
+        assert sentinel.read_text() == "kept", "second call must not recopy"
+
+    def test_symlinks_are_materialized_not_reproduced(self, tmp_path):
+        plugin = make_plugin(tmp_path / "plugins")
+        outside = tmp_path / "outside.txt"
+        outside.write_text("content")
+        (plugin / "skills" / "my-skill" / "link.txt").symlink_to(outside)
+        (plugin / "skills" / "my-skill" / "dangling.txt").symlink_to(
+            tmp_path / "does-not-exist")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        staged = stage_plugin_dir(plugin, ws)
+        copied = staged / "skills" / "my-skill" / "link.txt"
+        assert copied.is_file() and not copied.is_symlink()
+        assert copied.read_text() == "content"
+        assert not (staged / "skills" / "my-skill" / "dangling.txt").exists()
+
+    def test_plugin_without_skills_is_tolerated(self, tmp_path):
+        # A Claude plugin may ship only commands/agents/hooks; staging must
+        # not fail a configuration the unstaged path would have accepted.
+        plugin = make_plugin(tmp_path / "plugins", skills=())
+        (plugin / "commands").mkdir()
+        (plugin / "commands" / "go.md").write_text("cmd")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        staged = stage_plugin_dir(plugin, ws)
+        assert (staged / ".claude-plugin" / "plugin.json").is_file()
+        assert (staged / "commands" / "go.md").is_file()
+
+
+class TestClaudeCodeRunnerStaging:
+    """Integration through ClaudeCodeRunner.execute with a stub `claude` on
+    PATH that dumps its argv into the workspace (its cwd)."""
+
+    JSON_OK = ('{"type":"result","subtype":"success","is_error":false,'
+               '"num_turns":3,"total_cost_usd":0.1,"result":"done"}\n')
+
+    def _stub_claude(self, tmp_path, monkeypatch):
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        stub = bindir / "claude"
+        stub.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' \"$@\" > argv.txt\n"
+            "cat > /dev/null\n"
+            f"cat <<'JSON_EOF'\n{self.JSON_OK}JSON_EOF\n"
+        )
+        stub.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+
+    def _argv(self, ws):
+        return (ws / "argv.txt").read_text().splitlines()
+
+    def _plugin_dir_args(self, argv):
+        return [argv[i + 1] for i, a in enumerate(argv) if a == "--plugin-dir"]
+
+    def test_staged_path_replaces_real_path(self, tmp_path, monkeypatch):
+        self._stub_claude(tmp_path, monkeypatch)
+        plugin = make_plugin(tmp_path / "plugins")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        runner = ClaudeCodeRunner(
+            plugin_dirs=[str(plugin)], stage_plugins=True)
+        result = runner.execute(
+            target="epic-decompose", args="", workspace=ws,
+            model="m", timeout_s=60)
+        assert result.exit_code == 0, result.stderr
+        argv = self._argv(ws)
+        [staged] = self._plugin_dir_args(argv)
+        assert staged.startswith(str(ws)), (
+            "--plugin-dir must point inside the workspace")
+        assert str(plugin) not in "\n".join(argv), (
+            "the real plugin path must never enter the session")
+        assert (Path(staged) / "skills" / "my-skill" / "SKILL.md").is_file()
+
+    def test_default_passes_real_path_through(self, tmp_path, monkeypatch):
+        """Opt-in: without stage_plugins existing users see no change."""
+        self._stub_claude(tmp_path, monkeypatch)
+        plugin = make_plugin(tmp_path / "plugins")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        runner = ClaudeCodeRunner(plugin_dirs=[str(plugin)])
+        result = runner.execute(
+            target="epic-decompose", args="", workspace=ws,
+            model="m", timeout_s=60)
+        assert result.exit_code == 0, result.stderr
+        assert self._plugin_dir_args(self._argv(ws)) == [str(plugin)]
+        assert not (ws / ".staged-plugins").exists()
+
+    def test_duplicate_plugin_basenames_fail_loud(self, tmp_path, monkeypatch):
+        self._stub_claude(tmp_path, monkeypatch)
+        first = make_plugin(tmp_path / "a", name="pkg")
+        second = make_plugin(tmp_path / "b", name="pkg")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        runner = ClaudeCodeRunner(
+            plugin_dirs=[str(first), str(second)], stage_plugins=True)
+        result = runner.execute(
+            target="epic-decompose", args="", workspace=ws,
+            model="m", timeout_s=60)
+        assert result.exit_code == -1
+        assert "same directory name" in result.stderr
+
+
+class TestStagePluginsConfig:
+    """Config parsing and from_config plumbing."""
+
+    def _write(self, tmp_path, body):
+        p = tmp_path / "eval.yaml"
+        p.write_text(body)
+        return p
+
+    def test_defaults_to_false(self, tmp_path):
+        cfg = EvalConfig.from_yaml(self._write(tmp_path, """
+name: t
+execution:
+  skill: s
+runner:
+  type: claude-code
+"""))
+        assert cfg.runner.stage_plugins is False
+
+    def test_parses_true(self, tmp_path):
+        cfg = EvalConfig.from_yaml(self._write(tmp_path, """
+name: t
+execution:
+  skill: s
+runner:
+  type: claude-code
+  stage_plugins: true
+"""))
+        assert cfg.runner.stage_plugins is True
+
+    def test_rejects_non_boolean(self, tmp_path):
+        with pytest.raises(ValueError, match="stage_plugins"):
+            EvalConfig.from_yaml(self._write(tmp_path, """
+name: t
+execution:
+  skill: s
+runner:
+  type: claude-code
+  stage_plugins: "yes please"
+"""))
+
+    def test_from_config_plumbs_to_runner(self, tmp_path):
+        plugin = make_plugin(tmp_path / "plugins")
+        cfg = EvalConfig.from_yaml(self._write(tmp_path, f"""
+name: t
+execution:
+  skill: s
+runner:
+  type: claude-code
+  stage_plugins: true
+  plugin_dirs:
+    - {plugin}
+"""))
+        runner = ClaudeCodeRunner.from_config(cfg)
+        assert runner._stage_plugins is True
+        assert runner._plugin_dirs == [str(plugin)]

--- a/website/concepts/execution-model.md
+++ b/website/concepts/execution-model.md
@@ -43,6 +43,8 @@ and gives each its own throwaway workspace under
 - symlinks to project resources (`scripts`, `skills`, `.context`, `CLAUDE.md`, …),
 - freshly-generated output directories from the `outputs` block,
 - a per-workspace `.claude/settings.json` (permissions, hooks, injected env),
+- staged copies of out-of-workspace `runner.plugin_dirs` under
+  `.staged-plugins/` (claude-code runner — see [Runners](runners.md)),
 - an initialized git repo so [lifecycle hooks](lifecycle-hooks.md) and `collect`
   can diff for in-place edits.
 

--- a/website/concepts/runners.md
+++ b/website/concepts/runners.md
@@ -111,7 +111,7 @@ claude --print \
   --max-budget-usd "$BUDGET" \
   --verbose \                      # only with live logging
   --effort high \                  # only if runner.effort set
-  --plugin-dir <dir> \             # per runner.plugin_dirs entry
+  --plugin-dir <dir> \             # workspace-staged copy per runner.plugin_dirs entry
   --append-system-prompt "..." \   # if system_prompt set
   --settings <path>                # permissions/hooks/env
 # the prompt (/skill args, or raw prompt) is piped on stdin
@@ -125,6 +125,10 @@ the `result` event.
 
 **Highlights specific to this runner:**
 
+- **Plugin staging** — every `runner.plugin_dirs` entry outside the workspace is
+  copied into `<workspace>/.staged-plugins/` and `--plugin-dir` receives the copy,
+  so the real plugin path never enters session context; in-workspace entries
+  (including `workspace_mode: repo`) pass through unchanged.
 - **Budget** is enforced server-side via `--max-budget-usd`.
 - **Permissions** — simple string patterns become `--allowed-tools` /
   `--disallowed-tools`; path-based rules are compiled into a temporary

--- a/website/concepts/runners.md
+++ b/website/concepts/runners.md
@@ -128,7 +128,7 @@ the `result` event.
 - **Plugin staging** — every `runner.plugin_dirs` entry outside the workspace is
   copied into `<workspace>/.staged-plugins/` and `--plugin-dir` receives the copy,
   so the real plugin path never enters session context; in-workspace entries
-  (including `workspace_mode: repo`) pass through unchanged.
+  pass through unchanged and `workspace_mode: repo` skips staging entirely.
 - **Budget** is enforced server-side via `--max-budget-usd`.
 - **Permissions** — simple string patterns become `--allowed-tools` /
   `--disallowed-tools`; path-based rules are compiled into a temporary

--- a/website/concepts/runners.md
+++ b/website/concepts/runners.md
@@ -111,7 +111,7 @@ claude --print \
   --max-budget-usd "$BUDGET" \
   --verbose \                      # only with live logging
   --effort high \                  # only if runner.effort set
-  --plugin-dir <dir> \             # workspace-staged copy per runner.plugin_dirs entry
+  --plugin-dir <dir> \             # per runner.plugin_dirs entry (see Plugin staging)
   --append-system-prompt "..." \   # if system_prompt set
   --settings <path>                # permissions/hooks/env
 # the prompt (/skill args, or raw prompt) is piped on stdin

--- a/website/reference/config/runner.md
+++ b/website/reference/config/runner.md
@@ -39,7 +39,7 @@ Not every runner reads every field. The matrix below shows where each field land
 | `effort` | `str` (enum) | `--effort` flag | `model_reasoning_effort` | `{effort}` placeholder | — |
 | `permission_mode` | `str` (enum) | `--permission-mode` flag | mapped to Codex sandbox mode | — | — |
 | `settings` | `dict` | merged into workspace `.claude/settings.json` | `-c` config overrides for `codex exec` | — | connection settings (see below) |
-| `plugin_dirs` | `list[str]` | one `--plugin-dir` per entry | skills copied into `.agents/skills` | — | — |
+| `plugin_dirs` | `list[str]` | staged into the workspace, one `--plugin-dir` per staged copy | skills copied into `.agents/skills` | — | — |
 | `env` | `dict` | injected on the safe allowlist | injected on the safe allowlist | — (uses `execution.env`) | — |
 | `system_prompt` | `str` | `--append-system-prompt` | prepended to the prompt | `{system_prompt}` placeholder | `developer` message |
 | `command` | `str` \| `list[str]` | — | — | **required** — command template | — |
@@ -159,9 +159,16 @@ The `cli` runner ignores `settings`.
 
 ### `plugin_dirs`
 
-`claude-code` and `codex`. Claude Code receives one `--plugin-dir` per entry. Codex
-copies each plugin's skills into the case workspace's `.agents/skills` directory for
-the duration of the run. Relative paths are always resolved from the project root.
+`claude-code` and `codex`. Both runners copy plugin content into the case workspace
+rather than exposing the configured path to the session. Claude Code stages each
+entry's discoverable content (manifest, skill roots, `commands/`, `agents/`,
+`hooks/`, `scripts/`) into `.staged-plugins/` and passes the staged copy to
+`--plugin-dir` — the configured path would otherwise land verbatim in session
+context, where Bash (not path-gated) can follow it out of the workspace. An entry
+already inside the workspace (including `workspace_mode: repo`) is passed through
+unchanged. Codex copies each plugin's skills into the case workspace's
+`.agents/skills` directory for the duration of the run. Relative paths are always
+resolved from the project root.
 A lexically external path such as `../shared-skills` is an explicit opt-in like an
 absolute path; a path declared inside the project may not escape through a symlink.
 

--- a/website/reference/config/runner.md
+++ b/website/reference/config/runner.md
@@ -39,7 +39,7 @@ Not every runner reads every field. The matrix below shows where each field land
 | `effort` | `str` (enum) | `--effort` flag | `model_reasoning_effort` | `{effort}` placeholder | — |
 | `permission_mode` | `str` (enum) | `--permission-mode` flag | mapped to Codex sandbox mode | — | — |
 | `settings` | `dict` | merged into workspace `.claude/settings.json` | `-c` config overrides for `codex exec` | — | connection settings (see below) |
-| `plugin_dirs` | `list[str]` | staged into the workspace, one `--plugin-dir` per staged copy | skills copied into `.agents/skills` | — | — |
+| `plugin_dirs` | `list[str]` | one `--plugin-dir` per entry (workspace-staged copy for out-of-workspace paths) | skills copied into `.agents/skills` | — | — |
 | `env` | `dict` | injected on the safe allowlist | injected on the safe allowlist | — (uses `execution.env`) | — |
 | `system_prompt` | `str` | `--append-system-prompt` | prepended to the prompt | `{system_prompt}` placeholder | `developer` message |
 | `command` | `str` \| `list[str]` | — | — | **required** — command template | — |

--- a/website/reference/config/runner.md
+++ b/website/reference/config/runner.md
@@ -165,8 +165,9 @@ entry's discoverable content (manifest, skill roots, `commands/`, `agents/`,
 `hooks/`, `scripts/`) into `.staged-plugins/` and passes the staged copy to
 `--plugin-dir` — the configured path would otherwise land verbatim in session
 context, where Bash (not path-gated) can follow it out of the workspace. An entry
-already inside the workspace (including `workspace_mode: repo`) is passed through
-unchanged. Codex copies each plugin's skills into the case workspace's
+already inside the workspace is passed through unchanged, and
+`workspace_mode: repo` skips staging entirely — the workspace is the real
+project there, so there is nothing to isolate. Codex copies each plugin's skills into the case workspace's
 `.agents/skills` directory for the duration of the run. Relative paths are always
 resolved from the project root.
 A lexically external path such as `../shared-skills` is an explicit opt-in like an

--- a/website/reference/runs-directory.md
+++ b/website/reference/runs-directory.md
@@ -110,9 +110,9 @@ A case produces outputs in two distinct ways, and the harness collects both:
     ```
 
 !!! warning "`_modified/` excludes harness scaffolding"
-    Paths under `.work`, `subagents/`, and `hooks/` are skipped when building
-    `_modified/`, so a skill's own transcripts and hook files don't leak in as
-    "edits".
+    Paths under `.work`, `.staged-plugins/`, `subagents/`, and `hooks/` are
+    skipped when building `_modified/`, so a skill's own transcripts, hook
+    files, and the harness's staged plugin copies don't leak in as "edits".
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Problem

`runner.plugin_dirs` passes the **real project path** to `claude --plugin-dir`, and that path lands verbatim in every session's context via the init event's plugin registration. On eval run `2026-08-19` (epic-creator, 30 cases), two case dispatchers followed that path out of their isolated workspaces and ran pipeline phases in the real repo: one delivered an incomplete artifact, the other left mid-pipeline state files behind. The per-case staging hook strips the repo from `additionalDirectories`, which gates the Read tool — but **Bash is not path-gated**, so as long as the real path is in context, `cd <repo> && …` remains a standing escape vector.

## Change (no flag — this is the behavior)

Isolation is the harness's contract for case workspaces, so staging is unconditional rather than an opt-in knob (an opt-in safety default protects almost nobody, and the codex runner already stages skill content into the workspace — this makes claude-code consistent):

- Every plugin dir **outside** the workspace is staged into `<workspace>/.staged-plugins/<name>/` and `--plugin-dir` receives the workspace-local copy; the real path never enters session context.
- A plugin **already inside** the workspace is passed through unchanged — its path discloses nothing outside the sandbox. `workspace_mode: repo` **skips staging entirely**: the workspace *is* the real project there, so there is no isolation boundary to defend, and staging an external plugin would write `.staged-plugins/` into the user's repo and read back as a spurious repo modification (the pass-through alone only covered plugins living *inside* the repo).
- Staged set: `.claude-plugin/`, the skill roots from the existing `resolve_plugin_skill_roots()`, and `commands/agents/hooks/scripts` when present. `scripts/` is included because skills commonly invoke `${CLAUDE_PLUGIN_ROOT}/scripts/...` at runtime and would break without it. `.git`/`node_modules`/`__pycache__` ignored; symlinks are not reproduced — in-plugin targets are copied as content, dangling links skipped, and links resolving **outside the plugin are refused** (CWE-59: a third-party plugin must not be able to plant a link to host credentials and have staging copy them into the workspace); copy-to-`.partial`-then-rename so idempotence can never adopt a truncated copy; loud failure on two plugins sharing a basename, on a malformed manifest, and on a declared-but-missing skill root (a plugin staged without its declared skills would only resurface as an undiscoverable slash command); the legitimate skill-less layout (commands/hooks only, nothing declared) is tolerated.
- `collect.py` excludes `.staged-plugins/` from the modified-files diff — the staged tree lands after the workspace's initial commit and would otherwise surface as agent-"modified" files and flood judge context.

## Verified live, not just unit-tested

Ran the reworked runner against the actual epic-creator plugin (the one whose eval produced the escapes) with a real `claude` session:

- `/epic-decompose` resolved and **executed** from the staged copy (proper usage response, not `Unknown command`);
- the real repo path was absent from the **entire** session output;
- manifest, `skills/`, and `scripts/` present in the staged tree.

## Tests

16 tests: staging unit coverage (manifest + declared roots + optional dirs incl. `scripts/`, ignore rules, idempotence via `.partial` rename, escaping-symlink refusal, error propagation for broken configs, skill-less plugins) and stub-CLI integration (staging is the default; real path absent from argv; **in-workspace plugin passes through with no `.staged-plugins/` created**; **repo mode never writes `.staged-plugins/` into the repo**; `.staged-plugins/` excluded from `_modified/` collection; basename collision fails loudly).

Full suite green in CI. Ruff parity: base=head on touched source files.

Behavior note: configs relying on the session seeing the real plugin path change behavior on upgrade. That reliance is the vulnerability this PR removes.

## Related

- #192 (merged) — made these escapes *visible* in telemetry; this PR removes the escape vector itself
- #193 — session hermeticity, the sibling isolation gap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External plugins are automatically prepared in disposable workspaces before execution.
  * Supports plugin manifests, skills, scripts, and selected directories while preserving workspace-local and repository-mode plugins.
  * Safely handles symlinks, excludes bulk and unlisted content, and reuses staged plugins.

* **Bug Fixes**
  * Prevents staged plugin files from appearing as agent modifications.
  * Prevents conflicts from duplicate plugin names and reports preparation failures clearly.

* **Documentation**
  * Clarified plugin staging configuration, workspace behavior, and generated workspace artifacts.

* **Tests**
  * Added comprehensive coverage for staging, reuse, exclusions, symlinks, passthrough behavior, and failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
