### PR TITLE
fix(execute): persist permission_denials into run_result.json

### DIFF
--- a/skills/eval-run/prompts/analyze-results.md
+++ b/skills/eval-run/prompts/analyze-results.md
@@ -7,7 +7,7 @@ You will be given:
 2. Per-case results (which cases passed/failed which judges)
 3. The skill being evaluated (what it does)
 4. Run metrics (`summary.yaml.run_metrics`): workload-agnostic cost figures — `cost_per_turn_usd`, `output_tokens_per_turn`, `cache_hit_rate`, `cost_per_mtok_usd`. Stable across runs of the same model + effort.
-5. Run result (`run_result.json`): headline cost, duration, turns, token usage, model, effort.
+5. Run result (`run_result.json`): headline cost, duration, turns, token usage, model, effort, per-case `permission_denials` (structured denied tool calls).
 6. Collection summary (`collection.json`): per-case artifact counts — the actual output volumes the skill produced.
 7. Eval config (`eval.yaml`): in particular the `outputs` block, which describes what artifacts the skill is expected to produce.
 8. Optionally: a baseline comparison (what changed vs previous run)
@@ -28,7 +28,9 @@ You will be given:
 For each failure pattern, hypothesize WHY:
 - Is the skill not producing expected artifacts? (execution issue)
 - Is the skill producing artifacts but with quality issues? (quality issue)
-- Is the skill partially completing? (timeout, budget, permission issue, or
+- Is the skill partially completing? (timeout, budget, permission issue —
+  confirm via each case's `permission_denials` in `run_result.json`, whose
+  entries name the denied tool and input — or
   background tasks killed at the bg-wait ceiling -- exit_code=1 with an
   `ERROR: ... bg-wait ceiling` note at the end of stderr)
 - Does the failure correlate with input complexity? (scaling issue)

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -83,7 +83,7 @@ Each case gets ALL files from the dataset case directory (not just input.yaml), 
 - When `execution.parallelism` > 1 (or `--parallelism` CLI), cases run concurrently via thread pool; each case gets a per-case log prefix (e.g., `eval:case-003`)
 - Each case gets its own stdout.log, stderr.log, and subagent transcripts
 - Results are saved to `$AGENT_EVAL_RUNS_DIR/{id}/cases/{case_id}/stdout.log`
-- run_result.json includes `execution_mode: "case"`, `per_case` breakdown, `duration_s` (sum of per-case durations), and `wall_clock_s` (actual elapsed time). Each `per_case` entry (and each step entry under a multi-step case's `steps`) carries its own `permission_denials` list; the run-level aggregate does not sum these — read them per case
+- run_result.json includes `execution_mode: "case"`, `per_case` breakdown, `duration_s` (sum of per-case durations), and `wall_clock_s` (actual elapsed time). Each `per_case` entry (and each step entry under a multi-step case's `steps`) carries its own `permission_denials` list; the run-level aggregate and the case-level entry of a multi-step case carry the concatenation
 
 ## 3. Execution → Collection
 

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -64,7 +64,7 @@ Each case gets ALL files from the dataset case directory (not just input.yaml), 
 - Captures stdout (stream-json events) and stderr
 - Writes `stdout.log` and `stderr.log` to `$AGENT_EVAL_RUNS_DIR/{id}/`
 - Parses the final `result` event for token usage and cost; `cost_usd` is the **billed** cost — the conversation `total_cost_usd`, raised to the per-model `modelUsage` sum when that exceeds it by more than $0.01 (background agents killed after the final turn, or still running at an evaluator timeout, burn billed tokens the conversation total never sees)
-- Writes `run_result.json` with exit_code, duration_s, token_usage, cost_usd — `exit_code` reflects case truth, not the raw process code: the runner reports 1 when the CLI killed background tasks that outlived the final turn (or ran an unknown command) even though the process exited 0, with the reason appended as an ERROR note in stderr
+- Writes `run_result.json` with exit_code, duration_s, token_usage, cost_usd, and permission_denials (the CLI's structured denied-tool-call objects `{tool_name, tool_use_id, tool_input}`; `[]` when none) — `exit_code` reflects case truth, not the raw process code: the runner reports 1 when the CLI killed background tasks that outlived the final turn (or ran an unknown command) even though the process exited 0, with the reason appended as an ERROR note in stderr
 
 **What the skill sees (batch mode)**:
 - Working directory: the workspace
@@ -83,7 +83,7 @@ Each case gets ALL files from the dataset case directory (not just input.yaml), 
 - When `execution.parallelism` > 1 (or `--parallelism` CLI), cases run concurrently via thread pool; each case gets a per-case log prefix (e.g., `eval:case-003`)
 - Each case gets its own stdout.log, stderr.log, and subagent transcripts
 - Results are saved to `$AGENT_EVAL_RUNS_DIR/{id}/cases/{case_id}/stdout.log`
-- run_result.json includes `execution_mode: "case"`, `per_case` breakdown, `duration_s` (sum of per-case durations), and `wall_clock_s` (actual elapsed time)
+- run_result.json includes `execution_mode: "case"`, `per_case` breakdown, `duration_s` (sum of per-case durations), and `wall_clock_s` (actual elapsed time). Each `per_case` entry (and each step entry under a multi-step case's `steps`) carries its own `permission_denials` list; the run-level aggregate does not sum these — read them per case
 
 ## 3. Execution → Collection
 
@@ -257,7 +257,7 @@ For each judge across all cases:
 | `events: true` | Parse JSONL into events.json | Parsed from stdout.log at collection time | `outputs["events"]` (list of event dicts). Tool results/inputs capped at 50K chars |
 | `metrics: true` | Capture execution metadata | `run_result.json` | `outputs["exit_code"]`, `["duration_s"]`, `["cost_usd"]`, `["num_turns"]`, `["token_usage"]` |
 
-> `exit_code` reflects case truth, not the raw process code: the runner reports 1 when the CLI killed background tasks that outlived the final turn (or ran an unknown command) even though the process exited 0 — the reason is appended as an ERROR note in `outputs["stderr"]`. `cost_usd` is billed cost — the conversation total, raised to the per-model `modelUsage` sum when that exceeds it by more than $0.01 — so it includes tokens burned by killed or still-running background agents.
+> `exit_code` reflects case truth, not the raw process code: the runner reports 1 when the CLI killed background tasks that outlived the final turn (or ran an unknown command) even though the process exited 0 — the reason is appended as an ERROR note in `outputs["stderr"]`. `cost_usd` is billed cost — the conversation total, raised to the per-model `modelUsage` sum when that exceeds it by more than $0.01 — so it includes tokens burned by killed or still-running background agents. `permission_denials` is persisted in run_result.json but NOT loaded into the judge record — there is no `outputs["permission_denials"]`; a check judge that needs it can read `Path(outputs["case_dir"]) / "run_result.json"`.
 
 Note: `events.json` is generated at collection time by `collect.py` and includes merged subagent transcripts from `subagents/*.jsonl`. Tool calls in `outputs["tool_calls"]` are derived from events.
 

--- a/skills/eval-run/references/execution-monitoring.md
+++ b/skills/eval-run/references/execution-monitoring.md
@@ -82,8 +82,8 @@ cat $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/run_result.json
 Key fields: `exit_code`, `duration_s`, `wall_clock_s` (lower when parallelism is
 used), `cost_usd`, `num_turns`, `per_model_usage`, `per_model_turns`,
 `permission_denials` (structured list of tool calls denied by permissions,
-`[{tool_name, tool_use_id, tool_input}]`, `[]` when none; in case mode it
-lives inside each `per_case` entry, not at the top level).
+`[{tool_name, tool_use_id, tool_input}]`, `[]` when none; in case mode each
+`per_case` entry carries its own list and the top level the concatenation).
 `cost_usd` is billed cost: when the `per_model_usage` sum exceeds the
 conversation total by more than $0.01 (background agents killed at the bg-wait
 ceiling, or still running at an evaluator timeout), the larger figure is

--- a/skills/eval-run/references/execution-monitoring.md
+++ b/skills/eval-run/references/execution-monitoring.md
@@ -80,7 +80,10 @@ cat $AGENT_EVAL_RUNS_DIR/<eval-name>/<id>/run_result.json
 ```
 
 Key fields: `exit_code`, `duration_s`, `wall_clock_s` (lower when parallelism is
-used), `cost_usd`, `num_turns`, `per_model_usage`, `per_model_turns`.
+used), `cost_usd`, `num_turns`, `per_model_usage`, `per_model_turns`,
+`permission_denials` (structured list of tool calls denied by permissions,
+`[{tool_name, tool_use_id, tool_input}]`, `[]` when none; in case mode it
+lives inside each `per_case` entry, not at the top level).
 `cost_usd` is billed cost: when the `per_model_usage` sum exceeds the
 conversation total by more than $0.01 (background agents killed at the bg-wait
 ceiling, or still running at an evaluator timeout), the larger figure is
@@ -89,7 +92,10 @@ published.
 If `exit_code` is non-zero, report the failure with the exit code, duration, and
 the first and last few lines of `stderr.log` (harness-appended `ERROR:` notes,
 such as the background-task bg-wait-ceiling kill, land at the end). Do not
-continue to scoring.
+continue to scoring. Also check `permission_denials` per case: a non-empty
+list with exit_code 0 means the agent was silently blocked from tool calls
+(e.g. a nested Skill call missing from `permissions.allow`) and may have
+partially completed without failing.
 
 ## CLI flag fallbacks
 

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -636,6 +636,18 @@ def _aggregate_step_metrics(step_metrics):
     # non-zero exit code instead.
     exit_codes = [r.get("exit_code") or 0 for r in results]
     worst_exit = next((ec for ec in exit_codes if ec != 0), 0)
+    # Concatenate step denial lists in step order (dedup by tool_use_id in
+    # case a step result was double-counted) so the case-level entry reports
+    # denials like a single-step case does, instead of hiding them in steps.
+    agg_denials, seen_ids = [], set()
+    for r in results:
+        for d in (r.get("permission_denials") or []):
+            duid = d.get("tool_use_id") if isinstance(d, dict) else None
+            if duid is not None and duid in seen_ids:
+                continue
+            if duid is not None:
+                seen_ids.add(duid)
+            agg_denials.append(d)
     return {
         "exit_code": worst_exit,
         "duration_s": round(sum(r.get("duration_s") or 0 for r in results), 1),
@@ -645,6 +657,7 @@ def _aggregate_step_metrics(step_metrics):
         "num_turns": sum(r.get("num_turns") or 0 for r in results) or None,
         "per_model_usage": agg_pm or None,
         "per_model_turns": agg_pmt or None,
+        "permission_denials": agg_denials,
     }
 
 
@@ -921,6 +934,7 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
             "duration_s": 0,
             "token_usage": None,
             "cost_usd": None,
+            "permission_denials": [],  # case crashed before a result existed
             "num_turns": None,
             "per_model_usage": None,
             "per_model_turns": None,
@@ -1188,6 +1202,7 @@ def _run_multi_step_case(runner, case_id, case_ws, output_dir, model,
             "exit_code": 1, "duration_s": 0, "token_usage": None,
             "cost_usd": None, "num_turns": None, "per_model_usage": None,
             "per_model_turns": None, "error": error_msg,
+            "permission_denials": [],  # case crashed before a result existed
             "steps": step_metrics or None,
         }
         with open(case_output / "run_result.json", "w") as f:
@@ -1469,6 +1484,7 @@ def _execute_per_case(args, config, runner, runner_cls,
                             "duration_s": 0,
                             "token_usage": None,
                             "cost_usd": None,
+                            "permission_denials": [],  # crashed pre-result
                             "num_turns": None,
                             "per_model_usage": None,
                             "per_model_turns": None,
@@ -1545,6 +1561,8 @@ def _execute_per_case(args, config, runner, runner_cls,
             if isinstance(t, (int, float)):
                 agg_per_model_turns[m] = agg_per_model_turns.get(m, 0) + t
 
+    agg_denials = [d for r in case_results.values()
+                   for d in (r.get("permission_denials") or [])]
     run_meta = {
         "exit_code": worst_exit,
         "duration_s": round(total_duration, 1),
@@ -1554,6 +1572,7 @@ def _execute_per_case(args, config, runner, runner_cls,
         "num_turns": total_turns or None,
         "per_model_usage": agg_per_model or None,
         "per_model_turns": agg_per_model_turns or None,
+        "permission_denials": agg_denials,
         "num_cases": len(case_results),
         "model": model,
         "agent": runner.name,

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -785,6 +785,10 @@ def _run_single_case_in_repo(runner, skill_name, case_ws, output_dir,
         "num_turns": result.num_turns,
         "per_model_usage": result.per_model_usage,
         "per_model_turns": result.per_model_turns,
+        # Denials happen in the runner's stream but were never persisted:
+        # a real run's only denial (a workspace-escape attempt) survived
+        # solely in raw stdout.log, invisible to every downstream reader.
+        "permission_denials": result.permission_denials or [],
         "repo_modified": repo_dirty,
     }
 
@@ -967,6 +971,10 @@ def _run_single_case(runner, skill_name, case_id, case_ws, output_dir,
         "num_turns": result.num_turns,
         "per_model_usage": result.per_model_usage,
         "per_model_turns": result.per_model_turns,
+        # Denials happen in the runner's stream but were never persisted:
+        # a real run's only denial (a workspace-escape attempt) survived
+        # solely in raw stdout.log, invisible to every downstream reader.
+        "permission_denials": result.permission_denials or [],
     }
 
     with open(case_output / "run_result.json", "w") as f:
@@ -1149,6 +1157,7 @@ def _run_multi_step_case(runner, case_id, case_ws, output_dir, model,
                 "num_turns": step_result.num_turns,
                 "per_model_usage": step_result.per_model_usage,
                 "per_model_turns": step_result.per_model_turns,
+                "permission_denials": step_result.permission_denials or [],
             }
             steps_ctx[step_id] = {
                 "output": _extract_last_assistant_text(step_result.stdout),
@@ -1614,6 +1623,10 @@ def _save_result(result, args, output_dir, runner, model, eval_params=None):
         "per_model_usage": result.per_model_usage,
         "num_turns": result.num_turns,
         "per_model_turns": result.per_model_turns,
+        # Denials happen in the runner's stream but were never persisted:
+        # a real run's only denial (a workspace-escape attempt) survived
+        # solely in raw stdout.log, invisible to every downstream reader.
+        "permission_denials": result.permission_denials or [],
         "model": full_model,
         "subagent_model": subagent_model_str,
         "agent": runner.name,

--- a/tests/test_execute_result_fields.py
+++ b/tests/test_execute_result_fields.py
@@ -28,15 +28,11 @@ def _dict_keys(node):
 
 
 def _serializes_runresult(node):
-    """True for dicts whose per_model_turns value reads an attribute off a
-    result object (result.per_model_turns / step_result.per_model_turns) —
-    i.e. RunResult serialization sites, not aggregation dicts."""
-    for k, v in zip(node.keys, node.values):
-        if (isinstance(k, ast.Constant) and k.value == "per_model_turns"
-                and isinstance(v, ast.Attribute)
-                and v.attr == "per_model_turns"):
-            return True
-    return False
+    """True for any dict literal carrying a per_model_turns key — direct
+    RunResult serialization sites AND aggregation dicts. The first version
+    excluded aggregation, which is exactly where the multi-step case-level
+    dict silently dropped permission_denials."""
+    return "per_model_turns" in _dict_keys(node)
 
 
 def test_every_runresult_dict_carries_permission_denials():
@@ -50,3 +46,19 @@ def test_every_runresult_dict_carries_permission_denials():
         f"RunResult-serializing dict(s) at execute.py line(s) {missing} drop "
         f"permission_denials — denial telemetry would silently vanish from "
         f"run_result.json again.")
+
+
+def test_multi_step_aggregate_carries_denials():
+    """Case-level dicts for multi-step cases must surface the union of their
+    steps' denials — not hide them under steps[*].permission_denials."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("eval_run_execute", EXECUTE)
+    execute = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(execute)
+    d1 = {"tool_name": "Bash", "tool_use_id": "t1", "tool_input": {"command": "x"}}
+    d2 = {"tool_name": "Read", "tool_use_id": "t2", "tool_input": {"path": "y"}}
+    agg = execute._aggregate_step_metrics({
+        "step-a": {"exit_code": 0, "permission_denials": [d1]},
+        "step-b": {"exit_code": 0, "permission_denials": [d1, d2]},
+    })
+    assert agg["permission_denials"] == [d1, d2]

--- a/tests/test_execute_result_fields.py
+++ b/tests/test_execute_result_fields.py
@@ -1,0 +1,52 @@
+"""run_result.json must not silently drop RunResult telemetry.
+
+The runner has carried permission_denials since the CLI-side union fix, but
+execute.py never serialized it: on a real run, the only permission denial (a
+workspace-escape attempt by a subagent) survived solely in raw stdout.log —
+invisible to run_result.json, summary.yaml and every downstream reader, which
+is exactly how an earlier escape stayed hidden until a manual log audit.
+
+Pinned structurally (like test_venv_activation pins import order): every dict
+literal in execute.py that serializes per-RunResult telemetry (identified by a
+"per_model_turns" key fed from a result attribute) must also carry
+"permission_denials". This guards future result-dict sites too.
+"""
+
+import ast
+from pathlib import Path
+
+EXECUTE = (Path(__file__).resolve().parent.parent
+           / "skills" / "eval-run" / "scripts" / "execute.py")
+
+
+def _dict_keys(node):
+    keys = []
+    for k in node.keys:
+        if isinstance(k, ast.Constant) and isinstance(k.value, str):
+            keys.append(k.value)
+    return keys
+
+
+def _serializes_runresult(node):
+    """True for dicts whose per_model_turns value reads an attribute off a
+    result object (result.per_model_turns / step_result.per_model_turns) —
+    i.e. RunResult serialization sites, not aggregation dicts."""
+    for k, v in zip(node.keys, node.values):
+        if (isinstance(k, ast.Constant) and k.value == "per_model_turns"
+                and isinstance(v, ast.Attribute)
+                and v.attr == "per_model_turns"):
+            return True
+    return False
+
+
+def test_every_runresult_dict_carries_permission_denials():
+    tree = ast.parse(EXECUTE.read_text(), filename=str(EXECUTE))
+    sites = [n for n in ast.walk(tree)
+             if isinstance(n, ast.Dict) and _serializes_runresult(n)]
+    assert sites, "no RunResult serialization sites found — did execute.py move?"
+    missing = [n.lineno for n in sites
+               if "permission_denials" not in _dict_keys(n)]
+    assert not missing, (
+        f"RunResult-serializing dict(s) at execute.py line(s) {missing} drop "
+        f"permission_denials — denial telemetry would silently vanish from "
+        f"run_result.json again.")

--- a/website/concepts/runners.md
+++ b/website/concepts/runners.md
@@ -121,7 +121,8 @@ The runner reads the stream line by line, injecting timestamps and printing live
 progress (skill invocations, tool calls, permission denials, final cost). A watchdog
 thread kills the process at the deadline. From the stream it extracts usage, cost,
 turn counts, resolved model(s), and the structured `permission_denials` array from
-the `result` event. Reported `cost_usd` is the *billed* cost: the conversation's
+the `result` event, which is persisted per case into `run_result.json`
+(see [runs directory](../reference/runs-directory.md)). Reported `cost_usd` is the *billed* cost: the conversation's
 `total_cost_usd`, raised to the per-model `modelUsage` sum when that exceeds it
 by more than $0.01 (background agents killed after the final turn — or still running at an evaluator
 timeout — burn billed tokens the conversation total never sees), so it can exceed

--- a/website/concepts/tracing.md
+++ b/website/concepts/tracing.md
@@ -55,7 +55,7 @@ traces:
 | `stdout` | `stdout.log` — the full `stream-json` event log | `true` |
 | `stderr` | `stderr.log` | `true` |
 | `events` | `events.json` — parsed JSONL events | `true` |
-| `metrics` | `run_result.json` — exit code, duration, tokens, cost, model, per-model usage | `true` |
+| `metrics` | `run_result.json` — exit code, duration, tokens, cost, model, per-model usage, permission denials | `true` |
 
 !!! warning "The trace builder needs the raw stream-json"
     Hierarchical traces are reconstructed from `stdout.log`. If `stdout` capture is off (or the log is missing), `build_trace()` returns `None` and no trace is pushed. See the [traces config reference](../reference/config/traces.md).

--- a/website/guides/eval-run.md
+++ b/website/guides/eval-run.md
@@ -74,6 +74,8 @@ is no CLI flag for it.
       thread pool. Each case gets a log prefix like `eval:case-003`.
     - `run_result.json` records `execution_mode: "case"`, a `per_case` breakdown,
       `duration_s` (sum of per-case durations), and `wall_clock_s` (actual elapsed time).
+      Each `per_case` entry also carries `permission_denials` — tool calls denied by
+      permissions during that case.
 
 === "batch"
 
@@ -209,7 +211,7 @@ majority vote, numeric by median. See [pairwise & sampling](../concepts/pairwise
 The run directory (`$AGENT_EVAL_RUNS_DIR/<eval-name>/<run-id>/`) contains:
 
 ```text
-run_result.json     # exit_code, durations, token usage, cost, per_case breakdown
+run_result.json     # exit_code, durations, token usage, cost, permission denials, per_case breakdown
 collection.json     # per-case artifact counts
 summary.yaml        # judges (mean/pass_rate), per_case, pairwise
 analysis.md         # LLM interpretation, leading with a Recommendation

--- a/website/guides/headless.md
+++ b/website/guides/headless.md
@@ -168,7 +168,9 @@ permissions:
 !!! warning "Add `Skill` if the skill under test calls sub-skills"
     The `Skill` tool requires explicit permission in `--print` mode. If the skill's
     `allowed-tools` frontmatter lists `Skill`, add `"Skill"` to `permissions.allow` —
-    otherwise nested skill calls silently fail.
+    otherwise nested skill calls silently fail. A denied nested call shows up per
+    case in `run_result.json` under `permission_denials` (tool name + input),
+    so check there when a sub-skill never ran.
 
 Path-scoped deny rules (`Read`, `Edit`, `Grep`, `Glob`) are compiled by the harness
 (`agent_eval/tools/permissions.py`) so a directory like `eval/` is denied recursively.

--- a/website/guides/pipeline.md
+++ b/website/guides/pipeline.md
@@ -89,7 +89,7 @@ Each run writes to `$AGENT_EVAL_RUNS_DIR/<eval-name>/<run-id>/`, where:
 $AGENT_EVAL_RUNS_DIR/
 └── <eval-name>/
     └── <run-id>/
-        ├── run_result.json     # exit_code, duration_s, token usage, cost_usd
+        ├── run_result.json     # exit_code, duration_s, token usage, cost_usd, permission_denials
         ├── stdout.log          # full skill stdout (stream-json)
         ├── stderr.log
         ├── collection.json     # per-case artifact counts

--- a/website/reference/config/permissions.md
+++ b/website/reference/config/permissions.md
@@ -163,6 +163,15 @@ permissions:
     - { path: "tmp/",       tools: ["Read", "Edit"] }
 ```
 
+!!! tip "Auditing what was actually denied"
+    Every tool call denied by these rules is persisted per case in
+    `run_result.json` as `permission_denials` (`[{tool_name, tool_use_id,
+    tool_input}]` — inside `per_case` entries in case mode, top-level in batch
+    mode). Check it after a run to spot over-strict rules (e.g. a nested
+    `Skill` call missing from `permissions.allow`) or attempted answer-key
+    reads, instead of grepping `stdout.log`. See
+    [runs directory](../runs-directory.md).
+
 !!! tip "Answer-key protection is why path rules exist"
     Prompt-mode evals and `workspace_mode: repo` runs execute the agent inside
     the real repository, where the dataset, `eval.yaml`, and reference outputs

--- a/website/reference/config/traces.md
+++ b/website/reference/config/traces.md
@@ -20,7 +20,7 @@ traces:
 | `stdout` | `true` | Raw agent standard output | `stdout.log` |
 | `stderr` | `true` | Raw agent standard error | `stderr.log` |
 | `events` | `true` | Structured events (tool calls, reasoning, results) parsed from the stream-json stdout | `events.json` |
-| `metrics` | `true` | Exit code, duration, token usage, cost, turn count | `run_result.json` |
+| `metrics` | `true` | Exit code, duration, token usage, cost, turn count, permission denials | `run_result.json` |
 
 !!! note "Omitting the block keeps everything on"
     `traces` is optional. When absent, `TracesConfig` defaults apply and all
@@ -62,6 +62,10 @@ enriched with execution-metadata keys pulled from `run_result.json`
 | `token_usage` | Input/output token counts |
 | `cost_usd` | Dollar cost of the invocation |
 | `num_turns` | Number of agent turns |
+
+> `permission_denials` is persisted in `run_result.json` but is **not** added
+> to the judge `outputs` record — a check judge that needs it can read the
+> per-case copy at `Path(outputs["case_dir"]) / "run_result.json"`.
 
 A cost- or efficiency-oriented judge reads these directly:
 

--- a/website/reference/runs-directory.md
+++ b/website/reference/runs-directory.md
@@ -20,6 +20,14 @@ export AGENT_EVAL_RUNS_DIR=eval/runs   # default
     under the base. Either way, `report.html`, `run_result.json`, and `cases/` are
     siblings inside the run directory.
 
+!!! warning "Run artifacts are sensitive"
+    `stdout.log` / `events.json` hold the verbatim session transcript, and
+    `permission_denials` entries preserve each denied call's full `tool_input`
+    — deliberately, since the input is what distinguishes an over-strict rule
+    from an escape attempt. Anything the agent saw or tried (paths, commands,
+    tokens passed on command lines) is in these files: keep the runs directory
+    out of version control and scrub before sharing.
+
 ## Per-run layout
 
 ```text
@@ -64,7 +72,7 @@ breakdown; judges read it when `traces.metrics` is on.
 | `num_turns` | Total turns (root + subagent transcripts) |
 | `num_cases` | Number of cases executed |
 | `model` / `agent` / `agent_version` | Model, runner name, runner version |
-| `permission_denials` | Tool calls denied by permissions, as `[{tool_name, tool_use_id, tool_input}]` from the CLI result event (`[]` when none). Per case inside `per_case` entries (and per step under a multi-step case's `steps`); top-level in batch/single-run mode |
+| `permission_denials` | Tool calls denied by permissions, as `[{tool_name, tool_use_id, tool_input}]` from the CLI result event (`[]` when none). Per case inside `per_case` entries (and per step under a multi-step case's `steps`); the top level carries the concatenation across cases (batch/single-run mode: that run's own list) |
 | `execution_mode` | `case` or `batch` |
 | `per_case` | Per-case dict of the same metrics plus `permission_denials`, keyed by case ID |
 

--- a/website/reference/runs-directory.md
+++ b/website/reference/runs-directory.md
@@ -24,7 +24,7 @@ export AGENT_EVAL_RUNS_DIR=eval/runs   # default
 
 ```text
 $AGENT_EVAL_RUNS_DIR/<run-id>/
-├── run_result.json     # execution metadata (exit code, duration, tokens, cost)
+├── run_result.json     # execution metadata (exit code, duration, tokens, cost, permission denials)
 ├── stdout.log          # raw agent output (JSONL stream-json for claude-code)
 ├── stderr.log          # captured stderr
 ├── collection.json     # per-case artifact counts
@@ -64,8 +64,9 @@ breakdown; judges read it when `traces.metrics` is on.
 | `num_turns` | Total turns (root + subagent transcripts) |
 | `num_cases` | Number of cases executed |
 | `model` / `agent` / `agent_version` | Model, runner name, runner version |
+| `permission_denials` | Tool calls denied by permissions, as `[{tool_name, tool_use_id, tool_input}]` from the CLI result event (`[]` when none). Per case inside `per_case` entries (and per step under a multi-step case's `steps`); top-level in batch/single-run mode |
 | `execution_mode` | `case` or `batch` |
-| `per_case` | Per-case dict of the same metrics, keyed by case ID |
+| `per_case` | Per-case dict of the same metrics plus `permission_denials`, keyed by case ID |
 
 !!! note "Adjusted, not raw, per-case values"
     For the claude-code runner, per-case `exit_code` is `1` (not `0`) when the


### PR DESCRIPTION
## Problem

`RunResult.permission_denials` has carried denial telemetry since #192's CLI-side union fix — but `execute.py` never serialized it into `run_result.json`. On eval run `2026-08-20` the only denial that occurred (a subagent attempting to Read outside its workspace via a typo'd path) survived **solely in raw stdout.log**: absent from `run_result.json`, `summary.yaml`, `collection.json`, and every downstream reader. An earlier run's genuine workspace escapes stayed invisible at the run_result level through exactly this gap, and were only found by a manual log audit.

## Change

Serialize `permission_denials` (defaulting to `[]`, so an explicit empty list distinguishes "none occurred" from "not recorded") at all four RunResult serialization sites: per-case, per-case batch, multi-step, and run-level batch.

Pinned with an AST contract test in the repo's existing style (cf. `test_venv_activation`): every dict literal that serializes RunResult telemetry (identified by a `per_model_turns` key fed from a result attribute) must also carry `permission_denials` — so a future serialization site cannot silently drop the field again.

## Tests

`1301 passed, 7 skipped`; ruff parity base=head on `execute.py`.

## Related
- #192 (merged) fixed the CLI-side loss (union across resumed-session segments); this closes the harness-side half of the same evidence path.
- Sibling PR from the same audit: background-task kill mislabeling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation results now include permission-denial details across individual cases, multi-step runs, and batch summaries.
  * Denial information is available in persisted result files for downstream review and analysis.

* **Tests**
  * Added coverage to ensure all serialized evaluation results retain permission-denial details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->