### PR TITLE
feat(workspace): hermetic-by-default plugin isolation via enabledPlugins "*"

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -503,6 +503,17 @@ def _parse_runner_config(runner_raw, *, context="runner"):
     if workspace_mode is not None and workspace_mode not in ("repo",):
         raise ValueError(
             f"{context}.workspace_mode must be None or 'repo', got: {workspace_mode!r}")
+    # settings.enabledPlugins."*" is the harness-interpreted wildcard that
+    # steers hermetic plugin isolation (no upstream wildcard exists; it is
+    # stripped before settings.json is written). Strict boolean — a string
+    # like "false" silently flipping the policy would change which plugins
+    # load in every case.
+    enabled_plugins = (runner_raw.get("settings") or {}).get("enabledPlugins")
+    if isinstance(enabled_plugins, dict) and "*" in enabled_plugins:
+        if not isinstance(enabled_plugins["*"], bool):
+            raise ValueError(
+                f'{context}.settings.enabledPlugins."*" must be a boolean, '
+                f'got: {enabled_plugins["*"]!r}')
     return RunnerConfig(
         type=runner_raw.get("type", "claude-code"),
         command=command,

--- a/agent_eval/tools/hermetic.py
+++ b/agent_eval/tools/hermetic.py
@@ -51,7 +51,12 @@ def installed_plugin_ids(registry_path: Path | str | None = None) -> list[str]:
     plugins = raw.get("plugins")
     if not isinstance(plugins, dict):
         return []
-    return sorted(str(plugin_id) for plugin_id in plugins)
+    # "*" is the harness-reserved wildcard in runner.settings.enabledPlugins;
+    # a registry corrupt (or crafted) enough to contain it must not smuggle
+    # the pseudo-entry into the synthesized denylist — the wildcard strip in
+    # _apply_runner_settings only covers the user's own settings.
+    return sorted(
+        str(plugin_id) for plugin_id in plugins if str(plugin_id) != "*")
 
 
 def hermetic_enabled_plugins(registry_path: Path | str | None = None) -> dict:

--- a/agent_eval/tools/hermetic.py
+++ b/agent_eval/tools/hermetic.py
@@ -1,0 +1,59 @@
+"""Hermetic plugin isolation for eval case sessions (issue #193).
+
+Claude Code loads the operator's user-installed plugins — registered in
+``~/.claude/plugins/installed_plugins.json`` and toggled via ``enabledPlugins``
+in settings — into every session, eval case sessions included. There is no
+``enabledPlugins`` wildcard upstream (anthropics/claude-code#20873) and an
+absent entry means *enabled*, so a hand-maintained denylist rots the moment
+the operator installs a new plugin.
+
+The harness instead synthesizes the denylist at workspace-setup time:
+enumerate every installed plugin and emit ``enabledPlugins: {id: false}`` for
+each, merged into the case workspace's ``.claude/settings.json`` *before* the
+user's own ``runner.settings`` — so an explicit
+``runner.settings.enabledPlugins`` entry still wins. This is the DEFAULT for
+isolated workspaces (isolation is the workspace's contract); the
+``enabledPlugins`` pseudo-entry ``"*"`` steers it explicitly — ``"*": false``
+forces hermeticity, ``"*": true`` opts out — and is stripped before
+settings.json is written, since upstream has no wildcard. Plugins the harness
+passes via ``--plugin-dir`` register as ``<name>@inline`` and never appear in
+the registry, so the generated denylist cannot touch them.
+"""
+
+import json
+from pathlib import Path
+
+
+def installed_plugins_registry() -> Path:
+    """Path to the operator's user-level plugin registry."""
+    return Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+
+
+def installed_plugin_ids(registry_path: Path | str | None = None) -> list[str]:
+    """IDs (``<name>@<marketplace>``) of the operator's installed plugins.
+
+    Reads ``~/.claude/plugins/installed_plugins.json`` (format:
+    ``{"version": 2, "plugins": {"<name>@<marketplace>": ...}}``) unless
+    ``registry_path`` overrides the location (tests). A missing, unreadable,
+    or unparseable registry yields ``[]`` — hermetic mode then has nothing to
+    disable, which matches reality. Format drift is tolerated defensively:
+    if ``"plugins"`` is a dict its keys are the IDs, anything else counts as
+    no plugins.
+    """
+    path = (Path(registry_path) if registry_path is not None
+            else installed_plugins_registry())
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return []
+    if not isinstance(raw, dict):
+        return []
+    plugins = raw.get("plugins")
+    if not isinstance(plugins, dict):
+        return []
+    return sorted(str(plugin_id) for plugin_id in plugins)
+
+
+def hermetic_enabled_plugins(registry_path: Path | str | None = None) -> dict:
+    """The synthesized ``enabledPlugins`` denylist: every installed plugin off."""
+    return {plugin_id: False for plugin_id in installed_plugin_ids(registry_path)}

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -112,6 +112,16 @@ runner:
   # the sandbox. Plugins already inside the workspace are passed through
   # unchanged, and workspace_mode: repo skips staging entirely (the workspace
   # IS the real project there — nothing to isolate).
+  # Plugin hermeticity: isolated workspaces disable ALL of the operator's
+  # user-installed plugins by DEFAULT (the harness enumerates the installed
+  # registry and merges enabledPlugins: {id: false}; repo mode disables
+  # nothing). Steer it in settings.enabledPlugins — explicit entries win:
+  # settings:
+  #   enabledPlugins:
+  #     "*": false                      # explicit hermetic (also in repo mode)
+  #     memsearch@my-marketplace: true  # re-enable one plugin by exact id
+  # "*" is harness-interpreted (upstream has no wildcard) and stripped
+  # before settings.json is written; "*": true opts out of hermeticity.
   # env:                    # Extra env vars for the runner ($VAR resolves from caller)
   #   CUSTOM_AUTH_TOKEN: "$CUSTOM_AUTH_TOKEN"
   # system_prompt: ""       # Appended to harness system prompt

--- a/skills/eval-run/references/data-pipeline.md
+++ b/skills/eval-run/references/data-pipeline.md
@@ -44,7 +44,9 @@ When `execution.mode` is `case` (default), workspace.py creates a separate works
       strategy.md         # Copied from dataset (companion files)
       answers.yaml        # Copied from dataset (if present)
       {output_dirs}/      # Empty dirs for skill outputs
-      .claude/settings.json  # Generated (hooks + permissions)
+      .claude/settings.json  # Generated (hooks + permissions + the synthesized
+                             # enabledPlugins denylist: installed plugins are
+                             # disabled by default in isolated workspaces)
       subagents/           # SubagentStop hook target
       .staged-plugins/     # Staged copies of out-of-workspace runner.plugin_dirs
       scripts/ → symlink

--- a/skills/eval-run/scripts/workspace.py
+++ b/skills/eval-run/scripts/workspace.py
@@ -720,8 +720,35 @@ def _apply_runner_settings(settings, config):
     Lets users add Claude Code settings (model defaults, env, MCP servers,
     etc.) to a runner without forking the harness. Merged after harness
     defaults so user overrides win for scalar keys; lists are extended.
+
+    Plugin hermeticity: in an isolated workspace (workspace_mode is not
+    "repo") the operator's user-installed plugins are disabled by DEFAULT —
+    the harness synthesizes `enabledPlugins: {id: false}` for every entry of
+    the installed-plugin registry (see agent_eval.tools.hermetic) and merges
+    it first, so explicit `runner.settings.enabledPlugins` entries win.
+    Isolation is the workspace's contract; the operator's personal plugins
+    loading into case sessions is contamination (issue #193). repo mode runs
+    in the user's real environment, so nothing is disabled there.
+
+    The `enabledPlugins` pseudo-entry `"*"` makes the policy explicit:
+    `"*": false` forces hermeticity (even in repo mode), `"*": true` opts
+    out. It is harness-interpreted — upstream has no wildcard — and is
+    stripped here so the CLI never sees a key it does not understand.
     """
-    user_settings = getattr(config.runner, "settings", None) or {}
+    user_settings = dict(getattr(config.runner, "settings", None) or {})
+    enabled_plugins = user_settings.get("enabledPlugins")
+    wildcard = None
+    if isinstance(enabled_plugins, dict) and "*" in enabled_plugins:
+        enabled_plugins = dict(enabled_plugins)
+        wildcard = enabled_plugins.pop("*")
+        user_settings["enabledPlugins"] = enabled_plugins
+    isolated = getattr(config.runner, "workspace_mode", None) != "repo"
+    if wildcard is False or (wildcard is None and isolated):
+        from agent_eval.tools.hermetic import hermetic_enabled_plugins
+
+        denylist = hermetic_enabled_plugins()
+        if denylist:
+            _deep_merge(settings, {"enabledPlugins": denylist})
     if user_settings:
         _deep_merge(settings, user_settings)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,33 @@ def test_runner_type_default(tmp_path):
     assert cfg.runner.type == "claude-code"
 
 
+def test_enabled_plugins_wildcard_parses(tmp_path):
+    cfg = EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+execution:
+  skill: s
+runner:
+  settings:
+    enabledPlugins:
+      "*": false
+      memsearch@user-marketplace: true
+"""))
+    assert cfg.runner.settings["enabledPlugins"]["*"] is False
+
+
+def test_enabled_plugins_wildcard_rejects_non_boolean(tmp_path):
+    with pytest.raises(ValueError, match=r'enabledPlugins."\*" must be a boolean'):
+        EvalConfig.from_yaml(_write(tmp_path, """
+name: t
+execution:
+  skill: s
+runner:
+  settings:
+    enabledPlugins:
+      "*": "false"
+"""))
+
+
 def test_models_block_defaults(tmp_path):
     cfg = EvalConfig.from_yaml(_write(tmp_path, """
 name: t

--- a/tests/test_hermetic_plugins.py
+++ b/tests/test_hermetic_plugins.py
@@ -1,0 +1,231 @@
+"""Tests for hermetic plugin isolation (issue #193).
+
+The operator's user-installed plugins (registered in
+``~/.claude/plugins/installed_plugins.json``) load into every case session:
+there is no ``enabledPlugins`` wildcard upstream and an absent entry means
+enabled. In an ISOLATED workspace the harness therefore synthesizes the
+denylist by default — ``enabledPlugins: {id: false}`` for every registry
+entry — merged into the workspace settings before ``runner.settings`` so
+explicit user entries win. The pseudo-entry ``"*"`` steers the policy
+(``false`` forces hermeticity even in repo mode, ``true`` opts out) and is
+stripped before settings.json is written.
+
+All tests use a fixture registry under a temp HOME or an injected registry
+path; none reads the real ``~/.claude``.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure agent_eval is importable
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent_eval.config import EvalConfig
+from agent_eval.tools.hermetic import (
+    hermetic_enabled_plugins,
+    installed_plugin_ids,
+)
+import workspace  # skills/eval-run/scripts (sys.path via conftest)
+
+
+REGISTRY_PLUGINS = {
+    "memsearch@user-marketplace": {"version": "1.0.0"},
+    "clangd-lsp@claude-code-marketplace": {},
+    "skill-creator@claude-code-marketplace": {},
+}
+
+
+def _write_registry(home, plugins=None, text=None):
+    registry = home / ".claude" / "plugins" / "installed_plugins.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        text if text is not None
+        else json.dumps({"version": 2, "plugins": plugins or REGISTRY_PLUGINS}))
+    return registry
+
+
+def _config(directory, runner_yaml):
+    p = directory / "eval.yaml"
+    p.write_text("name: t\nexecution:\n  skill: s\nrunner:\n" + runner_yaml)
+    return EvalConfig.from_yaml(p)
+
+
+# ── Registry parsing ─────────────────────────────────────────────────
+
+
+def test_installed_plugin_ids_reads_registry(tmp_path):
+    registry = _write_registry(tmp_path)
+    assert installed_plugin_ids(registry) == sorted(REGISTRY_PLUGINS)
+
+
+def test_installed_plugin_ids_missing_file(tmp_path):
+    assert installed_plugin_ids(tmp_path / "nope.json") == []
+
+
+def test_installed_plugin_ids_malformed_json(tmp_path):
+    registry = _write_registry(tmp_path, text="{not json")
+    assert installed_plugin_ids(registry) == []
+
+
+@pytest.mark.parametrize("payload", [
+    "[]",                                     # top level is not an object
+    json.dumps({"version": 3}),               # no "plugins" key at all
+    json.dumps({"plugins": ["a@b", "c@d"]}),  # "plugins" is not a mapping
+    json.dumps({"plugins": None}),
+])
+def test_installed_plugin_ids_tolerates_format_drift(tmp_path, payload):
+    registry = _write_registry(tmp_path, text=payload)
+    assert installed_plugin_ids(registry) == []
+
+
+def test_installed_plugin_ids_default_path_is_home_registry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_registry(tmp_path)
+    assert installed_plugin_ids() == sorted(REGISTRY_PLUGINS)
+
+
+def test_denylist_only_covers_registry_ids_never_inline_plugins(tmp_path):
+    """Plugins passed via --plugin-dir register as ``<name>@inline`` and are
+    NOT in installed_plugins.json — so the generated denylist is exactly the
+    registry IDs and cannot disable an inline plugin under test."""
+    registry = _write_registry(tmp_path)
+    generated = hermetic_enabled_plugins(registry)
+    assert set(generated) == set(REGISTRY_PLUGINS)
+    assert not any(pid.endswith("@inline") for pid in generated)
+    assert all(value is False for value in generated.values())
+
+
+# ── Merge precedence ─────────────────────────────────────────────────
+
+
+def test_isolated_workspace_is_hermetic_by_default(tmp_path, monkeypatch):
+    """No plugin config at all: isolation is the workspace's contract."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_registry(tmp_path)
+    config = _config(tmp_path, "  type: claude-code\n")
+
+    settings = {}
+    workspace._apply_runner_settings(settings, config)
+
+    assert settings["enabledPlugins"] == {
+        plugin_id: False for plugin_id in REGISTRY_PLUGINS}
+
+
+def test_repo_mode_is_not_hermetic_by_default(tmp_path, monkeypatch):
+    """workspace_mode: repo runs in the user's real environment."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_registry(tmp_path)
+    config = _config(tmp_path, "  workspace_mode: repo\n")
+
+    settings = {}
+    workspace._apply_runner_settings(settings, config)
+
+    assert "enabledPlugins" not in settings
+
+
+def test_wildcard_false_forces_hermetic_in_repo_mode(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_registry(tmp_path)
+    config = _config(
+        tmp_path,
+        "  workspace_mode: repo\n"
+        "  settings:\n"
+        "    enabledPlugins:\n"
+        "      \"*\": false\n")
+
+    settings = {}
+    workspace._apply_runner_settings(settings, config)
+
+    enabled = settings["enabledPlugins"]
+    assert "*" not in enabled, "the pseudo-entry must never reach settings.json"
+    assert all(enabled[pid] is False for pid in REGISTRY_PLUGINS)
+
+
+def test_wildcard_true_opts_out_of_hermeticity(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_registry(tmp_path)
+    config = _config(
+        tmp_path,
+        "  settings:\n"
+        "    enabledPlugins:\n"
+        "      \"*\": true\n")
+
+    settings = {}
+    workspace._apply_runner_settings(settings, config)
+
+    assert settings.get("enabledPlugins", {}) == {}, (
+        "opt-out must synthesize nothing and strip the pseudo-entry")
+
+
+def test_explicit_runner_settings_entry_wins_over_denylist(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_registry(tmp_path)
+    config = _config(
+        tmp_path,
+        "  settings:\n"
+        "    enabledPlugins:\n"
+        "      memsearch@user-marketplace: true\n")
+
+    settings = {}
+    workspace._apply_runner_settings(settings, config)
+
+    enabled = settings["enabledPlugins"]
+    assert enabled["memsearch@user-marketplace"] is True  # explicit re-enable
+    assert enabled["clangd-lsp@claude-code-marketplace"] is False
+    assert enabled["skill-creator@claude-code-marketplace"] is False
+    assert "*" not in enabled
+
+
+def test_config_object_not_mutated_by_wildcard_stripping(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_registry(tmp_path)
+    config = _config(
+        tmp_path,
+        "  settings:\n"
+        "    enabledPlugins:\n"
+        "      \"*\": false\n")
+
+    workspace._apply_runner_settings({}, config)
+
+    assert config.runner.settings["enabledPlugins"]["*"] is False, (
+        "stripping must operate on a copy — a second workspace build "
+        "would otherwise see a different policy")
+
+
+# ── End-to-end workspace settings.json generation ────────────────────
+
+
+def _generate_workspace_settings(tmp_path, monkeypatch, runner_yaml):
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    _write_registry(home)
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)  # _carry_over_permissions reads cwd/.claude
+    config = _config(project, runner_yaml)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    workspace._setup_subagent_only_hook(ws, config)
+    return json.loads((ws / ".claude" / "settings.json").read_text())
+
+
+def test_workspace_settings_json_hermetic_by_default(tmp_path, monkeypatch):
+    settings = _generate_workspace_settings(
+        tmp_path, monkeypatch, "  type: claude-code\n")
+    assert settings["enabledPlugins"] == {
+        plugin_id: False for plugin_id in REGISTRY_PLUGINS}
+    # Harness defaults still composed alongside the denylist.
+    assert "SubagentStop" in settings["hooks"]
+
+
+def test_workspace_settings_json_opt_out_strips_wildcard(tmp_path, monkeypatch):
+    settings = _generate_workspace_settings(
+        tmp_path, monkeypatch,
+        "  settings:\n"
+        "    enabledPlugins:\n"
+        "      \"*\": true\n")
+    assert settings.get("enabledPlugins", {}) == {}
+    assert "SubagentStop" in settings["hooks"]

--- a/tests/test_hermetic_plugins.py
+++ b/tests/test_hermetic_plugins.py
@@ -81,6 +81,17 @@ def test_installed_plugin_ids_tolerates_format_drift(tmp_path, payload):
     assert installed_plugin_ids(registry) == []
 
 
+def test_registry_wildcard_key_is_rejected(tmp_path):
+    """A registry containing the reserved "*" key must not smuggle the
+    harness-only pseudo-entry into the synthesized denylist — the wildcard
+    strip in _apply_runner_settings covers only the user's own settings."""
+    registry = _write_registry(
+        tmp_path, plugins={**REGISTRY_PLUGINS, "*": {}})
+    assert "*" not in installed_plugin_ids(registry)
+    assert "*" not in hermetic_enabled_plugins(registry)
+    assert set(hermetic_enabled_plugins(registry)) == set(REGISTRY_PLUGINS)
+
+
 def test_installed_plugin_ids_default_path_is_home_registry(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     _write_registry(tmp_path)

--- a/website/concepts/execution-model.md
+++ b/website/concepts/execution-model.md
@@ -42,7 +42,9 @@ and gives each its own throwaway workspace under
 - the case's `input.yaml` (and `answers.yaml`, plus any `dataset.workspace.files`),
 - symlinks to project resources (`scripts`, `skills`, `.context`, `CLAUDE.md`, …),
 - freshly-generated output directories from the `outputs` block,
-- a per-workspace `.claude/settings.json` (permissions, hooks, injected env),
+- a per-workspace `.claude/settings.json` (permissions, hooks, injected env,
+  and the synthesized `enabledPlugins` denylist that keeps the operator's
+  installed plugins out of case sessions — see [Runners](runners.md)),
 - staged copies of out-of-workspace `runner.plugin_dirs` under
   `.staged-plugins/` (claude-code runner — see [Runners](runners.md)),
 - an initialized git repo so [lifecycle hooks](lifecycle-hooks.md) and `collect`

--- a/website/concepts/runners.md
+++ b/website/concepts/runners.md
@@ -134,6 +134,12 @@ the cost the CLI printed.
   copied into `<workspace>/.staged-plugins/` and `--plugin-dir` receives the copy,
   so the real plugin path never enters session context; in-workspace entries
   pass through unchanged and `workspace_mode: repo` skips staging entirely.
+- **Plugin hermeticity** — isolated workspaces disable all of the operator's
+  user-installed plugins by default (a synthesized `enabledPlugins` denylist in
+  the workspace settings; explicit `runner.settings.enabledPlugins` entries win,
+  and the harness-interpreted `"*"` pseudo-entry forces or opts out of the
+  policy). Plugins under test are immune — `--plugin-dir` registers them outside
+  the installed registry. See [runner settings](../reference/config/runner.md).
 - **Background-task truth** — the CLI waits up to `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS`
   (default 600 s) for background tasks that outlive the final turn, then kills
   them but still exits 0. The runner detects the kill and fails the case:

--- a/website/reference/config/runner.md
+++ b/website/reference/config/runner.md
@@ -38,7 +38,7 @@ Not every runner reads every field. The matrix below shows where each field land
 | `type` | `str` | discriminator | discriminator | discriminator | discriminator |
 | `effort` | `str` (enum) | `--effort` flag | `model_reasoning_effort` | `{effort}` placeholder | — |
 | `permission_mode` | `str` (enum) | `--permission-mode` flag | mapped to Codex sandbox mode | — | — |
-| `settings` | `dict` | merged into workspace `.claude/settings.json` | `-c` config overrides for `codex exec` | — | connection settings (see below) |
+| `settings` | `dict` | merged into workspace `.claude/settings.json` (plus a synthesized `enabledPlugins` denylist — see hermeticity below) | `-c` config overrides for `codex exec` | — | connection settings (see below) |
 | `plugin_dirs` | `list[str]` | one `--plugin-dir` per entry (workspace-staged copy for out-of-workspace paths) | skills copied into `.agents/skills` | — | — |
 | `env` | `dict` | injected on the safe allowlist | injected on the safe allowlist | — (uses `execution.env`) | — |
 | `system_prompt` | `str` | `--append-system-prompt` | prepended to the prompt | `{system_prompt}` placeholder | `developer` message |
@@ -125,6 +125,32 @@ A `dict` whose meaning depends on the runner:
           MY_FLAG: "1"
         # any valid .claude/settings.json keys
     ```
+
+    **Plugin hermeticity.** In an isolated workspace the operator's
+    user-installed plugins (from `~/.claude/plugins/installed_plugins.json`)
+    are disabled **by default**: the harness synthesizes
+    `enabledPlugins: {<id>: false}` for every installed plugin and merges it
+    before your `settings`, so an explicit entry re-enables a plugin with one
+    line. `workspace_mode: repo` disables nothing — that session runs in your
+    real environment. Plugins under test are immune: `--plugin-dir` plugins
+    register as `<name>@inline` and never appear in the registry.
+
+    The `enabledPlugins` pseudo-entry `"*"` steers the policy explicitly:
+
+    ```yaml
+    runner:
+      settings:
+        enabledPlugins:
+          "*": false                        # force hermeticity (also in repo mode)
+          "memsearch@my-marketplace": true  # explicit entries win
+    ```
+
+    `"*"` is **harness-interpreted** — upstream Claude Code has no
+    `enabledPlugins` wildcard — and is stripped before `settings.json` is
+    written, so the CLI never sees it. `"*": true` opts out of hermeticity
+    entirely. Configs that relied on an installed plugin silently loading
+    into case sessions fail loudly (`Unknown command`) after upgrading; the
+    fix is one explicit entry or a `plugin_dirs` entry.
 
 === "responses-api"
 


### PR DESCRIPTION
## Problem (#193)

The operator's user-installed plugins — registered in `~/.claude/plugins/installed_plugins.json` — load into **every** session, eval case sessions included. Upstream offers no way to say "none": `enabledPlugins` has no wildcard, an absent entry means *enabled*, and the `--no-plugins` CLI-flags request (anthropics/claude-code#20873) was closed as not planned. A hand-maintained denylist rots the moment a new plugin is installed. Observed on a real 30-case run: a memory plugin loaded into all 30 case sessions and wrote side-effect state (throwaway vector-DB collections) from inside the evals.

## Change: hermetic by default, steered in the native namespace

**Isolated workspaces disable all installed plugins by default.** Isolation is the workspace's contract — the same argument that made plugin staging unconditional. At workspace-setup time the harness enumerates the installed-plugin registry and merges `enabledPlugins: {id: false}` for every entry into the case workspace's `.claude/settings.json`, *before* `runner.settings`, so explicit entries win. `workspace_mode: repo` disables nothing — the session runs in the user's real environment there, mirroring the repo-mode staging skip.

**No new config field.** The policy is expressed where plugin policy already lives:

```yaml
runner:
  settings:
    enabledPlugins:
      "*": false                          # explicit hermetic (also forces it in repo mode)
      "memsearch@my-marketplace": true    # explicit entries win — re-enable one plugin
```

`"*"` is a harness-interpreted pseudo-entry (`false` = force hermeticity, `true` = opt out), validated strictly at config load and **stripped before settings.json is written** — the CLI never sees a key it doesn't understand. If upstream ever grows a real wildcard, these configs keep working verbatim and the harness expansion becomes a pass-through.

**The plugin under test is immune by construction**: `--plugin-dir` plugins register as `<name>@inline` and never appear in the installed registry, so the synthesized denylist cannot touch them.

Behavior note: configs that relied on an installed plugin silently loading into case sessions change behavior on upgrade — the case fails loudly (`Unknown command`) and the fix is one explicit `enabledPlugins` line or a `plugin_dirs` entry. That implicit reliance is the hermeticity leak this PR removes.

## Tests

17 hermetic tests: registry parsing (missing/malformed/format-drift tolerated), inline-plugin immunity, default-on in isolated workspaces, default-off in repo mode, `"*": false` forcing repo-mode hermeticity, `"*": true` opt-out, explicit-entry precedence, pseudo-entry stripped from the written settings.json, and config-object non-mutation (a second workspace build must see the same policy). Plus strict `"*"` boolean validation in config tests. Full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Isolated evaluation workspaces now disable installed plugins by default for more consistent runs.
  - Added configuration options to re-enable specific plugins or opt out of plugin isolation.
  - Repository-mode workspaces continue using installed plugins by default.
  - Explicit plugin settings take precedence over default isolation behavior.

- **Bug Fixes**
  - Invalid wildcard plugin settings are now rejected unless they use a strict boolean value.

- **Documentation**
  - Added guidance and examples for configuring plugin isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->