### PR TITLE
fix(claude-code): stop mislabeling cases whose background tasks were killed

### DIFF
--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -403,6 +403,17 @@ class ClaudeCodeRunner(EvalRunner):
         if not cost_usd and isinstance(result_obj, dict):
             cost_usd = result_obj.get("total_cost_usd")
 
+        # total_cost_usd covers the CONVERSATION; modelUsage covers every
+        # token billed, including a background agent killed after the final
+        # turn. Normally they agree to the cent — when modelUsage is higher,
+        # the difference is real spend the conversation never saw (a real
+        # case published $0.30 while burning $1.47). Trust the larger figure.
+        per_model_total = sum(
+            (v or {}).get("cost_usd") or 0
+            for v in (per_model_usage or {}).values())
+        if per_model_total and per_model_total > (cost_usd or 0) + 0.01:
+            cost_usd = per_model_total
+
         # Add subagent turns from captured transcripts, deduplicating
         # against IDs already seen in the stream (Claude Code >= 2.1.108
         # streams subagent messages in stdout too)
@@ -422,6 +433,20 @@ class ClaudeCodeRunner(EvalRunner):
         # run. Fail the case instead of letting a never-started skill look like
         # a skill that produced nothing.
         exit_code = proc.returncode
+        # The CLI kills background tasks that outlive the final turn by the
+        # bg-wait ceiling (default 600s) and still exits 0 with a "success"
+        # result event. For pipeline skills whose real work happens in
+        # background agents, that is a dead case wearing an OK label: on a
+        # real run the killed agent left half-written artifacts and the case
+        # was published as "OK | exit 0". Fail it honestly.
+        if _BG_KILL_RE.search(stderr or "") and exit_code == 0:
+            exit_code = 1
+            stderr = (stderr or "") + (
+                "\nERROR: the CLI terminated still-running background tasks at "
+                "the bg-wait ceiling — their work is incomplete and artifacts "
+                "may be half-written. Raise CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS "
+                "(0 = wait indefinitely) for long-running pipeline skills."
+            )
         unknown_command = _detect_unknown_command(result_obj)
         if unknown_command and exit_code == 0:
             exit_code = 1
@@ -511,6 +536,10 @@ class ClaudeCodeRunner(EvalRunner):
 
 
 _UNKNOWN_COMMAND_RE = re.compile(r"^Unknown command:\s*(/\S+)")
+
+# Emitted on stderr when the CLI gives up waiting for background tasks
+# (message text as of Claude Code 2.1.x; keep the match loose).
+_BG_KILL_RE = re.compile(r"Background tasks still running after .*terminating", re.S)
 
 
 def _detect_unknown_command(result_obj) -> Optional[str]:

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -587,7 +587,8 @@ class ClaudeCodeRunner(EvalRunner):
                 "\nERROR: the CLI terminated still-running background tasks at "
                 "the bg-wait ceiling — their work is incomplete and artifacts "
                 "may be half-written. Raise CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS "
-                "(0 = wait indefinitely) for long-running pipeline skills."
+                "(0 = wait indefinitely) for long-running pipeline skills, via "
+                "the environment or runner.env in eval.yaml."
             )
         unknown_command = _detect_unknown_command(result_obj)
         if unknown_command and exit_code == 0:
@@ -680,6 +681,10 @@ class ClaudeCodeRunner(EvalRunner):
         "ANTHROPIC_DEFAULT_HAIKU_MODEL",
         "CLOUD_ML_REGION", "CLAUDE_CODE_USE_VERTEX",
         "CLAUDE_CODE_AUTO_COMPACT_WINDOW", "CLAUDE_CODE_SUBAGENT_MODEL",
+        # The bg-kill failure note tells users to raise this; an exact-name
+        # allowlist would otherwise swallow the export and make that advice
+        # a lie. runner.env also works and wins on collision.
+        "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS",
         "GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT",
         "CLOUDSDK_CONFIG", "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
         "MLFLOW_TRACKING_URI", "MLFLOW_EXPERIMENT_NAME",

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -340,6 +340,9 @@ class ClaudeCodeRunner(EvalRunner):
                 num_turns = (num_turns or 0) + subagent_turns
             per_model_turns = _per_model_turns(
                 workspace / "subagents", stream_ids_by_model)
+            # An evaluator timeout can land after the CLI already emitted
+            # usage data — same under-reporting risk as the bg-kill path.
+            cost_usd = _billed_cost(cost_usd, per_model_usage)
             timeout_stderr = f"Timed out after {timeout_s}s"
             denial_list = _extract_denial_list(result_obj, permission_denials, result_denials)
             if denial_list:
@@ -403,16 +406,7 @@ class ClaudeCodeRunner(EvalRunner):
         if not cost_usd and isinstance(result_obj, dict):
             cost_usd = result_obj.get("total_cost_usd")
 
-        # total_cost_usd covers the CONVERSATION; modelUsage covers every
-        # token billed, including a background agent killed after the final
-        # turn. Normally they agree to the cent — when modelUsage is higher,
-        # the difference is real spend the conversation never saw (a real
-        # case published $0.30 while burning $1.47). Trust the larger figure.
-        per_model_total = sum(
-            (v or {}).get("cost_usd") or 0
-            for v in (per_model_usage or {}).values())
-        if per_model_total and per_model_total > (cost_usd or 0) + 0.01:
-            cost_usd = per_model_total
+        cost_usd = _billed_cost(cost_usd, per_model_usage)
 
         # Add subagent turns from captured transcripts, deduplicating
         # against IDs already seen in the stream (Claude Code >= 2.1.108
@@ -533,6 +527,23 @@ class ClaudeCodeRunner(EvalRunner):
         if self._mlflow_tracking_uri:
             env["MLFLOW_TRACKING_URI"] = self._mlflow_tracking_uri
         return env
+
+
+def _billed_cost(cost_usd, per_model_usage):
+    """The larger of conversation cost and per-model billed cost.
+
+    total_cost_usd covers the CONVERSATION; modelUsage covers every token
+    billed, including a background agent killed after the final turn (or
+    still running at an evaluator timeout). Normally they agree to the cent —
+    when modelUsage is higher, the difference is real spend the conversation
+    never saw (a real case published $0.30 while burning $1.47).
+    """
+    per_model_total = sum(
+        (v or {}).get("cost_usd") or 0
+        for v in (per_model_usage or {}).values())
+    if per_model_total and per_model_total > (cost_usd or 0) + 0.01:
+        return per_model_total
+    return cost_usd
 
 
 _UNKNOWN_COMMAND_RE = re.compile(r"^Unknown command:\s*(/\S+)")

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -154,7 +154,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
 
 **Launch with `run_in_background: true` and do NOT redirect its output** (no `>`, `|`, `tee`, `2>&1`) — a redirect diverts the stream Claude Code's background viewer reads and leaves it blank. You don't need one: `execute.py` mirrors its live console to `<output_dir>/console.log`.
 
-**Poll until the task completes — do not end your turn while execute.py is running**, or the idle session kills the background task and CI reports the empty result as green. Check progress every 2–3 minutes via the Bash output-file path or `tail -20 <output_dir>/console.log` (never a self-created redirect); this also keeps the session active. When it finishes, read `run_result.json` — if `exit_code` is non-zero, report the failure and stop. For session-lifecycle details, polling patterns, problem detection, and CLI fallbacks, see [`references/execution-monitoring.md`](references/execution-monitoring.md).
+When it finishes, read `run_result.json` — if `exit_code` is non-zero, report the failure and stop. If `stderr.log` ends with an `ERROR:` about background tasks terminated at the bg-wait ceiling, the fix is configuration, not the skill: raise `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` (e.g. `"0"` = wait indefinitely) via `runner.env:` in eval.yaml and rerun — see [`references/execution-monitoring.md`](references/execution-monitoring.md). For session-lifecycle details, polling patterns, problem detection, and CLI fallbacks, see [`references/execution-monitoring.md`](references/execution-monitoring.md).
 
 ## Step 5: Collect Artifacts
 

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -154,7 +154,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
 
 **Launch with `run_in_background: true` and do NOT redirect its output** (no `>`, `|`, `tee`, `2>&1`) — a redirect diverts the stream Claude Code's background viewer reads and leaves it blank. You don't need one: `execute.py` mirrors its live console to `<output_dir>/console.log`.
 
-When it finishes, read `run_result.json` — if `exit_code` is non-zero, report the failure and stop. If `stderr.log` ends with an `ERROR:` about background tasks terminated at the bg-wait ceiling, first determine which side is wrong: a skill whose final turn is SUPPOSED to await its background agents has a turn-discipline defect to fix, while a skill designed around intentionally long-running background work needs a higher ceiling — `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` via `runner.env:` in eval.yaml (`execution.timeout` remains the backstop) — see [`references/execution-monitoring.md`](references/execution-monitoring.md). For session-lifecycle details, polling patterns, problem detection, and CLI fallbacks, see [`references/execution-monitoring.md`](references/execution-monitoring.md).
+When it finishes, read `run_result.json` — if `exit_code` is non-zero, report the failure and stop. If `stderr.log` ends with a bg-wait-ceiling `ERROR:`, fix the skill's turn discipline if it should have awaited its agents; raise `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` via `runner.env:` only for intentionally long-running background work. For session-lifecycle details, polling patterns, problem detection, and CLI fallbacks, see [`references/execution-monitoring.md`](references/execution-monitoring.md).
 
 ## Step 5: Collect Artifacts
 

--- a/skills/eval-run/SKILL.md
+++ b/skills/eval-run/SKILL.md
@@ -154,7 +154,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/execute.py \
 
 **Launch with `run_in_background: true` and do NOT redirect its output** (no `>`, `|`, `tee`, `2>&1`) — a redirect diverts the stream Claude Code's background viewer reads and leaves it blank. You don't need one: `execute.py` mirrors its live console to `<output_dir>/console.log`.
 
-When it finishes, read `run_result.json` — if `exit_code` is non-zero, report the failure and stop. If `stderr.log` ends with an `ERROR:` about background tasks terminated at the bg-wait ceiling, the fix is configuration, not the skill: raise `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` (e.g. `"0"` = wait indefinitely) via `runner.env:` in eval.yaml and rerun — see [`references/execution-monitoring.md`](references/execution-monitoring.md). For session-lifecycle details, polling patterns, problem detection, and CLI fallbacks, see [`references/execution-monitoring.md`](references/execution-monitoring.md).
+When it finishes, read `run_result.json` — if `exit_code` is non-zero, report the failure and stop. If `stderr.log` ends with an `ERROR:` about background tasks terminated at the bg-wait ceiling, first determine which side is wrong: a skill whose final turn is SUPPOSED to await its background agents has a turn-discipline defect to fix, while a skill designed around intentionally long-running background work needs a higher ceiling — `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` via `runner.env:` in eval.yaml (`execution.timeout` remains the backstop) — see [`references/execution-monitoring.md`](references/execution-monitoring.md). For session-lifecycle details, polling patterns, problem detection, and CLI fallbacks, see [`references/execution-monitoring.md`](references/execution-monitoring.md).
 
 ## Step 5: Collect Artifacts
 

--- a/skills/eval-run/prompts/analyze-results.md
+++ b/skills/eval-run/prompts/analyze-results.md
@@ -28,7 +28,9 @@ You will be given:
 For each failure pattern, hypothesize WHY:
 - Is the skill not producing expected artifacts? (execution issue)
 - Is the skill producing artifacts but with quality issues? (quality issue)
-- Is the skill partially completing? (timeout, budget, or permission issue)
+- Is the skill partially completing? (timeout, budget, permission issue, or
+  background tasks killed at the bg-wait ceiling -- exit_code=1 with an
+  `ERROR: ... bg-wait ceiling` note at the end of stderr)
 - Does the failure correlate with input complexity? (scaling issue)
 
 ### 4. Regression Analysis (if baseline provided)
@@ -38,9 +40,17 @@ For each failure pattern, hypothesize WHY:
 
 ### 4b. Cost Attribution
 
-The headline cost (`cost_usd` in `run_result.json`) mixes two independent effects:
+The headline cost (`cost_usd` in `run_result.json`) mixes three independent effects:
 - **Model/runner cost** — how much each turn or token costs. Surfaced in `run_metrics`: `cost_per_turn_usd`, `cost_per_mtok_usd`, `cache_hit_rate`. These stay flat across runs of the same model + effort, so any drift here is a model, runner-version, or effort change — **not** the skill doing different work.
 - **Workload cost** — how much work the skill did. Stochastic per run: more revisions, splits, retries, or fan-out subagents → higher cost without any model/runner change.
+- **Billed-vs-conversation gap** -- `cost_usd` is billed cost: when background
+  agents are killed at the bg-wait ceiling or still running at an evaluator
+  timeout, their tokens are billed but produce no conversation turns, inflating
+  `cost_per_turn_usd` with no model/runner change. Check the end of stderr.log
+  for the bg-kill ERROR note and compare the `per_model_usage` sum against the
+  headline. Baselines from harness versions predating the billed-cost rule
+  under-report cost -- treat cross-boundary cost jumps as a measurement
+  correction, not a regression.
 
 Attribute the gap by deriving a **skill-specific cost-per-unit-of-work** metric on the fly:
 

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -63,7 +63,7 @@ Each case gets ALL files from the dataset case directory (not just input.yaml), 
 - Passes `batch.yaml` content as the skill prompt via stdin
 - Captures stdout (stream-json events) and stderr
 - Writes `stdout.log` and `stderr.log` to `$AGENT_EVAL_RUNS_DIR/{id}/`
-- Parses the final `result` event for token usage and cost; `cost_usd` is the **billed** cost — the larger of the conversation `total_cost_usd` and the summed per-model `modelUsage` costs (background agents killed after the final turn, or still running at an evaluator timeout, burn billed tokens the conversation total never sees)
+- Parses the final `result` event for token usage and cost; `cost_usd` is the **billed** cost — the conversation `total_cost_usd`, raised to the per-model `modelUsage` sum when that exceeds it by more than $0.01 (background agents killed after the final turn, or still running at an evaluator timeout, burn billed tokens the conversation total never sees)
 - Writes `run_result.json` with exit_code, duration_s, token_usage, cost_usd — `exit_code` reflects case truth, not the raw process code: the runner reports 1 when the CLI killed background tasks that outlived the final turn (or ran an unknown command) even though the process exited 0, with the reason appended as an ERROR note in stderr
 
 **What the skill sees (batch mode)**:
@@ -257,7 +257,7 @@ For each judge across all cases:
 | `events: true` | Parse JSONL into events.json | Parsed from stdout.log at collection time | `outputs["events"]` (list of event dicts). Tool results/inputs capped at 50K chars |
 | `metrics: true` | Capture execution metadata | `run_result.json` | `outputs["exit_code"]`, `["duration_s"]`, `["cost_usd"]`, `["num_turns"]`, `["token_usage"]` |
 
-> `exit_code` reflects case truth, not the raw process code: the runner reports 1 when the CLI killed background tasks that outlived the final turn (or ran an unknown command) even though the process exited 0 — the reason is appended as an ERROR note in `outputs["stderr"]`. `cost_usd` is billed cost — the max of the conversation total and the per-model `modelUsage` sum — so it includes tokens burned by killed or still-running background agents.
+> `exit_code` reflects case truth, not the raw process code: the runner reports 1 when the CLI killed background tasks that outlived the final turn (or ran an unknown command) even though the process exited 0 — the reason is appended as an ERROR note in `outputs["stderr"]`. `cost_usd` is billed cost — the conversation total, raised to the per-model `modelUsage` sum when that exceeds it by more than $0.01 — so it includes tokens burned by killed or still-running background agents.
 
 Note: `events.json` is generated at collection time by `collect.py` and includes merged subagent transcripts from `subagents/*.jsonl`. Tool calls in `outputs["tool_calls"]` are derived from events.
 

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -63,8 +63,8 @@ Each case gets ALL files from the dataset case directory (not just input.yaml), 
 - Passes `batch.yaml` content as the skill prompt via stdin
 - Captures stdout (stream-json events) and stderr
 - Writes `stdout.log` and `stderr.log` to `$AGENT_EVAL_RUNS_DIR/{id}/`
-- Parses the final `result` event for token usage and cost
-- Writes `run_result.json` with exit_code, duration_s, token_usage, cost_usd
+- Parses the final `result` event for token usage and cost; `cost_usd` is the **billed** cost — the larger of the conversation `total_cost_usd` and the summed per-model `modelUsage` costs (background agents killed after the final turn, or still running at an evaluator timeout, burn billed tokens the conversation total never sees)
+- Writes `run_result.json` with exit_code, duration_s, token_usage, cost_usd — `exit_code` reflects case truth, not the raw process code: the runner reports 1 when the CLI killed background tasks that outlived the final turn (or ran an unknown command) even though the process exited 0, with the reason appended as an ERROR note in stderr
 
 **What the skill sees (batch mode)**:
 - Working directory: the workspace
@@ -256,6 +256,8 @@ For each judge across all cases:
 | `stderr: true` | Capture full stderr | `stderr.log` in case/run dir | `outputs["stderr"]` |
 | `events: true` | Parse JSONL into events.json | Parsed from stdout.log at collection time | `outputs["events"]` (list of event dicts). Tool results/inputs capped at 50K chars |
 | `metrics: true` | Capture execution metadata | `run_result.json` | `outputs["exit_code"]`, `["duration_s"]`, `["cost_usd"]`, `["num_turns"]`, `["token_usage"]` |
+
+> `exit_code` reflects case truth, not the raw process code: the runner reports 1 when the CLI killed background tasks that outlived the final turn (or ran an unknown command) even though the process exited 0 — the reason is appended as an ERROR note in `outputs["stderr"]`. `cost_usd` is billed cost — the max of the conversation total and the per-model `modelUsage` sum — so it includes tokens burned by killed or still-running background agents.
 
 Note: `events.json` is generated at collection time by `collect.py` and includes merged subagent transcripts from `subagents/*.jsonl`. Tool calls in `outputs["tool_calls"]` are derived from events.
 

--- a/skills/eval-run/references/execution-monitoring.md
+++ b/skills/eval-run/references/execution-monitoring.md
@@ -62,9 +62,12 @@ pipeline may be stuck. Common signs:
   skills) outlived the final turn and were killed after
   `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` (default 600s); their artifacts may be
   half-written, and the harness fails the case (`exit_code=1`) even though the
-  CLI exited 0. Fix by raising the ceiling -- `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS: "0"`
-  (wait indefinitely) via `runner.env:` in eval.yaml or exported in the
-  environment (the key is on the runner's env allowlist)
+  CLI exited 0. First check whether the skill MEANT to end its turn there: a
+  dispatcher that should have awaited its agents has a turn-discipline defect
+  to fix in the skill. Only for intentionally long-running background work,
+  raise the ceiling -- `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` via `runner.env:`
+  in eval.yaml or exported (the key is on the runner's env allowlist); keep
+  `execution.timeout` finite as the backstop rather than defaulting to `"0"`
 
 Report issues with the relevant output lines rather than waiting for completion.
 
@@ -79,8 +82,9 @@ cat $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/run_result.json
 Key fields: `exit_code`, `duration_s`, `wall_clock_s` (lower when parallelism is
 used), `cost_usd`, `num_turns`, `per_model_usage`, `per_model_turns`.
 `cost_usd` is billed cost: when the `per_model_usage` sum exceeds the
-conversation total (background agents killed at the bg-wait ceiling, or still
-running at an evaluator timeout), the larger figure is published.
+conversation total by more than $0.01 (background agents killed at the bg-wait
+ceiling, or still running at an evaluator timeout), the larger figure is
+published.
 
 If `exit_code` is non-zero, report the failure with the exit code, duration, and
 the first and last few lines of `stderr.log` (harness-appended `ERROR:` notes,

--- a/skills/eval-run/references/execution-monitoring.md
+++ b/skills/eval-run/references/execution-monitoring.md
@@ -19,6 +19,10 @@ modes:
 
 - **Headless (`-p`):** ending the turn exits the session immediately, killing all
   background tasks and producing empty results that CI reports as green.
+  (This warning is about the eval session's own execute.py task. Separately,
+  INSIDE each case, the CLI kills the skill-under-test's background tasks that
+  outlive its final turn at the bg-wait ceiling -- the harness detects that and
+  fails the case with exit_code=1; see Detecting problems below.)
 - **Interactive:** Claude Code SIGTERMs background tasks after ~55 minutes of
   session inactivity. A long-running execute.py (common with 20+ cases) will be
   killed silently if no tool calls keep the session active.
@@ -53,6 +57,14 @@ pipeline may be stuck. Common signs:
 - `ERROR` or `Traceback` in the output → script failure, report immediately
 - No new output for 5+ minutes → possible hang, check if the process is running
 - `exit code` or `EXIT:` appearing → execution finished (check the code)
+- `ERROR: the CLI terminated still-running background tasks at the bg-wait
+  ceiling` in stderr.log -> the case's background agents (common in pipeline
+  skills) outlived the final turn and were killed after
+  `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` (default 600s); their artifacts may be
+  half-written, and the harness fails the case (`exit_code=1`) even though the
+  CLI exited 0. Fix by raising the ceiling -- `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS: "0"`
+  (wait indefinitely) via `runner.env:` in eval.yaml or exported in the
+  environment (the key is on the runner's env allowlist)
 
 Report issues with the relevant output lines rather than waiting for completion.
 
@@ -66,9 +78,14 @@ cat $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/run_result.json
 
 Key fields: `exit_code`, `duration_s`, `wall_clock_s` (lower when parallelism is
 used), `cost_usd`, `num_turns`, `per_model_usage`, `per_model_turns`.
+`cost_usd` is billed cost: when the `per_model_usage` sum exceeds the
+conversation total (background agents killed at the bg-wait ceiling, or still
+running at an evaluator timeout), the larger figure is published.
 
 If `exit_code` is non-zero, report the failure with the exit code, duration, and
-the first few lines of `stderr.log`. Do not continue to scoring.
+the first and last few lines of `stderr.log` (harness-appended `ERROR:` notes,
+such as the background-task bg-wait-ceiling kill, land at the end). Do not
+continue to scoring.
 
 ## CLI flag fallbacks
 

--- a/tests/test_extract_progress.py
+++ b/tests/test_extract_progress.py
@@ -302,3 +302,65 @@ class TestDenialAggregationAcrossSegments:
             target="x", args="", workspace=ws, model="m", timeout_s=60)
         assert result.permission_denials is not None
         assert [d["tool_use_id"] for d in result.permission_denials] == ["tu_esc"]
+
+
+class TestBackgroundKillAndCostTruth:
+    """A case whose background agents are killed at the CLI's bg-wait ceiling
+    exits 0 with a "success" result event; and total_cost_usd counts only the
+    conversation, not the killed agent's tokens. On a real run this published
+    a dead case as "OK | $0.30" while modelUsage recorded $1.47."""
+
+    KILLED_STREAM = (
+        '{"type":"system","subtype":"init","session_id":"s1"}\n'
+        '{"type":"result","subtype":"success","is_error":false,"num_turns":12,'
+        '"total_cost_usd":0.2981,'
+        '"modelUsage":{"claude-opus-4-6":{"inputTokens":9000,"outputTokens":30803,'
+        '"cacheReadInputTokens":0,"cacheCreationInputTokens":0,"costUSD":1.4695}},'
+        '"result":"Waiting for it to complete.","session_id":"s1"}\n'
+    )
+    KILL_STDERR = ("Background tasks still running after 600s; terminating. "
+                   "Set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 to wait indefinitely.")
+
+    HEALTHY_STREAM = (
+        '{"type":"system","subtype":"init","session_id":"s1"}\n'
+        '{"type":"result","subtype":"success","is_error":false,"num_turns":12,'
+        '"total_cost_usd":1.4695,'
+        '"modelUsage":{"claude-opus-4-6":{"inputTokens":9000,"outputTokens":30803,'
+        '"cacheReadInputTokens":0,"cacheCreationInputTokens":0,"costUSD":1.4695}},'
+        '"result":"done","session_id":"s1"}\n'
+    )
+
+    def _run(self, tmp_path, monkeypatch, stream, stderr_text=""):
+        import os
+        bindir = tmp_path / "bin"
+        bindir.mkdir(exist_ok=True)
+        stub = bindir / "claude"
+        stub.write_text(
+            "#!/bin/sh\ncat > /dev/null\n"
+            + (f"echo '{stderr_text}' >&2\n" if stderr_text else "")
+            + f"cat <<'STREAM_EOF'\n{stream}STREAM_EOF\n")
+        stub.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+        ws = tmp_path / "ws"
+        ws.mkdir(exist_ok=True)
+        return ClaudeCodeRunner(log_prefix="test").execute(
+            target="x", args="", workspace=ws, model="m", timeout_s=60)
+
+    def test_bg_kill_fails_the_case(self, tmp_path, monkeypatch):
+        result = self._run(tmp_path, monkeypatch, self.KILLED_STREAM,
+                           stderr_text=self.KILL_STDERR)
+        assert result.exit_code != 0, "a killed pipeline must not read as OK"
+        assert "bg-wait ceiling" in result.stderr
+
+    def test_cost_prefers_model_usage_when_higher(self, tmp_path, monkeypatch):
+        result = self._run(tmp_path, monkeypatch, self.KILLED_STREAM,
+                           stderr_text=self.KILL_STDERR)
+        assert result.cost_usd is not None
+        assert abs(result.cost_usd - 1.4695) < 1e-6, (
+            "cost must include the killed background agent's tokens")
+
+    def test_healthy_run_untouched(self, tmp_path, monkeypatch):
+        result = self._run(tmp_path, monkeypatch, self.HEALTHY_STREAM)
+        assert result.exit_code == 0
+        assert abs(result.cost_usd - 1.4695) < 1e-6
+        assert "bg-wait ceiling" not in (result.stderr or "")

--- a/tests/test_extract_progress.py
+++ b/tests/test_extract_progress.py
@@ -392,3 +392,13 @@ class TestBackgroundKillAndCostTruth:
         assert result.cost_usd is not None
         assert abs(result.cost_usd - 1.4695) < 1e-6, (
             "timeout path must include background-agent cost from modelUsage")
+
+
+def test_bg_wait_ceiling_env_propagates(monkeypatch):
+    """The bg-kill failure note tells users to raise
+    CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS — the exact-name env allowlist must
+    therefore pass an exported value through, or the advice is a lie."""
+    from agent_eval.agent.claude_code import ClaudeCodeRunner
+    monkeypatch.setenv("CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS", "0")
+    env = ClaudeCodeRunner()._build_env()
+    assert env.get("CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS") == "0"

--- a/tests/test_extract_progress.py
+++ b/tests/test_extract_progress.py
@@ -364,3 +364,31 @@ class TestBackgroundKillAndCostTruth:
         assert result.exit_code == 0
         assert abs(result.cost_usd - 1.4695) < 1e-6
         assert "bg-wait ceiling" not in (result.stderr or "")
+
+    def test_timeout_path_applies_cost_rule(self, tmp_path, monkeypatch):
+        """An evaluator timeout after the CLI emitted usage data must not
+        under-report the billed cost either (same rule as the bg-kill path,
+        via the shared _billed_cost helper)."""
+        import os
+        bindir = tmp_path / "bin"
+        bindir.mkdir(exist_ok=True)
+        stub = bindir / "claude"
+        # Emit the stream (low total_cost_usd, higher modelUsage), then stall
+        # past the runner deadline and emit one more line so the reader's
+        # deadline check fires and raises TimeoutExpired.
+        stub.write_text(
+            "#!/bin/sh\ncat > /dev/null\n"
+            f"cat <<'STREAM_EOF'\n{self.KILLED_STREAM}STREAM_EOF\n"
+            "sleep 4\n"
+            "echo '{\"type\":\"system\",\"subtype\":\"late\"}'\n")
+        stub.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+        ws = tmp_path / "ws"
+        ws.mkdir(exist_ok=True)
+        result = ClaudeCodeRunner(log_prefix="test").execute(
+            target="x", args="", workspace=ws, model="m", timeout_s=2)
+        assert result.exit_code == -1, "timeout path expected"
+        assert "Timed out" in result.stderr
+        assert result.cost_usd is not None
+        assert abs(result.cost_usd - 1.4695) < 1e-6, (
+            "timeout path must include background-agent cost from modelUsage")

--- a/website/concepts/execution-model.md
+++ b/website/concepts/execution-model.md
@@ -131,6 +131,7 @@ Three guardrails bound each invocation. In `case` mode "per-invocation" means
 | Config key | CLI override | Default | Meaning |
 | --- | --- | --- | --- |
 | `execution.timeout` | `--timeout` | `3600` (s) | Subprocess wall-clock timeout |
+| `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` | env / `runner.env` | `600000` (ms) | How long the CLI waits for background tasks after the final turn before killing them — killed tasks fail the case (exit 1) even though the CLI exits 0 |
 | `execution.max_budget_usd` | `--max-budget` | `100.0` | Cost cap per invocation |
 | `execution.parallelism` | `--parallelism` | `1` (sequential) | Concurrent cases (case mode only) |
 

--- a/website/concepts/runners.md
+++ b/website/concepts/runners.md
@@ -84,11 +84,11 @@ Whatever the runtime, results are normalized into one `RunResult` dataclass:
 
 | Field | Type | Meaning |
 | --- | --- | --- |
-| `exit_code` | `int` | `0` = success; `-1` = timeout or harness-level failure |
+| `exit_code` | `int` | `0` = success; `-1` = timeout or harness-level failure. Runners may convert a process exit 0 into `1` when the run demonstrably failed — e.g. the claude-code runner fails a case whose background tasks the CLI killed at the bg-wait ceiling, or whose slash command was unknown |
 | `stdout` / `stderr` | `str` | Captured output |
 | `duration_s` | `float` | Wall-clock seconds |
 | `token_usage` | `dict` | `{"input": N, "output": N}` |
-| `cost_usd` | `float` | API spend |
+| `cost_usd` | `float` | Billed API spend — at least the conversation `total_cost_usd`, raised to the per-model usage sum when background agents burned tokens the conversation total never saw |
 | `num_turns` | `int` | Assistant turns (incl. subagents where captured) |
 | `resolved_model` | `str` | Full model ID observed at runtime |
 | `models_used` | `list` | All distinct models observed |
@@ -121,7 +121,11 @@ The runner reads the stream line by line, injecting timestamps and printing live
 progress (skill invocations, tool calls, permission denials, final cost). A watchdog
 thread kills the process at the deadline. From the stream it extracts usage, cost,
 turn counts, resolved model(s), and the structured `permission_denials` array from
-the `result` event.
+the `result` event. Reported `cost_usd` is the *billed* cost: the conversation's
+`total_cost_usd`, raised to the per-model `modelUsage` sum when that is higher
+(background agents killed after the final turn — or still running at an evaluator
+timeout — burn billed tokens the conversation total never sees), so it can exceed
+the cost the CLI printed.
 
 **Highlights specific to this runner:**
 
@@ -129,6 +133,13 @@ the `result` event.
   copied into `<workspace>/.staged-plugins/` and `--plugin-dir` receives the copy,
   so the real plugin path never enters session context; in-workspace entries
   pass through unchanged and `workspace_mode: repo` skips staging entirely.
+- **Background-task truth** — the CLI waits up to `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`
+  (default 600 s) for background tasks that outlive the final turn, then kills
+  them but still exits 0. The runner detects the kill and fails the case:
+  `exit_code` becomes `1` and an ERROR note is appended to stderr — artifacts
+  from the killed agent may be half-written. For long-running pipeline skills,
+  raise the ceiling (`0` = wait indefinitely) via `runner.env:` or an exported
+  variable (the key is on the env allowlist).
 - **Budget** is enforced server-side via `--max-budget-usd`.
 - **Permissions** — simple string patterns become `--allowed-tools` /
   `--disallowed-tools`; path-based rules are compiled into a temporary

--- a/website/concepts/runners.md
+++ b/website/concepts/runners.md
@@ -88,7 +88,7 @@ Whatever the runtime, results are normalized into one `RunResult` dataclass:
 | `stdout` / `stderr` | `str` | Captured output |
 | `duration_s` | `float` | Wall-clock seconds |
 | `token_usage` | `dict` | `{"input": N, "output": N}` |
-| `cost_usd` | `float` | Billed API spend — at least the conversation `total_cost_usd`, raised to the per-model usage sum when background agents burned tokens the conversation total never saw |
+| `cost_usd` | `float` | Billed API spend — the conversation `total_cost_usd`, raised to the per-model usage sum when that exceeds it by more than $0.01 (background agents burning tokens the conversation total never saw) |
 | `num_turns` | `int` | Assistant turns (incl. subagents where captured) |
 | `resolved_model` | `str` | Full model ID observed at runtime |
 | `models_used` | `list` | All distinct models observed |
@@ -122,8 +122,8 @@ progress (skill invocations, tool calls, permission denials, final cost). A watc
 thread kills the process at the deadline. From the stream it extracts usage, cost,
 turn counts, resolved model(s), and the structured `permission_denials` array from
 the `result` event. Reported `cost_usd` is the *billed* cost: the conversation's
-`total_cost_usd`, raised to the per-model `modelUsage` sum when that is higher
-(background agents killed after the final turn — or still running at an evaluator
+`total_cost_usd`, raised to the per-model `modelUsage` sum when that exceeds it
+by more than $0.01 (background agents killed after the final turn — or still running at an evaluator
 timeout — burn billed tokens the conversation total never sees), so it can exceed
 the cost the CLI printed.
 

--- a/website/reference/builtin-judges.md
+++ b/website/reference/builtin-judges.md
@@ -107,6 +107,9 @@ judges:
 !!! warning "Cost data must be captured"
     `cost_usd` comes from run metrics. If [`traces.metrics`](config/traces.md) is off (or
     the runner reports no cost), the judge returns `False` with `"No cost data available"`.
+    For the claude-code runner, `cost_usd` is the *billed* cost — it can exceed the
+    conversation total the CLI prints when background agents burned tokens after the
+    final turn. Budget against billed spend, not the CLI final-cost line.
 
 ## process/consulted_docs
 

--- a/website/reference/config/traces.md
+++ b/website/reference/config/traces.md
@@ -57,7 +57,7 @@ enriched with execution-metadata keys pulled from `run_result.json`
 
 | Key in `outputs` | Meaning |
 | --- | --- |
-| `exit_code` | Agent process exit code |
+| `exit_code` | Exit code of the invocation. `0` = clean run; the runner reports `1` for failures it detects even when the agent process exited 0 (e.g. background tasks killed at the CLI bg-wait ceiling, unknown slash command); `-1` = timeout |
 | `duration_s` | Wall-clock duration in seconds |
 | `token_usage` | Input/output token counts |
 | `cost_usd` | Dollar cost of the invocation |

--- a/website/reference/environment-variables.md
+++ b/website/reference/environment-variables.md
@@ -85,6 +85,7 @@ General harness knobs, read by the skills and runner directly.
 | `AGENT_EVAL_RUNS_DIR` | `eval/runs` | Base directory where each run's workspace, artifacts, scores, and `report.html` are written. See [the runs directory](runs-directory.md). |
 | `EVAL_JUDGE_MODEL` | *(none)* | Fallback model for LLM and pairwise judges. Resolution order: per-judge `model:` **>** `models.judge` **>** this variable. |
 | `CLAUDE_CODE_SUBAGENT_MODEL` | *(none)* | Model used for subagents spawned by the skill under test. Set automatically from `models.subagent` when configured. |
+| `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` | `600000` | How long the Claude Code CLI waits for background tasks that outlive the final turn before terminating them (`0` = wait indefinitely). Tasks killed at this ceiling fail the case (exit 1) since their artifacts may be half-written — raise it for long-running pipeline skills, via export (on the env allowlist) or `runner.env:`. |
 
 !!! note "Workspace env allowlist"
     The Claude Code runner does **not** forward your whole environment into an

--- a/website/reference/runs-directory.md
+++ b/website/reference/runs-directory.md
@@ -67,6 +67,13 @@ breakdown; judges read it when `traces.metrics` is on.
 | `execution_mode` | `case` or `batch` |
 | `per_case` | Per-case dict of the same metrics, keyed by case ID |
 
+!!! note "Adjusted, not raw, per-case values"
+    For the claude-code runner, per-case `exit_code` is `1` (not `0`) when the
+    CLI killed background tasks at its bg-wait ceiling — the ERROR note appended
+    to `stderr.log` explains why — and `cost_usd` is the billed cost, which can
+    exceed the conversation total shown in `stdout.log` when background agents
+    burned tokens after the final turn.
+
 ### `collection.json`
 
 Written by `collect.py` — a map of case ID to per-output-path artifact counts, e.g.
@@ -135,6 +142,10 @@ where noted.
 | --- | --- | --- | --- |
 | `stdout: true` | Raw agent output | `stdout.log` | `outputs["stdout"]` (debugging; large) |
 | `stderr: true` | Captured stderr | `stderr.log` | `outputs["stderr"]` |
+
+> `stderr.log` may end with harness-appended `ERROR:`/`WARNING:` lines explaining
+> why a case was failed (e.g. background tasks killed at the bg-wait ceiling,
+> with advice to raise `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`).
 | `events: true` | Parsed JSONL event stream | `events.json` | `outputs["events"]` (tool results capped at 50K chars) |
 | `metrics: true` | Execution metadata | `run_result.json` | `outputs["exit_code"]`, `["duration_s"]`, `["cost_usd"]`, `["num_turns"]`, `["token_usage"]` |
 


### PR DESCRIPTION
## Problem

Auditing eval run `2026-08-20` (30 cases, epic-creator) found a case that died mid-pipeline yet was published as a success, twice over:

1. **A killed pipeline reads as OK.** The CLI terminates background tasks that outlive the final turn by the bg-wait ceiling (default 600s, `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`), emits `Background tasks still running after 600s; terminating.` on stderr — and still exits 0 with a `subtype: "success"` result event. The audited case's decompose agent was killed **7 seconds after its last file write** (one API turn with a 28.9K-char extended-thinking block ate 70% of the window); it shipped a half-written decomposition, four judges failed the corpse, and the harness line read `OK | exit 0`. A `stopped` background-task notification does not auto-resume the session the way `completed` ones do (verified 4/4 reliable), so nothing ever finished the work.

2. **Its cost was published 5× low.** `total_cost_usd` counts only the conversation; `modelUsage` counts every billed token including the killed agent's 30,803 output tokens. The case published **$0.30** while `modelUsage` recorded **$1.47** — and the run report showed two contradictory totals ($113.06 vs $114.23) because per-case sums and per-model sums disagreed by exactly that delta. List-price reconstruction matched all other 29 cases to the cent; the killed case was the sole mismatch.

## Change

- Detect the CLI's termination message on stderr; when the process exited 0 anyway, fail the case (`exit_code=1`) with an explanatory stderr note pointing at the ceiling env var. Mirrors the existing unknown-command detection pattern.
- When the per-model cost total exceeds the conversation total by more than a cent, use the per-model figure. Normal runs agree to the cent and are untouched (asserted).

## Tests

Stub-CLI end-to-end: killed stream + kill stderr → non-zero exit with the explanatory note, and `cost_usd == 1.4695` (the modelUsage figure); healthy stream → exit 0, cost unchanged, no note. `1303 passed, 7 skipped`; ruff parity base=head.

## Related
- The killed case's root trigger is a skill-side dispatcher violation (idling on notifications) already policed project-side by a deterministic judge; this PR fixes the harness half — a dead case must not wear an OK label, and its money must be counted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure plugin staging for workspace-based runs, preventing unsafe path access.
  * Added configuration for background-task wait ceilings.
* **Bug Fixes**
  * Improved billed-cost reporting, including timed-out and background-agent usage.
  * Runs affected by background-task termination now report failure details and accurate exit codes.
* **Documentation**
  * Clarified billed-cost metrics, timeout behavior, failure reporting, and background-task configuration.
* **Tests**
  * Added coverage for timeout cost reporting and background-task wait-ceiling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->