### PR TITLE
fix(evalhub): resolve _run_with_client names from its own scope

### DIFF
--- a/agent_eval/evalhub/runner.py
+++ b/agent_eval/evalhub/runner.py
@@ -123,17 +123,22 @@ def run_eval_on_evalhub(
     # 2. Submit job to EvalHub
     client = EvalHubClient(base_url=url, auth_token=token)
     try:
-        return _run_with_client(client, config, config_path, ns, provider_id,
-                                benchmark_id, model, params, output_dir,
-                                timeout, poll_interval)
+        return _run_with_client(client, url, config, config_path, ns,
+                                provider_id, benchmark_id, model, params,
+                                output_dir, timeout, poll_interval)
     finally:
         client.close()
 
 
-def _run_with_client(client, config, config_path, ns, provider_id,
+def _run_with_client(client, url, config, config_path, ns, provider_id,
                      benchmark_id, model, params, output_dir,
                      timeout, poll_interval):
     """Inner function so the client is always closed."""
+    # The SDK is an optional dependency; the caller has already proven it
+    # imports. Re-import here because these names must not leak into module
+    # scope (module import must succeed without the SDK installed).
+    from evalhub import JobSubmissionRequest, ModelConfig, BenchmarkConfig
+
     bench_id = benchmark_id or config.name or "skill-eval"
 
     request = JobSubmissionRequest(

--- a/tests/test_evalhub_runner_scope.py
+++ b/tests/test_evalhub_runner_scope.py
@@ -1,0 +1,63 @@
+"""Contract test: every name in evalhub runner functions must resolve.
+
+_run_with_client once referenced ``url`` (and the SDK request classes) from
+its caller's local scope — module import succeeded, and every submission
+crashed with NameError at runtime. The SDK is optional, so this cannot be
+caught by importing and running the function in CI; instead resolve each
+function's free variables statically against its own bindings, module scope,
+and builtins.
+"""
+
+import ast
+import builtins
+from pathlib import Path
+
+RUNNER = Path(__file__).parent.parent / "agent_eval" / "evalhub" / "runner.py"
+
+
+def _module_scope(tree):
+    names = set()
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names.update((a.asname or a.name).split(".")[0] for a in node.names)
+        elif isinstance(node, ast.Assign):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+    return names
+
+
+def _bound_in(fn):
+    bound = {a.arg for a in fn.args.args + fn.args.kwonlyargs}
+    bound.update(a.arg for a in (fn.args.vararg, fn.args.kwarg) if a)
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            bound.add(node.id)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            bound.update((a.asname or a.name).split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ExceptHandler) and node.name:
+            bound.add(node.name)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(node.name)
+    return bound
+
+
+def test_every_function_name_resolves():
+    tree = ast.parse(RUNNER.read_text())
+    module_scope = _module_scope(tree) | set(dir(builtins))
+    problems = []
+    for fn in tree.body:
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        bound = _bound_in(fn)
+        free = {
+            node.id
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+        } - bound - module_scope
+        if free:
+            problems.append(f"{fn.name}: {sorted(free)}")
+    assert not problems, (
+        "names that resolve in no enclosing scope (NameError at runtime): "
+        + "; ".join(problems)
+    )

--- a/tests/test_evalhub_runner_scope.py
+++ b/tests/test_evalhub_runner_scope.py
@@ -3,13 +3,25 @@
 _run_with_client once referenced ``url`` (and the SDK request classes) from
 its caller's local scope — module import succeeded, and every submission
 crashed with NameError at runtime. The SDK is optional, so this cannot be
-caught by importing and running the function in CI; instead resolve each
-function's free variables statically against its own bindings, module scope,
-and builtins.
+caught by importing and running the function in CI; instead resolve names
+statically.
+
+Resolution uses :mod:`symtable` — the compiler's own scope analysis — rather
+than a hand-rolled AST walk. A flat ``ast.walk`` over a function treats
+comprehension targets, nested-function locals and class-body assignments as
+outer-function bindings, which hides exactly the NameError class this test
+exists to catch (comprehension targets do not leak in Python 3). symtable
+scopes each of those correctly and marks closure captures FREE rather than
+GLOBAL, so legitimate nesting never false-positives.
+
+A name is a problem when a function scope references it, never assigns it,
+and resolution falls through to module scope (``is_global()``) where neither
+the module body nor builtins define it.
 """
 
 import ast
 import builtins
+import symtable
 from pathlib import Path
 
 RUNNER = Path(__file__).parent.parent / "agent_eval" / "evalhub" / "runner.py"
@@ -27,37 +39,98 @@ def _module_scope(tree):
     return names
 
 
-def _bound_in(fn):
-    bound = {a.arg for a in fn.args.args + fn.args.kwonlyargs}
-    bound.update(a.arg for a in (fn.args.vararg, fn.args.kwarg) if a)
-    for node in ast.walk(fn):
-        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
-            bound.add(node.id)
-        elif isinstance(node, (ast.Import, ast.ImportFrom)):
-            bound.update((a.asname or a.name).split(".")[0] for a in node.names)
-        elif isinstance(node, ast.ExceptHandler) and node.name:
-            bound.add(node.name)
-        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            bound.add(node.name)
-    return bound
+def _unresolved(source, filename, module_names):
+    """``[(scope_name, [names])]`` that resolve in no enclosing scope."""
+    known = module_names | set(dir(builtins))
+    problems = []
+
+    def visit(table):
+        if table.get_type() == "function":
+            bad = sorted(
+                s.get_name()
+                for s in table.get_symbols()
+                if s.is_referenced() and s.is_global() and not s.is_assigned()
+                and s.get_name() not in known
+            )
+            if bad:
+                problems.append((table.get_name(), bad))
+        for child in table.get_children():
+            visit(child)
+
+    visit(symtable.symtable(source, filename, "exec"))
+    return problems
 
 
 def test_every_function_name_resolves():
-    tree = ast.parse(RUNNER.read_text())
-    module_scope = _module_scope(tree) | set(dir(builtins))
-    problems = []
-    for fn in tree.body:
-        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        bound = _bound_in(fn)
-        free = {
-            node.id
-            for node in ast.walk(fn)
-            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
-        } - bound - module_scope
-        if free:
-            problems.append(f"{fn.name}: {sorted(free)}")
+    source = RUNNER.read_text()
+    problems = _unresolved(source, str(RUNNER), _module_scope(ast.parse(source)))
     assert not problems, (
         "names that resolve in no enclosing scope (NameError at runtime): "
-        + "; ".join(problems)
+        + "; ".join(f"{scope}: {names}" for scope, names in problems)
     )
+
+
+# ── Detector regression cases ────────────────────────────────────────────
+# Each fixture is a scoping trap a flat ast.walk-based binder gets wrong.
+
+def _check(snippet):
+    tree = ast.parse(snippet)
+    return _unresolved(snippet, "<snippet>", _module_scope(tree))
+
+
+def test_detects_caller_scope_leak():
+    # The original bug shape: a helper using its caller's local.
+    problems = _check(
+        "def caller(client):\n"
+        "    url = 'http://x'\n"
+        "    return helper(client)\n"
+        "def helper(client):\n"
+        "    return str(url)\n"
+    )
+    assert problems == [("helper", ["url"])]
+
+
+def test_comprehension_target_does_not_count_as_binding():
+    problems = _check(
+        "def f(values):\n"
+        "    [x for x in values]\n"
+        "    return x\n"
+    )
+    assert ("f", ["x"]) in problems
+
+
+def test_nested_function_local_does_not_leak_out():
+    problems = _check(
+        "def outer():\n"
+        "    def inner():\n"
+        "        y = 1\n"
+        "        return y\n"
+        "    inner()\n"
+        "    return y\n"
+    )
+    assert any(scope == "outer" and "y" in names for scope, names in problems)
+
+
+def test_class_body_assignment_does_not_leak_into_methods():
+    problems = _check(
+        "def build():\n"
+        "    class C:\n"
+        "        attr = 1\n"
+        "        def m(self):\n"
+        "            return attr\n"
+        "    return C\n"
+    )
+    assert any("attr" in names for _, names in problems)
+
+
+def test_closure_and_comprehension_use_are_not_false_positives():
+    problems = _check(
+        "def outer(values):\n"
+        "    threshold = 2\n"
+        "    def inner():\n"
+        "        return threshold\n"
+        "    squares = [v * v for v in values if v > threshold]\n"
+        "    fn = lambda v: v + threshold\n"
+        "    return inner(), squares, fn(1)\n"
+    )
+    assert problems == []


### PR DESCRIPTION
## Problem

`_run_with_client` references names that exist only as locals of its caller `run_eval_on_evalhub`:

- `url` — assigned at `runner.py:100`, used in the submission banner print
- `JobSubmissionRequest`, `ModelConfig`, `BenchmarkConfig` — imported inside the caller's `try: from evalhub import ...` (the SDK is an optional dependency)

Python resolves these at call time, not definition time, and neither function is nested in the other — so module import succeeds, CI stays green, and **every `--runner evalhub` invocation that reaches submission dies with `NameError`** before contacting the server.

## Fix

- Pass `url` through as a parameter.
- Re-import the SDK request classes inside `_run_with_client`. The caller has already proven the SDK imports (it returns early with an install hint otherwise), and the import must not move to module scope — `agent_eval.evalhub.runner` has to import cleanly without `eval-hub-sdk` installed.

## Test

`tests/test_evalhub_runner_scope.py` statically resolves every function's free variables against its own bindings, module scope, and builtins (params, assignments, imports, `except ... as` names, nested defs). This catches the whole class of caller-scope leaks without needing the optional SDK in CI — verified to fail on unpatched `main` and pass with the fix.

Found by a cross-runner consistency audit of plugin/config handling while reviewing #194.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EvalHub evaluation runs by ensuring client resources are closed reliably, including when errors occur.
  * Resolved request handling issues that could affect evaluation execution.

* **Tests**
  * Added automated coverage to detect unresolved names and prevent related runtime failures in evaluation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->