### PR TITLE
feat(hooks): add Stop guard to prevent background-kill empty-green evals

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-eval-harness",
-  "version": "1.40.2",
+  "version": "1.40.1",
   "description": "Agent and skill evaluation harness with MLflow integration",
   "author": {
     "name": "opendatahub-io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-eval-harness",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "description": "Agent and skill evaluation harness with MLflow integration",
   "author": {
     "name": "opendatahub-io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-eval-harness",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "description": "Agent and skill evaluation harness with MLflow integration",
   "author": {
     "name": "opendatahub-io"
@@ -22,6 +22,17 @@
           {
             "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/ensure_deps.py\" \"${CLAUDE_PLUGIN_DATA}\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/eval_stop_guard.py\"",
+            "timeout": 30
           }
         ]
       }

--- a/scripts/eval_stop_guard.py
+++ b/scripts/eval_stop_guard.py
@@ -1,52 +1,63 @@
 #!/usr/bin/env python3
-"""Stop hook: keep the eval-run orchestrator from ending its turn while it still
-has a live background task (e.g. ``execute.py``), with a bounded escape hatch so
-a genuinely stuck run can never hang the session forever.
+"""Stop hook: keep the eval-run orchestrator from ending its turn while an eval
+executor (``execute.py``) is still alive, with a bounded escape hatch so a
+genuinely stuck run can never hang the session forever.
 
 Root cause it fixes
 -------------------
 In headless / CI runs the orchestrator sometimes launches ``execute.py`` with
 ``run_in_background: true`` and then ends its turn right away ("I'll report
-when it finishes"). The session tears down, the background task is killed
-before it writes ``run_result.json``, and the eval reports an *empty* result as
-green. This has been observed repeatedly on the OpenShift CI
+when it finishes"). The session tears down, the background process is killed
+before it writes ``run_result.json``, and the eval records an *empty* result as
+a false pass. This has been observed repeatedly on the OpenShift CI
 ``eval-payload-analysis`` job — including under harness 1.40.x, whose bg-kill
 handling only *relabels* per-case kills and cannot help when the whole
 orchestrator dies before any ``run_result.json`` exists.
 
 The eval-run skill already tells the agent to poll until completion, but in a
-non-interactive session nothing *enforces* it. This hook does: while the
-session has a live background task, it blocks the Stop, forcing the agent to
-keep polling until the task finishes.
+non-interactive session nothing *enforces* it. This hook does: while an
+executor is alive, it blocks the Stop, forcing the agent to keep polling until
+the run finishes.
 
-Why the transcript, not ``pgrep``
+Why a pidfile, not the transcript
 ---------------------------------
-Claude Code records background-task lifecycle in the session transcript
-(handed to the hook via ``transcript_path``):
+An earlier version reconstructed the live-task set from ``system`` events in
+the session transcript (``background_tasks_changed`` / ``task_started`` /
+``task_updated`` / ``task_notification``). Those event subtypes do not exist as
+structured records in current Claude Code transcripts — background-task
+lifecycle is encoded as Bash ``tool_result`` payloads and ``<task-notification>``
+XML embedded in *user*-role message content, and the exact shape drifts across
+CLI versions. Parsing it made the guard silently inert (it always saw zero
+tasks and allowed every stop), reproducing the very empty-result failure it was
+meant to prevent.
 
-  * ``background_tasks_changed`` — carries the *full* current live-task list
-    (``tasks: []`` once they all end);
-  * ``task_started`` — a task began;
-  * ``task_updated`` / ``task_notification`` — status transitions, terminal
-    when ``completed`` / ``failed`` / ``killed`` / ``stopped`` / ``cancelled``.
+Instead the harness owns ``execute.py``, so we use a first-party signal that is
+CLI-version-proof and self-scoping:
 
-Because the transcript is per-session, this is inherently scoped to *this*
-agent. A host-wide ``pgrep execute.py`` would also match executions from other
-concurrent sessions and block spuriously; reading the transcript does not.
+  * ``execute.py`` writes ``<output_dir>/execute.pid`` (pid + an OS process
+    creation marker) at startup and removes it at exit.
+  * this hook scans ``$AGENT_EVAL_RUNS_DIR`` (default ``eval/runs``) under the
+    session cwd for ``execute.pid`` files, and treats a run as *live* when the
+    recorded pid is still alive (``os.kill(pid, 0)``), the creation marker still
+    matches (defeats pid reuse), and no ``run_result.json`` sits beside it yet.
+
+Because only ``execute.py`` writes ``execute.pid``, the guard is inherently
+scoped to evals: a backgrounded dev server or a deliberately-backgrounded agent
+is never mistaken for one, so it is not blocked.
 
 Escape hatch (stuck runs)
 -------------------------
-If a background task hangs, blocking forever would just defer the failure to
-the CI pod's outer timeout. So the hook records when it *first* blocked this
-session and, once more than ``AGENT_EVAL_STOP_GUARD_MAX_MIN`` (default 180)
-have elapsed, it allows the Stop and emits a loud warning to stderr. Progress
+If an executor hangs, blocking forever would just defer the failure to the CI
+pod's outer timeout. So the hook records when it *first* blocked this session
+and, once more than ``AGENT_EVAL_STOP_GUARD_MAX_MIN`` (default 180) minutes have
+elapsed, it allows the Stop and emits a loud warning to stderr. Progress
 sniffing (e.g. console.log mtime) is deliberately NOT used: at high reasoning
 effort a single case can run ~30 min with no console output, so "quiet" is not
 "stuck". A bounded wall-clock ceiling is the only false-positive-free signal.
 
 Contract (Claude Code ``Stop`` hook)
 ------------------------------------
-* stdin: JSON with ``transcript_path``, ``session_id``, ``cwd``,
+* stdin: JSON with ``session_id``, ``cwd``, ``transcript_path``,
   ``stop_hook_active``, ``hook_event_name`` (best-effort; absence tolerated).
 * allow the stop: exit 0 with no stdout.
 * block the stop: print ``{"decision": "block", "reason": "..."}`` and exit 0.
@@ -54,30 +65,29 @@ Contract (Claude Code ``Stop`` hook)
 
 Scope
 -----
-Enabled by default, everywhere. The background-kill failure is specific to
-headless / print mode (``claude -p`` / the Agent SDK), where ending the turn
-tears down the session and kills background tasks ~5s later — but Claude Code
-exposes no reliable signal (no env var, no Stop-payload field) to distinguish
-headless from interactive, so the guard cannot gate on mode and instead runs
-everywhere. In interactive sessions background tasks *persist* across turns, so
-a spurious block there is at most a nuisance: interrupt with Esc, or set
-``AGENT_EVAL_STOP_GUARD=0``. Disabled explicitly when that variable is falsy.
+Enabled by default, everywhere. The pidfile signal already limits blocking to
+sessions with a live eval executor, so a spurious block outside CI is not
+possible unless an eval really is running. ``AGENT_EVAL_STOP_GUARD=0`` disables
+it entirely if ever needed. Fails open on any error.
 
 Environment
 -----------
 * ``AGENT_EVAL_STOP_GUARD``        — force on/off (default on).
 * ``AGENT_EVAL_STOP_GUARD_MAX_MIN``— escape-hatch ceiling in minutes (default
-  180; ``0`` disables the ceiling and blocks until the task ends).
+  180; ``0`` disables the ceiling and blocks until the executor exits).
+* ``AGENT_EVAL_RUNS_DIR``          — runs directory to scan (default
+  ``eval/runs`` under the session cwd).
 """
 
+import glob
 import hashlib
 import json
 import os
 import stat
+import subprocess
 import sys
 import time
 
-TERMINAL_STATUSES = {"completed", "failed", "killed", "stopped", "cancelled"}
 DEFAULT_MAX_MIN = 180
 STATE_DIRNAME = "agent-eval-stop-guard"
 _NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
@@ -93,13 +103,7 @@ def _truthy(value):
 
 
 def _guard_enabled():
-    """Enabled by default; an explicit ``AGENT_EVAL_STOP_GUARD`` always wins.
-
-    The failure this guards against only happens in headless / print mode, but
-    that mode is not detectable from a hook, so the guard defaults on. A
-    spurious block in an interactive session is only a nuisance (background
-    tasks persist there anyway), so defaulting on is safe.
-    """
+    """Enabled by default; an explicit ``AGENT_EVAL_STOP_GUARD`` always wins."""
     override = os.environ.get("AGENT_EVAL_STOP_GUARD")
     if override is not None:
         return _truthy(override)
@@ -116,21 +120,51 @@ def _max_seconds():
         return DEFAULT_MAX_MIN * 60
 
 
-def _transcript_root():
-    """Directory tree Claude Code keeps session transcripts under.
+# ── Process-liveness signal ──────────────────────────────────────────────
 
-    Transcripts live beneath ``${CLAUDE_CONFIG_DIR:-~/.claude}``. Confining
-    reads to this root stops a crafted ``transcript_path`` on hook stdin from
-    pointing the guard at an arbitrary file (CWE-22). Returns ``None`` if the
-    root can't be resolved, in which case the caller fails open.
-    """
-    base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(
-        os.path.expanduser("~"), ".claude")
+def _pid_alive(pid):
+    """True if a process with ``pid`` currently exists."""
     try:
-        return os.path.realpath(base)
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user
     except OSError:
-        return None
+        return False
+    return True
 
+
+def _process_create_time(pid):
+    """Best-effort, stable per-process creation marker used to detect pid reuse.
+
+    Returns a string identity for the process currently at ``pid`` (Linux boot
+    tick count, or the macOS start timestamp), or ``None`` if it cannot be
+    determined. Must match ``execute.py``'s derivation for the reuse check to
+    work, so the two implementations are kept identical.
+    """
+    try:
+        with open("/proc/%d/stat" % pid, encoding="utf-8") as fh:
+            data = fh.read()
+        # comm (field 2) is parenthesised and may itself contain spaces/parens;
+        # starttime is field 22 -> index 19 after the final ')'.
+        after = data[data.rfind(")") + 2:].split()
+        return after[19]
+    except (OSError, IndexError, ValueError):
+        pass
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.run(
+                ["ps", "-o", "lstart=", "-p", str(pid)],
+                capture_output=True, text=True, timeout=5,
+            )
+            return out.stdout.strip() or None
+        except (OSError, subprocess.SubprocessError):
+            pass
+    return None
+
+
+# ── Filesystem helpers (symlink-hardened) ────────────────────────────────
 
 def _within(root, path):
     """True if ``path`` resolves to a location inside ``root`` (no symlink escape)."""
@@ -140,6 +174,7 @@ def _within(root, path):
         real = os.path.realpath(path)
     except OSError:
         return False
+    root = os.path.realpath(root)
     return real == root or real.startswith(root + os.sep)
 
 
@@ -160,69 +195,96 @@ def _open_read_nofollow(path):
         return None
 
 
-def _live_background_tasks(transcript_path):
-    """Reconstruct the set of still-running background tasks from the transcript.
+# ── Live-executor detection ──────────────────────────────────────────────
 
-    Returns a dict of ``task_id -> description`` for tasks that started and have
-    not reached a terminal status, or ``None`` if the transcript cannot be read
-    (caller fails open in that case).
-    """
-    if not transcript_path or not _within(_transcript_root(), transcript_path):
-        return None
+def _run_output_roots(cwd):
+    """Runs directories to scan for ``execute.pid`` (existing dirs, de-duped)."""
+    base = cwd or os.getcwd()
+    candidates = []
+    env = os.environ.get("AGENT_EVAL_RUNS_DIR")
+    if env:
+        candidates.append(env if os.path.isabs(env) else os.path.join(base, env))
+    candidates.append(os.path.join(base, "eval", "runs"))
 
-    fh = _open_read_nofollow(transcript_path)
+    seen = set()
+    roots = []
+    for c in candidates:
+        try:
+            real = os.path.realpath(c)
+        except OSError:
+            continue
+        if real not in seen and os.path.isdir(real):
+            seen.add(real)
+            roots.append(real)
+    return roots
+
+
+def _read_pidfile(path):
+    fh = _open_read_nofollow(path)
     if fh is None:
         return None
-
-    live = {}
     try:
         with fh:
-            for line in fh:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    event = json.loads(line)
-                except (ValueError, TypeError):
-                    continue
-                if event.get("type") != "system":
-                    continue
-                subtype = event.get("subtype")
-
-                if subtype == "background_tasks_changed":
-                    # Authoritative full snapshot of the current live set.
-                    live = {
-                        t.get("task_id"): t.get("description", "")
-                        for t in (event.get("tasks") or [])
-                        if t.get("task_id")
-                    }
-                elif subtype == "task_started":
-                    tid = event.get("task_id")
-                    if tid:
-                        live[tid] = event.get("description", "")
-                elif subtype in ("task_updated", "task_notification"):
-                    tid = event.get("task_id")
-                    if not tid:
-                        continue
-                    status = (event.get("status")
-                              or (event.get("patch") or {}).get("status"))
-                    if status in TERMINAL_STATUSES:
-                        live.pop(tid, None)
-    except OSError:
+            data = json.load(fh)
+    except (ValueError, TypeError, OSError):
         return None
+    return data if isinstance(data, dict) else None
 
+
+def _live_eval_runs(cwd):
+    """Return the output dirs of eval executors that are still alive.
+
+    An executor counts as live when its ``execute.pid`` names a process that is
+    still running, whose creation marker still matches (not a reused pid), and
+    which has not yet written ``run_result.json`` beside the pidfile. Any error
+    on a given pidfile just skips it — the guard fails open, never closed.
+    """
+    live = []
+    seen = set()
+    for root in _run_output_roots(cwd):
+        try:
+            matches = glob.glob(os.path.join(root, "**", "execute.pid"),
+                                recursive=True)
+        except OSError:
+            continue
+        for pidfile in matches:
+            real = os.path.realpath(pidfile)
+            if real in seen:
+                continue
+            seen.add(real)
+            if not _within(root, pidfile):
+                continue  # symlink escaping the runs tree
+            info = _read_pidfile(pidfile)
+            if not info:
+                continue
+            pid = info.get("pid")
+            if not isinstance(pid, int):
+                continue
+            run_dir = os.path.dirname(pidfile)
+            if os.path.exists(os.path.join(run_dir, "run_result.json")):
+                continue  # run already finished
+            if not _pid_alive(pid):
+                continue  # executor already dead — nothing to guard
+            recorded = info.get("create_time")
+            current = _process_create_time(pid)
+            if (recorded is not None and current is not None
+                    and str(recorded) != str(current)):
+                continue  # pid was reused by an unrelated process
+            live.append(run_dir)
     return live
 
 
-def _state_key(session_id, transcript_path):
+# ── Escape-hatch state (per session, symlink/ownership hardened) ─────────
+
+def _state_key(session_id, fallback):
     """Stable, collision-resistant per-session key for the escape-hatch timer.
 
-    Prefer ``session_id``; fall back to the transcript path (also per-session)
-    when it is absent. Returns ``None`` when neither identity exists — the
-    caller then fails open rather than sharing one ``default`` file across
-    unrelated sessions, where one session could clear or inherit another's timer.
+    Prefer ``session_id``; fall back to the session cwd. Returns ``None`` when
+    neither identity exists — the caller then fails open rather than sharing one
+    ``default`` file across unrelated sessions, where one session could clear or
+    inherit another's timer.
     """
-    ident = session_id or transcript_path
+    ident = session_id or fallback
     if not ident:
         return None
     return hashlib.sha256(ident.encode("utf-8", "replace")).hexdigest()
@@ -254,8 +316,8 @@ def _state_dir():
     return path
 
 
-def _state_path(session_id, transcript_path):
-    key = _state_key(session_id, transcript_path)
+def _state_path(session_id, fallback):
+    key = _state_key(session_id, fallback)
     if not key:
         return None
     directory = _state_dir()
@@ -314,16 +376,16 @@ def main():
         payload = {}
 
     session_id = payload.get("session_id")
-    transcript_path = payload.get("transcript_path")
-    state_path = _state_path(session_id, transcript_path)
+    cwd = payload.get("cwd") or os.getcwd()
+    state_path = _state_path(session_id, cwd)
 
     if not _guard_enabled():
         _clear_state(state_path)
         return 0  # allow stop
 
-    live = _live_background_tasks(transcript_path)
-    # Fail open if we could not read the transcript, or nothing is running —
-    # better to let the agent stop than to hang a session we can't reason about.
+    live = _live_eval_runs(cwd)
+    # Fail open if no executor is alive — better to let the agent stop than to
+    # hang a session with nothing left to wait for.
     if not live:
         _clear_state(state_path)
         return 0
@@ -337,20 +399,19 @@ def main():
             # unwritable state dir). Fail open rather than risk blocking forever.
             print(
                 "eval_stop_guard: cannot persist the escape-hatch timer; "
-                "allowing stop rather than risk hanging the session. A "
-                "background task may still be running and the eval incomplete.",
+                "allowing stop rather than risk hanging the session. An eval "
+                "executor may still be running and the result incomplete.",
                 file=sys.stderr,
             )
             return 0  # allow stop
         elapsed = now - first
         if elapsed > max_s:
-            desc = next(iter(live.values()), "") or "a background task"
             print(
                 "eval_stop_guard: escape hatch — blocked for "
-                f"{elapsed / 60:.0f} min (ceiling "
-                f"{max_s / 60:.0f} min) with {len(live)} task(s) still live "
-                f"(e.g. \"{desc}\"). Allowing stop; the run is likely stuck and "
-                "may be incomplete. Tune with AGENT_EVAL_STOP_GUARD_MAX_MIN.",
+                f"{elapsed / 60:.0f} min (ceiling {max_s / 60:.0f} min) with "
+                f"{len(live)} eval executor(s) still alive (e.g. \"{live[0]}\"). "
+                "Allowing stop; the run is likely stuck and may be incomplete. "
+                "Tune with AGENT_EVAL_STOP_GUARD_MAX_MIN.",
                 file=sys.stderr,
             )
             _clear_state(state_path)
@@ -361,15 +422,12 @@ def main():
     # timeout; it does not itself wait for completion.
     time.sleep(5)
 
-    desc = next(iter(live.values()), "") or "a background task"
+    run_dir = live[0]
     reason = (
-        f"You still have {len(live)} background task(s) running "
-        f"(e.g. \"{desc}\"). Do NOT end your turn — ending it now tears down "
-        "the session and kills the task before it writes run_result.json, "
-        "which reports an empty eval result as green. Poll progress with "
-        "`tail -20 <output_dir>/console.log` (or BashOutput on the task) every "
-        "2-3 minutes, and only stop once the task has finished and "
-        "run_result.json exists."
+        f"Eval executor still running ({run_dir}). Don't end your turn — "
+        "stopping now kills it before run_result.json is written. Poll "
+        f"`tail -20 {run_dir}/console.log` every few minutes; stop only once "
+        f"{run_dir}/run_result.json exists."
     )
     print(json.dumps({"decision": "block", "reason": reason}))
     return 0

--- a/scripts/eval_stop_guard.py
+++ b/scripts/eval_stop_guard.py
@@ -48,6 +48,12 @@ Because only ``execute.py`` writes ``execute.pid``, the guard is inherently
 scoped to evals: a backgrounded dev server or a deliberately-backgrounded agent
 is never mistaken for one, so it is not blocked.
 
+That cuts both ways — the guard covers exactly the local ``execute.py`` path and
+nothing else. ``--runner harbor`` (``agent_eval.harbor.run``), the EvalHub
+adapter, and the ANOVA orchestrator's gaps between execute cells are all
+long-running and currently unguarded; extending pidfiles to those entry points
+is follow-up work.
+
 Escape hatch (stuck runs)
 -------------------------
 If an executor hangs, blocking forever would just defer the failure to the CI
@@ -119,7 +125,17 @@ def _truthy(value):
 
 
 def _guard_enabled():
-    """Enabled by default; an explicit ``AGENT_EVAL_STOP_GUARD`` always wins."""
+    """Enabled by default on POSIX; an explicit ``AGENT_EVAL_STOP_GUARD`` wins,
+    except that it can never turn the guard *on* under Windows.
+
+    Windows has no signal-0 probe: CPython's ``os.kill`` maps any ``sig`` other
+    than ``CTRL_C_EVENT``/``CTRL_BREAK_EVENT`` onto ``TerminateProcess``, so the
+    liveness check would *kill the very executor it is inspecting* — manufacturing
+    the truncated-run failure this hook exists to prevent. Until there is a real
+    probe there (e.g. ``OpenProcess``), refuse to run rather than risk it.
+    """
+    if sys.platform == "win32":
+        return False
     override = os.environ.get("AGENT_EVAL_STOP_GUARD")
     if override is not None:
         return _truthy(override)
@@ -138,8 +154,22 @@ def _max_seconds():
 
 # ── Process-liveness signal ──────────────────────────────────────────────
 
+def _valid_pid(pid):
+    """True only for a plausible individual process id.
+
+    ``os.kill`` overloads non-positive pids into broadcasts — ``0`` signals the
+    caller's whole process group and ``-1`` every process it may signal, so both
+    report "alive" unconditionally and would wedge the session until the escape
+    hatch. ``bool`` is an ``int`` subclass, so a JSON ``true`` would otherwise
+    sail through as pid 1 (init), which always exists.
+    """
+    return isinstance(pid, int) and not isinstance(pid, bool) and pid > 0
+
+
 def _pid_alive(pid):
     """True if a process with ``pid`` currently exists."""
+    if not _valid_pid(pid):
+        return False
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -158,6 +188,13 @@ def _process_create_time(pid):
     tick count, or the macOS start timestamp), or ``None`` if it cannot be
     determined. Must match ``execute.py``'s derivation for the reuse check to
     work, so the two implementations are kept identical.
+
+    The macOS ``ps`` env is pinned because ``lstart`` renders a *formatted
+    local* timestamp: the same pid yields "Fri Aug 21 12:34:22 2026" plainly,
+    "…16:34:22…" under ``TZ=UTC`` and "ven. 21 août…" under a French locale.
+    execute.py records the marker under the launching shell's env while this
+    hook re-derives it under Claude Code's, so any ``TZ``/``LC_TIME`` export
+    would make every live run look pid-reused and silently disable the guard.
     """
     try:
         with open("/proc/%d/stat" % pid, encoding="utf-8") as fh:
@@ -173,6 +210,7 @@ def _process_create_time(pid):
             out = subprocess.run(
                 ["ps", "-o", "lstart=", "-p", str(pid)],
                 capture_output=True, text=True, timeout=5,
+                env={"TZ": "UTC", "LC_ALL": "C", "PATH": "/bin:/usr/bin"},
             )
             return out.stdout.strip() or None
         except (OSError, subprocess.SubprocessError):
@@ -258,10 +296,15 @@ def _pidfile_candidates(root):
     vs 0.6 ms bounded).
     """
     matches = []
+    # glob.escape: a checkout path containing glob metacharacters (a CI
+    # workspace like ``linux[py311]`` is the realistic case) would otherwise be
+    # read as a pattern, match nothing, and silently disable the guard —
+    # ``isdir`` on the root passes, so nothing else would flag it.
+    safe_root = glob.escape(root)
     for pattern in ("execute.pid", "*/execute.pid", "*/*/execute.pid",
                     "*/*/*/execute.pid"):
         try:
-            matches.extend(glob.glob(os.path.join(root, pattern)))
+            matches.extend(glob.glob(os.path.join(safe_root, pattern)))
         except OSError:
             continue
     return matches
@@ -290,20 +333,33 @@ def _live_eval_runs(cwd):
             if not info:
                 continue
             pid = info.get("pid")
-            if not isinstance(pid, int):
+            if not _valid_pid(pid):
                 continue
             run_dir = os.path.dirname(pidfile)
-            if os.path.exists(os.path.join(run_dir, "run_result.json")):
+            # "Finished" means a result written by *this* executor. Run dirs get
+            # reused (the default run-id is date+model, so a same-day retry
+            # lands in the same directory), and a result left by the previous
+            # attempt would otherwise mark the new run finished the moment it
+            # starts — the guard would wave through the very kill it exists to
+            # stop, and the stale result would be reported as the retry's.
+            # A result older than the pidfile therefore predates this executor.
+            try:
+                result_mtime = os.path.getmtime(
+                    os.path.join(run_dir, "run_result.json"))
+            except OSError:
+                result_mtime = None
+            try:
+                pid_mtime = os.path.getmtime(pidfile)
+            except OSError:
+                continue
+            if result_mtime is not None and result_mtime >= pid_mtime:
                 continue  # run already finished
             # Staleness backstop. The create_time check below is the primary
             # pid-reuse defense, but it is inert where no marker is obtainable
             # (no /proc and not darwin), leaving a reused pid able to block
             # until the ceiling. No eval outlives MAX_PIDFILE_AGE_S, so an
             # older pidfile is abandoned by definition — on every platform.
-            try:
-                if now - os.path.getmtime(pidfile) > MAX_PIDFILE_AGE_S:
-                    continue
-            except OSError:
+            if now - pid_mtime > MAX_PIDFILE_AGE_S:
                 continue
             if not _pid_alive(pid):
                 continue  # executor already dead — nothing to guard
@@ -368,15 +424,34 @@ def _state_path(session_id, fallback):
     return os.path.join(directory, f"{key}.json")
 
 
-def _first_block_ts(path, now, runs_key):
-    """When this session first blocked *on this set of runs*, recording ``now``
-    if new.
+def _write_timer(path, data):
+    """Persist guard state with no-follow, 0600 semantics. True on success."""
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | _NOFOLLOW, 0o600)
+    except OSError:
+        return False
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+    except OSError:
+        return False
+    return True
+
+
+def _load_timer(path, now, runs_key):
+    """Return ``(first_block, escaped)`` for this run set, seeding it if new.
 
     ``runs_key`` scopes the timer to the runs actually being waited on. Without
     it a session that chains evals back to back — with no intervening idle Stop
     to clear the state — would inherit the previous run's ``first_block`` and
     could trip the escape hatch almost immediately on a fresh run. A changed run
     set means new work, so the clock restarts.
+
+    ``escaped`` records that the ceiling has already been reached for this run
+    set. It has to be durable: simply clearing the state on escape would let the
+    *next* Stop reseed ``first_block`` and open a fresh full-length window on the
+    same wedged executor, turning "can never hang the session forever" into a
+    repeating hostage cycle for as long as the user keeps talking.
 
     Returns ``_PERSIST_FAILED`` when no durable timestamp exists and one cannot
     be written, so the caller can fail open instead of letting a state-write
@@ -393,21 +468,13 @@ def _first_block_ts(path, now, runs_key):
                 data = json.load(fh)
             ts = data.get("first_block")
             if isinstance(ts, (int, float)) and data.get("runs") == runs_key:
-                return ts
+                return ts, bool(data.get("escaped"))
         except (OSError, ValueError, TypeError, AttributeError):
             pass
 
-    # No usable timestamp yet — create one with no-follow, 0600 semantics.
-    try:
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | _NOFOLLOW, 0o600)
-    except OSError:
+    if not _write_timer(path, {"first_block": now, "runs": runs_key}):
         return _PERSIST_FAILED
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump({"first_block": now, "runs": runs_key}, fh)
-    except OSError:
-        return _PERSIST_FAILED
-    return now
+    return now, False
 
 
 def _clear_state(path):
@@ -442,15 +509,26 @@ def main():
 
     now = time.time()
     max_s = _max_seconds()
+    runs_key = sorted(live)
     if max_s > 0:
-        first = _first_block_ts(state_path, now, sorted(live))
-        if first is _PERSIST_FAILED:
+        timer = _load_timer(state_path, now, runs_key)
+        if timer is _PERSIST_FAILED:
             # Can't durably track elapsed time (no session identity or an
             # unwritable state dir). Fail open rather than risk blocking forever.
             print(
                 "eval_stop_guard: cannot persist the escape-hatch timer; "
                 "allowing stop rather than risk hanging the session. An eval "
                 "executor may still be running and the result incomplete.",
+                file=sys.stderr,
+            )
+            return 0  # allow stop
+        first, escaped = timer
+        if escaped:
+            # Ceiling already reached for these runs; stand down permanently
+            # rather than arming a fresh window on every later Stop.
+            print(
+                "eval_stop_guard: escape hatch already tripped for this run; "
+                "allowing stop without re-arming.",
                 file=sys.stderr,
             )
             return 0  # allow stop
@@ -464,13 +542,9 @@ def main():
                 "Tune with AGENT_EVAL_STOP_GUARD_MAX_MIN.",
                 file=sys.stderr,
             )
-            _clear_state(state_path)
+            _write_timer(state_path, {"first_block": first, "runs": runs_key,
+                                      "escaped": True})
             return 0  # allow stop
-
-    # Small courtesy pause so repeated block -> stop cycles don't churn the
-    # model faster than roughly once per turn. Stays well within the hook
-    # timeout; it does not itself wait for completion.
-    time.sleep(5)
 
     run_dir = live[0]
     reason = (
@@ -479,7 +553,14 @@ def main():
         f"written. Poll `tail -20 {run_dir}/console.log`; stop once "
         "run_result.json exists."
     )
-    print(json.dumps({"decision": "block", "reason": reason}))
+    print(json.dumps({"decision": "block", "reason": reason}), flush=True)
+
+    # Courtesy pause so repeated block -> stop cycles don't churn the model
+    # faster than roughly once per turn. Deliberately *after* the decision is
+    # flushed: spending it beforehand would burn 5s of the hook's 30s budget
+    # before rendering any verdict, and a timed-out hook renders none — which
+    # allows the stop, the precise failure this guard exists to prevent.
+    time.sleep(5)
     return 0
 
 

--- a/scripts/eval_stop_guard.py
+++ b/scripts/eval_stop_guard.py
@@ -70,14 +70,22 @@ Environment
   180; ``0`` disables the ceiling and blocks until the task ends).
 """
 
+import hashlib
 import json
 import os
-import re
+import stat
 import sys
 import time
 
 TERMINAL_STATUSES = {"completed", "failed", "killed", "stopped", "cancelled"}
 DEFAULT_MAX_MIN = 180
+STATE_DIRNAME = "agent-eval-stop-guard"
+_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+
+# Sentinel: no durable first-block timestamp exists and one cannot be written.
+# Distinct from a real timestamp so main() can fail open instead of treating a
+# state-write failure as "elapsed ~= 0" and blocking the session forever.
+_PERSIST_FAILED = object()
 
 
 def _truthy(value):
@@ -108,6 +116,50 @@ def _max_seconds():
         return DEFAULT_MAX_MIN * 60
 
 
+def _transcript_root():
+    """Directory tree Claude Code keeps session transcripts under.
+
+    Transcripts live beneath ``${CLAUDE_CONFIG_DIR:-~/.claude}``. Confining
+    reads to this root stops a crafted ``transcript_path`` on hook stdin from
+    pointing the guard at an arbitrary file (CWE-22). Returns ``None`` if the
+    root can't be resolved, in which case the caller fails open.
+    """
+    base = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(
+        os.path.expanduser("~"), ".claude")
+    try:
+        return os.path.realpath(base)
+    except OSError:
+        return None
+
+
+def _within(root, path):
+    """True if ``path`` resolves to a location inside ``root`` (no symlink escape)."""
+    if not root:
+        return False
+    try:
+        real = os.path.realpath(path)
+    except OSError:
+        return False
+    return real == root or real.startswith(root + os.sep)
+
+
+def _open_read_nofollow(path):
+    """Open ``path`` for reading, refusing a final-component symlink.
+
+    Returns a text file object, or ``None`` on any failure (missing file, a
+    symlink swapped in via TOCTOU, permission error, …).
+    """
+    try:
+        fd = os.open(path, os.O_RDONLY | _NOFOLLOW)
+    except OSError:
+        return None
+    try:
+        return os.fdopen(fd, encoding="utf-8", errors="replace")
+    except OSError:
+        os.close(fd)
+        return None
+
+
 def _live_background_tasks(transcript_path):
     """Reconstruct the set of still-running background tasks from the transcript.
 
@@ -115,12 +167,16 @@ def _live_background_tasks(transcript_path):
     not reached a terminal status, or ``None`` if the transcript cannot be read
     (caller fails open in that case).
     """
-    if not transcript_path or not os.path.isfile(transcript_path):
+    if not transcript_path or not _within(_transcript_root(), transcript_path):
+        return None
+
+    fh = _open_read_nofollow(transcript_path)
+    if fh is None:
         return None
 
     live = {}
     try:
-        with open(transcript_path, encoding="utf-8", errors="replace") as fh:
+        with fh:
             for line in fh:
                 line = line.strip()
                 if not line:
@@ -158,33 +214,95 @@ def _live_background_tasks(transcript_path):
     return live
 
 
-def _state_path(session_id):
+def _state_key(session_id, transcript_path):
+    """Stable, collision-resistant per-session key for the escape-hatch timer.
+
+    Prefer ``session_id``; fall back to the transcript path (also per-session)
+    when it is absent. Returns ``None`` when neither identity exists — the
+    caller then fails open rather than sharing one ``default`` file across
+    unrelated sessions, where one session could clear or inherit another's timer.
+    """
+    ident = session_id or transcript_path
+    if not ident:
+        return None
+    return hashlib.sha256(ident.encode("utf-8", "replace")).hexdigest()
+
+
+def _state_dir():
+    """Plugin-owned ``0700`` directory for guard state, or ``None`` if it can't
+    be secured.
+
+    Kept private and non-symlinked so a shared ``TMPDIR`` can't be used to make
+    the hook follow an attacker-planted symlink onto another file (CWE-59/377).
+    """
     tmp = os.environ.get("TMPDIR") or "/tmp"
-    safe = re.sub(r"[^A-Za-z0-9._-]", "_", session_id or "default")
-    return os.path.join(tmp, f"agent-eval-stop-guard-{safe}.json")
-
-
-def _first_block_ts(session_id, now):
-    """Return when this session first blocked, recording ``now`` if new."""
-    path = _state_path(session_id)
+    path = os.path.join(tmp, STATE_DIRNAME)
     try:
-        with open(path, encoding="utf-8") as fh:
-            ts = json.load(fh).get("first_block")
+        os.makedirs(path, mode=0o700, exist_ok=True)
+        info = os.lstat(path)
+    except OSError:
+        return None
+    # Refuse a symlink, a non-directory, or a directory owned by someone else.
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        return None
+    if hasattr(os, "getuid") and info.st_uid != os.getuid():
+        return None
+    try:
+        os.chmod(path, 0o700)  # tighten in case it pre-existed with looser bits
+    except OSError:
+        return None
+    return path
+
+
+def _state_path(session_id, transcript_path):
+    key = _state_key(session_id, transcript_path)
+    if not key:
+        return None
+    directory = _state_dir()
+    if not directory:
+        return None
+    return os.path.join(directory, f"{key}.json")
+
+
+def _first_block_ts(path, now):
+    """When this session first blocked, recording ``now`` if new.
+
+    Returns ``_PERSIST_FAILED`` when no durable timestamp exists and one cannot
+    be written, so the caller can fail open instead of letting a state-write
+    failure block the session forever (each later Stop would otherwise see
+    ``elapsed ~= 0``).
+    """
+    if not path:
+        return _PERSIST_FAILED
+
+    fh = _open_read_nofollow(path)
+    if fh is not None:
+        try:
+            with fh:
+                ts = json.load(fh).get("first_block")
             if isinstance(ts, (int, float)):
                 return ts
-    except (OSError, ValueError, TypeError):
-        pass
+        except (OSError, ValueError, TypeError, AttributeError):
+            pass
+
+    # No usable timestamp yet — create one with no-follow, 0600 semantics.
     try:
-        with open(path, "w", encoding="utf-8") as fh:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | _NOFOLLOW, 0o600)
+    except OSError:
+        return _PERSIST_FAILED
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump({"first_block": now}, fh)
     except OSError:
-        pass
+        return _PERSIST_FAILED
     return now
 
 
-def _clear_state(session_id):
+def _clear_state(path):
+    if not path:
+        return
     try:
-        os.remove(_state_path(session_id))
+        os.remove(path)
     except OSError:
         pass
 
@@ -196,22 +314,35 @@ def main():
         payload = {}
 
     session_id = payload.get("session_id")
+    transcript_path = payload.get("transcript_path")
+    state_path = _state_path(session_id, transcript_path)
 
     if not _guard_enabled():
-        _clear_state(session_id)
+        _clear_state(state_path)
         return 0  # allow stop
 
-    live = _live_background_tasks(payload.get("transcript_path"))
+    live = _live_background_tasks(transcript_path)
     # Fail open if we could not read the transcript, or nothing is running —
     # better to let the agent stop than to hang a session we can't reason about.
     if not live:
-        _clear_state(session_id)
+        _clear_state(state_path)
         return 0
 
     now = time.time()
     max_s = _max_seconds()
     if max_s > 0:
-        elapsed = now - _first_block_ts(session_id, now)
+        first = _first_block_ts(state_path, now)
+        if first is _PERSIST_FAILED:
+            # Can't durably track elapsed time (no session identity or an
+            # unwritable state dir). Fail open rather than risk blocking forever.
+            print(
+                "eval_stop_guard: cannot persist the escape-hatch timer; "
+                "allowing stop rather than risk hanging the session. A "
+                "background task may still be running and the eval incomplete.",
+                file=sys.stderr,
+            )
+            return 0  # allow stop
+        elapsed = now - first
         if elapsed > max_s:
             desc = next(iter(live.values()), "") or "a background task"
             print(
@@ -222,7 +353,7 @@ def main():
                 "may be incomplete. Tune with AGENT_EVAL_STOP_GUARD_MAX_MIN.",
                 file=sys.stderr,
             )
-            _clear_state(session_id)
+            _clear_state(state_path)
             return 0  # allow stop
 
     # Small courtesy pause so repeated block -> stop cycles don't churn the

--- a/scripts/eval_stop_guard.py
+++ b/scripts/eval_stop_guard.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Stop hook: keep the eval-run orchestrator from ending its turn while it still
+has a live background task (e.g. ``execute.py``), with a bounded escape hatch so
+a genuinely stuck run can never hang the session forever.
+
+Root cause it fixes
+-------------------
+In headless / CI runs the orchestrator sometimes launches ``execute.py`` with
+``run_in_background: true`` and then ends its turn right away ("I'll report
+when it finishes"). The session tears down, the background task is killed
+before it writes ``run_result.json``, and the eval reports an *empty* result as
+green. This has been observed repeatedly on the OpenShift CI
+``eval-payload-analysis`` job — including under harness 1.40.x, whose bg-kill
+handling only *relabels* per-case kills and cannot help when the whole
+orchestrator dies before any ``run_result.json`` exists.
+
+The eval-run skill already tells the agent to poll until completion, but in a
+non-interactive session nothing *enforces* it. This hook does: while the
+session has a live background task, it blocks the Stop, forcing the agent to
+keep polling until the task finishes.
+
+Why the transcript, not ``pgrep``
+---------------------------------
+Claude Code records background-task lifecycle in the session transcript
+(handed to the hook via ``transcript_path``):
+
+  * ``background_tasks_changed`` — carries the *full* current live-task list
+    (``tasks: []`` once they all end);
+  * ``task_started`` — a task began;
+  * ``task_updated`` / ``task_notification`` — status transitions, terminal
+    when ``completed`` / ``failed`` / ``killed`` / ``stopped`` / ``cancelled``.
+
+Because the transcript is per-session, this is inherently scoped to *this*
+agent. A host-wide ``pgrep execute.py`` would also match executions from other
+concurrent sessions and block spuriously; reading the transcript does not.
+
+Escape hatch (stuck runs)
+-------------------------
+If a background task hangs, blocking forever would just defer the failure to
+the CI pod's outer timeout. So the hook records when it *first* blocked this
+session and, once more than ``AGENT_EVAL_STOP_GUARD_MAX_MIN`` (default 180)
+have elapsed, it allows the Stop and emits a loud warning to stderr. Progress
+sniffing (e.g. console.log mtime) is deliberately NOT used: at high reasoning
+effort a single case can run ~30 min with no console output, so "quiet" is not
+"stuck". A bounded wall-clock ceiling is the only false-positive-free signal.
+
+Contract (Claude Code ``Stop`` hook)
+------------------------------------
+* stdin: JSON with ``transcript_path``, ``session_id``, ``cwd``,
+  ``stop_hook_active``, ``hook_event_name`` (best-effort; absence tolerated).
+* allow the stop: exit 0 with no stdout.
+* block the stop: print ``{"decision": "block", "reason": "..."}`` and exit 0.
+  The reason is surfaced to the model, which then continues instead of stopping.
+
+Scope
+-----
+Enabled by default, everywhere. The background-kill failure is specific to
+headless / print mode (``claude -p`` / the Agent SDK), where ending the turn
+tears down the session and kills background tasks ~5s later — but Claude Code
+exposes no reliable signal (no env var, no Stop-payload field) to distinguish
+headless from interactive, so the guard cannot gate on mode and instead runs
+everywhere. In interactive sessions background tasks *persist* across turns, so
+a spurious block there is at most a nuisance: interrupt with Esc, or set
+``AGENT_EVAL_STOP_GUARD=0``. Disabled explicitly when that variable is falsy.
+
+Environment
+-----------
+* ``AGENT_EVAL_STOP_GUARD``        — force on/off (default on).
+* ``AGENT_EVAL_STOP_GUARD_MAX_MIN``— escape-hatch ceiling in minutes (default
+  180; ``0`` disables the ceiling and blocks until the task ends).
+"""
+
+import json
+import os
+import re
+import sys
+import time
+
+TERMINAL_STATUSES = {"completed", "failed", "killed", "stopped", "cancelled"}
+DEFAULT_MAX_MIN = 180
+
+
+def _truthy(value):
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _guard_enabled():
+    """Enabled by default; an explicit ``AGENT_EVAL_STOP_GUARD`` always wins.
+
+    The failure this guards against only happens in headless / print mode, but
+    that mode is not detectable from a hook, so the guard defaults on. A
+    spurious block in an interactive session is only a nuisance (background
+    tasks persist there anyway), so defaulting on is safe.
+    """
+    override = os.environ.get("AGENT_EVAL_STOP_GUARD")
+    if override is not None:
+        return _truthy(override)
+    return True
+
+
+def _max_seconds():
+    raw = os.environ.get("AGENT_EVAL_STOP_GUARD_MAX_MIN")
+    if raw is None:
+        return DEFAULT_MAX_MIN * 60
+    try:
+        return max(0, float(raw)) * 60
+    except (ValueError, TypeError):
+        return DEFAULT_MAX_MIN * 60
+
+
+def _live_background_tasks(transcript_path):
+    """Reconstruct the set of still-running background tasks from the transcript.
+
+    Returns a dict of ``task_id -> description`` for tasks that started and have
+    not reached a terminal status, or ``None`` if the transcript cannot be read
+    (caller fails open in that case).
+    """
+    if not transcript_path or not os.path.isfile(transcript_path):
+        return None
+
+    live = {}
+    try:
+        with open(transcript_path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except (ValueError, TypeError):
+                    continue
+                if event.get("type") != "system":
+                    continue
+                subtype = event.get("subtype")
+
+                if subtype == "background_tasks_changed":
+                    # Authoritative full snapshot of the current live set.
+                    live = {
+                        t.get("task_id"): t.get("description", "")
+                        for t in (event.get("tasks") or [])
+                        if t.get("task_id")
+                    }
+                elif subtype == "task_started":
+                    tid = event.get("task_id")
+                    if tid:
+                        live[tid] = event.get("description", "")
+                elif subtype in ("task_updated", "task_notification"):
+                    tid = event.get("task_id")
+                    if not tid:
+                        continue
+                    status = (event.get("status")
+                              or (event.get("patch") or {}).get("status"))
+                    if status in TERMINAL_STATUSES:
+                        live.pop(tid, None)
+    except OSError:
+        return None
+
+    return live
+
+
+def _state_path(session_id):
+    tmp = os.environ.get("TMPDIR") or "/tmp"
+    safe = re.sub(r"[^A-Za-z0-9._-]", "_", session_id or "default")
+    return os.path.join(tmp, f"agent-eval-stop-guard-{safe}.json")
+
+
+def _first_block_ts(session_id, now):
+    """Return when this session first blocked, recording ``now`` if new."""
+    path = _state_path(session_id)
+    try:
+        with open(path, encoding="utf-8") as fh:
+            ts = json.load(fh).get("first_block")
+            if isinstance(ts, (int, float)):
+                return ts
+    except (OSError, ValueError, TypeError):
+        pass
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump({"first_block": now}, fh)
+    except OSError:
+        pass
+    return now
+
+
+def _clear_state(session_id):
+    try:
+        os.remove(_state_path(session_id))
+    except OSError:
+        pass
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        payload = {}
+
+    session_id = payload.get("session_id")
+
+    if not _guard_enabled():
+        _clear_state(session_id)
+        return 0  # allow stop
+
+    live = _live_background_tasks(payload.get("transcript_path"))
+    # Fail open if we could not read the transcript, or nothing is running —
+    # better to let the agent stop than to hang a session we can't reason about.
+    if not live:
+        _clear_state(session_id)
+        return 0
+
+    now = time.time()
+    max_s = _max_seconds()
+    if max_s > 0:
+        elapsed = now - _first_block_ts(session_id, now)
+        if elapsed > max_s:
+            desc = next(iter(live.values()), "") or "a background task"
+            print(
+                "eval_stop_guard: escape hatch — blocked for "
+                f"{elapsed / 60:.0f} min (ceiling "
+                f"{max_s / 60:.0f} min) with {len(live)} task(s) still live "
+                f"(e.g. \"{desc}\"). Allowing stop; the run is likely stuck and "
+                "may be incomplete. Tune with AGENT_EVAL_STOP_GUARD_MAX_MIN.",
+                file=sys.stderr,
+            )
+            _clear_state(session_id)
+            return 0  # allow stop
+
+    # Small courtesy pause so repeated block -> stop cycles don't churn the
+    # model faster than roughly once per turn. Stays well within the hook
+    # timeout; it does not itself wait for completion.
+    time.sleep(5)
+
+    desc = next(iter(live.values()), "") or "a background task"
+    reason = (
+        f"You still have {len(live)} background task(s) running "
+        f"(e.g. \"{desc}\"). Do NOT end your turn — ending it now tears down "
+        "the session and kills the task before it writes run_result.json, "
+        "which reports an empty eval result as green. Poll progress with "
+        "`tail -20 <output_dir>/console.log` (or BashOutput on the task) every "
+        "2-3 minutes, and only stop once the task has finished and "
+        "run_result.json exists."
+    )
+    print(json.dumps({"decision": "block", "reason": reason}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/eval_stop_guard.py
+++ b/scripts/eval_stop_guard.py
@@ -35,7 +35,10 @@ Instead the harness owns ``execute.py``, so we use a first-party signal that is
 CLI-version-proof and self-scoping:
 
   * ``execute.py`` writes ``<output_dir>/execute.pid`` (pid + an OS process
-    creation marker) at startup and removes it at exit.
+    creation marker) before it does anything else — ahead of its own imports,
+    argument parsing and config load, since the guard is blind until that file
+    exists and the racing orchestrator ends its turn immediately after launch —
+    and removes it at exit.
   * this hook scans ``$AGENT_EVAL_RUNS_DIR`` (default ``eval/runs``) under the
     session cwd for ``execute.pid`` files, and treats a run as *live* when the
     recorded pid is still alive (``os.kill(pid, 0)``), the creation marker still
@@ -63,12 +66,22 @@ Contract (Claude Code ``Stop`` hook)
 * block the stop: print ``{"decision": "block", "reason": "..."}`` and exit 0.
   The reason is surfaced to the model, which then continues instead of stopping.
 
-Scope
------
-Enabled by default, everywhere. The pidfile signal already limits blocking to
-sessions with a live eval executor, so a spurious block outside CI is not
-possible unless an eval really is running. ``AGENT_EVAL_STOP_GUARD=0`` disables
-it entirely if ever needed. Fails open on any error.
+Scope (per project, NOT per session)
+------------------------------------
+Enabled by default, everywhere. Note the deliberate trade-off against the
+transcript version this replaced: a pidfile scan is scoped to the *project*,
+not to the session that launched the run. So a second session working in the
+same repo while an eval runs — a user chatting about the code in another
+terminal, say — is also blocked from ending its turn, until the executor exits
+or the escape-hatch ceiling is reached.
+
+That is accepted rather than fixed: the blast radius is bounded (the ceiling
+applies, the block reason names the offending run directory, and the run really
+is live), whereas tying the block to the launching session means walking the
+process ancestry to a top-level ``claude`` pid and comparing it against the
+hook's own — more machinery, and more ways to be wrong, than the nuisance
+warrants. ``AGENT_EVAL_STOP_GUARD=0`` disables the guard for such a session.
+Fails open on any error.
 
 Environment
 -----------
@@ -90,6 +103,9 @@ import time
 
 DEFAULT_MAX_MIN = 180
 STATE_DIRNAME = "agent-eval-stop-guard"
+# A pidfile older than this is treated as abandoned regardless of pid liveness.
+# Comfortably longer than any eval (the CI step caps at 3h).
+MAX_PIDFILE_AGE_S = 24 * 3600
 _NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
 # Sentinel: no durable first-block timestamp exists and one cannot be written.
@@ -231,6 +247,26 @@ def _read_pidfile(path):
     return data if isinstance(data, dict) else None
 
 
+def _pidfile_candidates(root):
+    """Pidfile paths under ``root``, found with bounded-depth globs.
+
+    Pidfiles only ever live at ``<runs>/<eval-name>/<run-id>/execute.pid``, so a
+    handful of fixed-depth patterns covers every layout. A ``**`` recursive glob
+    would instead walk the whole runs tree on *every* Stop — including the
+    subagent transcripts and collected artifacts under each run, which reach
+    six figures of files on a busy tree (measured: 1,859 files → 64 ms recursive
+    vs 0.6 ms bounded).
+    """
+    matches = []
+    for pattern in ("execute.pid", "*/execute.pid", "*/*/execute.pid",
+                    "*/*/*/execute.pid"):
+        try:
+            matches.extend(glob.glob(os.path.join(root, pattern)))
+        except OSError:
+            continue
+    return matches
+
+
 def _live_eval_runs(cwd):
     """Return the output dirs of eval executors that are still alive.
 
@@ -241,13 +277,9 @@ def _live_eval_runs(cwd):
     """
     live = []
     seen = set()
+    now = time.time()
     for root in _run_output_roots(cwd):
-        try:
-            matches = glob.glob(os.path.join(root, "**", "execute.pid"),
-                                recursive=True)
-        except OSError:
-            continue
-        for pidfile in matches:
+        for pidfile in _pidfile_candidates(root):
             real = os.path.realpath(pidfile)
             if real in seen:
                 continue
@@ -263,6 +295,16 @@ def _live_eval_runs(cwd):
             run_dir = os.path.dirname(pidfile)
             if os.path.exists(os.path.join(run_dir, "run_result.json")):
                 continue  # run already finished
+            # Staleness backstop. The create_time check below is the primary
+            # pid-reuse defense, but it is inert where no marker is obtainable
+            # (no /proc and not darwin), leaving a reused pid able to block
+            # until the ceiling. No eval outlives MAX_PIDFILE_AGE_S, so an
+            # older pidfile is abandoned by definition — on every platform.
+            try:
+                if now - os.path.getmtime(pidfile) > MAX_PIDFILE_AGE_S:
+                    continue
+            except OSError:
+                continue
             if not _pid_alive(pid):
                 continue  # executor already dead — nothing to guard
             recorded = info.get("create_time")
@@ -326,8 +368,15 @@ def _state_path(session_id, fallback):
     return os.path.join(directory, f"{key}.json")
 
 
-def _first_block_ts(path, now):
-    """When this session first blocked, recording ``now`` if new.
+def _first_block_ts(path, now, runs_key):
+    """When this session first blocked *on this set of runs*, recording ``now``
+    if new.
+
+    ``runs_key`` scopes the timer to the runs actually being waited on. Without
+    it a session that chains evals back to back — with no intervening idle Stop
+    to clear the state — would inherit the previous run's ``first_block`` and
+    could trip the escape hatch almost immediately on a fresh run. A changed run
+    set means new work, so the clock restarts.
 
     Returns ``_PERSIST_FAILED`` when no durable timestamp exists and one cannot
     be written, so the caller can fail open instead of letting a state-write
@@ -341,8 +390,9 @@ def _first_block_ts(path, now):
     if fh is not None:
         try:
             with fh:
-                ts = json.load(fh).get("first_block")
-            if isinstance(ts, (int, float)):
+                data = json.load(fh)
+            ts = data.get("first_block")
+            if isinstance(ts, (int, float)) and data.get("runs") == runs_key:
                 return ts
         except (OSError, ValueError, TypeError, AttributeError):
             pass
@@ -354,7 +404,7 @@ def _first_block_ts(path, now):
         return _PERSIST_FAILED
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump({"first_block": now}, fh)
+            json.dump({"first_block": now, "runs": runs_key}, fh)
     except OSError:
         return _PERSIST_FAILED
     return now
@@ -393,7 +443,7 @@ def main():
     now = time.time()
     max_s = _max_seconds()
     if max_s > 0:
-        first = _first_block_ts(state_path, now)
+        first = _first_block_ts(state_path, now, sorted(live))
         if first is _PERSIST_FAILED:
             # Can't durably track elapsed time (no session identity or an
             # unwritable state dir). Fail open rather than risk blocking forever.
@@ -424,10 +474,10 @@ def main():
 
     run_dir = live[0]
     reason = (
-        f"Eval executor still running ({run_dir}). Don't end your turn — "
-        "stopping now kills it before run_result.json is written. Poll "
-        f"`tail -20 {run_dir}/console.log` every few minutes; stop only once "
-        f"{run_dir}/run_result.json exists."
+        f"Eval executor still running ({run_dir} — possibly another session). "
+        "Don't end your turn: stopping kills it before run_result.json is "
+        f"written. Poll `tail -20 {run_dir}/console.log`; stop once "
+        "run_result.json exists."
     )
     print(json.dumps({"decision": "block", "reason": reason}))
     return 0

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -21,6 +21,7 @@ Usage:
 import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
 
 import argparse
+import atexit
 import copy
 import json
 import os
@@ -30,8 +31,114 @@ import sys
 import time
 from pathlib import Path
 
-from agent_eval.agent import RUNNERS
-from agent_eval.hooks import (
+# ── Stop-guard pidfile ───────────────────────────────────────────────────
+# Defined and invoked *before* the heavy agent_eval imports below, and before
+# argparse/config load, because the window this closes is a race: the
+# orchestrator can launch us with run_in_background and end its turn
+# immediately, and the Stop guard hook can only block that teardown once
+# execute.pid exists. Every millisecond before the write is a millisecond the
+# guard is blind — and module import is the dominant cost (~25 ms warm, far
+# more on a cold container), so waiting until main() would leave the guard
+# weakest at exactly the moment it is needed most.
+
+_PIDFILE_WRITTEN = False
+
+
+def _process_create_time(pid):
+    """Best-effort, stable per-process creation marker used to detect pid reuse.
+
+    Returns a string identity for the process currently at ``pid`` (Linux boot
+    tick count, or the macOS start timestamp), or ``None`` if it cannot be
+    determined. Must match the Stop guard hook's derivation
+    (``scripts/eval_stop_guard.py``) for the reuse check to work, so the two
+    implementations are kept identical.
+    """
+    try:
+        with open("/proc/%d/stat" % pid, encoding="utf-8") as fh:
+            data = fh.read()
+        # comm (field 2) is parenthesised and may itself contain spaces/parens;
+        # starttime is field 22 -> index 19 after the final ')'.
+        after = data[data.rfind(")") + 2:].split()
+        return after[19]
+    except (OSError, IndexError, ValueError):
+        pass
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.run(
+                ["ps", "-o", "lstart=", "-p", str(pid)],
+                capture_output=True, text=True, timeout=5,
+            )
+            return out.stdout.strip() or None
+        except (OSError, subprocess.SubprocessError):
+            pass
+    return None
+
+
+def _write_pidfile(output_dir):
+    """Write ``<output_dir>/execute.pid`` so the Stop guard hook can tell this
+    executor is still alive.
+
+    The hook blocks the orchestrator from ending its turn (which would tear down
+    the session and kill this process before ``run_result.json`` is written)
+    while an ``execute.pid`` names a live process with no result beside it. The
+    file records the pid plus a process-creation marker so a reused pid can't be
+    mistaken for this run, and is removed at exit.
+
+    Idempotent: only the first call writes, so the early call below and the
+    fallback in ``main()`` never double-register the cleanup.
+    """
+    global _PIDFILE_WRITTEN
+    if _PIDFILE_WRITTEN:
+        return
+    pid = os.getpid()
+    pidfile = Path(output_dir) / "execute.pid"
+    try:
+        with open(pidfile, "w", encoding="utf-8") as fh:
+            json.dump({"pid": pid, "create_time": _process_create_time(pid)}, fh)
+    except OSError:
+        return  # non-fatal: guard just won't see this run
+    _PIDFILE_WRITTEN = True
+
+    def _remove():
+        try:
+            os.remove(pidfile)
+        except OSError:
+            pass
+    atexit.register(_remove)
+
+
+def _early_pidfile(argv):
+    """Write the pidfile straight from ``argv``, before anything else runs.
+
+    ``--output`` is scraped by hand rather than via argparse so the write does
+    not wait on the parser, the config load, or the imports below. Best effort:
+    on any miss ``main()`` still calls ``_write_pidfile`` once ``args.output``
+    is parsed, so the guard degrades to a slightly later write, never to none.
+    """
+    out = None
+    for i, token in enumerate(argv):
+        if token == "--output" and i + 1 < len(argv):
+            out = argv[i + 1]
+            break
+        if token.startswith("--output="):
+            out = token.split("=", 1)[1]
+            break
+    if not out:
+        return
+    try:
+        directory = Path(out)
+        directory.mkdir(parents=True, exist_ok=True)
+        _write_pidfile(directory)
+    except OSError:
+        pass
+
+
+# Guarded so importing execute.py (tests do) never touches the filesystem.
+if __name__ == "__main__":
+    _early_pidfile(sys.argv[1:])
+
+from agent_eval.agent import RUNNERS  # noqa: E402 — after the early pidfile write
+from agent_eval.hooks import (  # noqa: E402 — after the early pidfile write
     HookError, build_hook_env, collect_hook_outputs,
     run_hooks, run_hooks_safe, save_hook_data,
 )
@@ -110,63 +217,6 @@ def _fd_path(fd):
         return os.readlink(f"/proc/self/fd/{fd}")
     except (OSError, ValueError, ImportError):
         return None
-
-
-def _process_create_time(pid):
-    """Best-effort, stable per-process creation marker used to detect pid reuse.
-
-    Returns a string identity for the process currently at ``pid`` (Linux boot
-    tick count, or the macOS start timestamp), or ``None`` if it cannot be
-    determined. Must match the Stop guard hook's derivation
-    (``scripts/eval_stop_guard.py``) for the reuse check to work, so the two
-    implementations are kept identical.
-    """
-    try:
-        with open("/proc/%d/stat" % pid, encoding="utf-8") as fh:
-            data = fh.read()
-        # comm (field 2) is parenthesised and may itself contain spaces/parens;
-        # starttime is field 22 -> index 19 after the final ')'.
-        after = data[data.rfind(")") + 2:].split()
-        return after[19]
-    except (OSError, IndexError, ValueError):
-        pass
-    if sys.platform == "darwin":
-        try:
-            out = subprocess.run(
-                ["ps", "-o", "lstart=", "-p", str(pid)],
-                capture_output=True, text=True, timeout=5,
-            )
-            return out.stdout.strip() or None
-        except (OSError, subprocess.SubprocessError):
-            pass
-    return None
-
-
-def _write_pidfile(output_dir):
-    """Write ``<output_dir>/execute.pid`` so the Stop guard hook can tell this
-    executor is still alive.
-
-    The hook blocks the orchestrator from ending its turn (which would tear down
-    the session and kill this process before ``run_result.json`` is written)
-    while an ``execute.pid`` names a live process with no result beside it. The
-    file records the pid plus a process-creation marker so a reused pid can't be
-    mistaken for this run, and is removed at exit.
-    """
-    pid = os.getpid()
-    pidfile = output_dir / "execute.pid"
-    try:
-        with open(pidfile, "w", encoding="utf-8") as fh:
-            json.dump({"pid": pid, "create_time": _process_create_time(pid)}, fh)
-    except OSError:
-        return  # non-fatal: guard just won't see this run
-
-    import atexit
-    def _remove():
-        try:
-            os.remove(pidfile)
-        except OSError:
-            pass
-    atexit.register(_remove)
 
 
 def _setup_console_log(output_dir):
@@ -307,9 +357,9 @@ def main():
     # viewer). The real stdout/stderr streams still receive everything.
     _setup_console_log(output_dir)
 
-    # Record our pid so the Stop guard hook can tell this executor is still
-    # alive and block the orchestrator from ending its turn (which would kill
-    # us before run_result.json is written).
+    # Fallback for the Stop-guard pidfile: normally already written by
+    # _early_pidfile() before the imports at the top of this module. No-op
+    # unless that scrape missed (e.g. an --output form it didn't recognise).
     _write_pidfile(output_dir)
 
     # Resolve skill args: CLI override > config > empty

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -112,6 +112,63 @@ def _fd_path(fd):
         return None
 
 
+def _process_create_time(pid):
+    """Best-effort, stable per-process creation marker used to detect pid reuse.
+
+    Returns a string identity for the process currently at ``pid`` (Linux boot
+    tick count, or the macOS start timestamp), or ``None`` if it cannot be
+    determined. Must match the Stop guard hook's derivation
+    (``scripts/eval_stop_guard.py``) for the reuse check to work, so the two
+    implementations are kept identical.
+    """
+    try:
+        with open("/proc/%d/stat" % pid, encoding="utf-8") as fh:
+            data = fh.read()
+        # comm (field 2) is parenthesised and may itself contain spaces/parens;
+        # starttime is field 22 -> index 19 after the final ')'.
+        after = data[data.rfind(")") + 2:].split()
+        return after[19]
+    except (OSError, IndexError, ValueError):
+        pass
+    if sys.platform == "darwin":
+        try:
+            out = subprocess.run(
+                ["ps", "-o", "lstart=", "-p", str(pid)],
+                capture_output=True, text=True, timeout=5,
+            )
+            return out.stdout.strip() or None
+        except (OSError, subprocess.SubprocessError):
+            pass
+    return None
+
+
+def _write_pidfile(output_dir):
+    """Write ``<output_dir>/execute.pid`` so the Stop guard hook can tell this
+    executor is still alive.
+
+    The hook blocks the orchestrator from ending its turn (which would tear down
+    the session and kill this process before ``run_result.json`` is written)
+    while an ``execute.pid`` names a live process with no result beside it. The
+    file records the pid plus a process-creation marker so a reused pid can't be
+    mistaken for this run, and is removed at exit.
+    """
+    pid = os.getpid()
+    pidfile = output_dir / "execute.pid"
+    try:
+        with open(pidfile, "w", encoding="utf-8") as fh:
+            json.dump({"pid": pid, "create_time": _process_create_time(pid)}, fh)
+    except OSError:
+        return  # non-fatal: guard just won't see this run
+
+    import atexit
+    def _remove():
+        try:
+            os.remove(pidfile)
+        except OSError:
+            pass
+    atexit.register(_remove)
+
+
 def _setup_console_log(output_dir):
     """Mirror console output to ``<output_dir>/console.log`` and warn on a
     stdout redirect into the run directory.
@@ -249,6 +306,11 @@ def main():
     # need to redirect stdout with '>' (which blanks the background-command
     # viewer). The real stdout/stderr streams still receive everything.
     _setup_console_log(output_dir)
+
+    # Record our pid so the Stop guard hook can tell this executor is still
+    # alive and block the orchestrator from ending its turn (which would kill
+    # us before run_result.json is written).
+    _write_pidfile(output_dir)
 
     # Resolve skill args: CLI override > config > empty
     # Treat empty/whitespace-only strings as unset (normalize before fallback)

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -52,6 +52,13 @@ def _process_create_time(pid):
     determined. Must match the Stop guard hook's derivation
     (``scripts/eval_stop_guard.py``) for the reuse check to work, so the two
     implementations are kept identical.
+
+    The macOS ``ps`` env is pinned because ``lstart`` renders a *formatted
+    local* timestamp: the same pid yields "Fri Aug 21 12:34:22 2026" plainly,
+    "…16:34:22…" under ``TZ=UTC`` and "ven. 21 août…" under a French locale.
+    This process records the marker under the launching shell's env while the
+    hook re-derives it under Claude Code's, so any ``TZ``/``LC_TIME`` export
+    would make every live run look pid-reused and silently disable the guard.
     """
     try:
         with open("/proc/%d/stat" % pid, encoding="utf-8") as fh:
@@ -67,6 +74,7 @@ def _process_create_time(pid):
             out = subprocess.run(
                 ["ps", "-o", "lstart=", "-p", str(pid)],
                 capture_output=True, text=True, timeout=5,
+                env={"TZ": "UTC", "LC_ALL": "C", "PATH": "/bin:/usr/bin"},
             )
             return out.stdout.strip() or None
         except (OSError, subprocess.SubprocessError):
@@ -93,13 +101,28 @@ def _write_pidfile(output_dir):
     pid = os.getpid()
     pidfile = Path(output_dir) / "execute.pid"
     try:
-        with open(pidfile, "w", encoding="utf-8") as fh:
+        # O_NOFOLLOW: the guard reads this path with no-follow semantics, so the
+        # writer must match. Otherwise a symlink pre-planted at execute.pid by
+        # anyone with write access to the runs tree would be followed, letting
+        # this process truncate an arbitrary file it can write (CWE-59).
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(pidfile, flags, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump({"pid": pid, "create_time": _process_create_time(pid)}, fh)
     except OSError:
         return  # non-fatal: guard just won't see this run
     _PIDFILE_WRITTEN = True
 
     def _remove():
+        # Only reap our own pidfile. Run dirs get reused, so a straggler from a
+        # previous attempt dying late must not delete the live pidfile of the
+        # run that replaced it — that would blind the guard to an active run.
+        try:
+            with open(pidfile, encoding="utf-8") as fh:
+                if json.load(fh).get("pid") != pid:
+                    return
+        except (OSError, ValueError):
+            return
         try:
             os.remove(pidfile)
         except OSError:
@@ -129,7 +152,40 @@ def _early_pidfile(argv):
         directory = Path(out)
         directory.mkdir(parents=True, exist_ok=True)
         _write_pidfile(directory)
+        _warn_if_unscannable(directory)
     except OSError:
+        pass
+
+
+def _warn_if_unscannable(output_dir):
+    """Warn when the Stop guard will not find this run's pidfile.
+
+    The hook scans ``$AGENT_EVAL_RUNS_DIR`` (read from *its own* env, so an
+    inline ``AGENT_EVAL_RUNS_DIR=… python3 execute.py`` never reaches it) or
+    ``<cwd>/eval/runs``. An ``--output`` outside both — or a bounded-glob depth
+    of more than three below the root — leaves the run silently unguarded. Say
+    so once, rather than letting the protection be absent without a trace.
+    """
+    try:
+        target = output_dir.resolve()
+        roots = []
+        env_root = os.environ.get("AGENT_EVAL_RUNS_DIR")
+        if env_root:
+            roots.append(Path(env_root).resolve())
+        roots.append((Path.cwd() / "eval" / "runs").resolve())
+        for root in roots:
+            if target == root or root in target.parents:
+                if len(target.relative_to(root).parts) <= 3:
+                    return
+        print(
+            f"WARNING: {target} is not under a directory the eval Stop guard "
+            f"scans ({', '.join(str(r) for r in roots)}), so it will not "
+            f"protect this run from being killed mid-flight. Set "
+            f"AGENT_EVAL_RUNS_DIR in the environment the agent itself runs in, "
+            f"or place --output under one of those roots.",
+            file=sys.stderr,
+        )
+    except (OSError, ValueError):
         pass
 
 

--- a/skills/eval-run/scripts/execute.py
+++ b/skills/eval-run/scripts/execute.py
@@ -165,6 +165,11 @@ def _warn_if_unscannable(output_dir):
     ``<cwd>/eval/runs``. An ``--output`` outside both — or a bounded-glob depth
     of more than three below the root — leaves the run silently unguarded. Say
     so once, rather than letting the protection be absent without a trace.
+
+    False-negative: the roots are computed from *this process's* env and cwd,
+    which is exactly what diverges from the hook's view when the two disagree
+    (e.g. ``cd subproj && execute.py``). Nothing better is computable here —
+    execute.py cannot know the session's cwd.
     """
     try:
         target = output_dir.resolve()

--- a/tests/test_eval_stop_guard.py
+++ b/tests/test_eval_stop_guard.py
@@ -1,0 +1,205 @@
+"""Tests for the Stop guard hook (scripts/eval_stop_guard.py).
+
+The hook is stdlib-only and detects a live eval executor from the
+``execute.pid`` file that execute.py writes, so these tests use a real
+subprocess as the "live executor" rather than mocking process liveness.
+"""
+import ast
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+HOOK_PATH = REPO / "scripts" / "eval_stop_guard.py"
+EXECUTE_PATH = REPO / "skills" / "eval-run" / "scripts" / "execute.py"
+
+
+def _load_hook():
+    spec = importlib.util.spec_from_file_location("eval_stop_guard", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+guard = _load_hook()
+
+
+@pytest.fixture
+def live_proc():
+    """A real, still-running child process to stand in for a live executor."""
+    p = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+    try:
+        yield p
+    finally:
+        p.terminate()
+        try:
+            p.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            p.kill()
+
+
+def _make_run(runs_dir, name, pid, create_time, with_result=False):
+    d = runs_dir / name
+    d.mkdir(parents=True)
+    (d / "execute.pid").write_text(
+        json.dumps({"pid": pid, "create_time": create_time})
+    )
+    if with_result:
+        (d / "run_result.json").write_text("{}")
+    return d
+
+
+def test_live_executor_detected(tmp_path, monkeypatch, live_proc):
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    run_dir = _make_run(runs, "run-1", live_proc.pid, ct)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+
+    live = guard._live_eval_runs(str(tmp_path))
+    assert str(run_dir) in live
+
+
+def test_finished_run_not_live(tmp_path, monkeypatch, live_proc):
+    # Process is alive, but run_result.json exists -> already done.
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    _make_run(runs, "run-1", live_proc.pid, ct, with_result=True)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+
+    assert guard._live_eval_runs(str(tmp_path)) == []
+
+
+def test_dead_pid_not_live(tmp_path, monkeypatch):
+    # Spawn then reap a child so its pid is reliably gone.
+    p = subprocess.Popen([sys.executable, "-c", "pass"])
+    p.wait()
+    runs = tmp_path / "eval" / "runs"
+    _make_run(runs, "run-1", p.pid, None)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+
+    assert guard._live_eval_runs(str(tmp_path)) == []
+
+
+def test_pid_reuse_guarded(tmp_path, monkeypatch, live_proc):
+    # pid is alive, but the recorded create_time doesn't match -> treat as a
+    # reused pid belonging to an unrelated process, not this run.
+    runs = tmp_path / "eval" / "runs"
+    _make_run(runs, "run-1", live_proc.pid, "definitely-not-the-real-marker")
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+
+    # Only assert the guard fires where create_time is actually resolvable.
+    if guard._process_create_time(live_proc.pid) is not None:
+        assert guard._live_eval_runs(str(tmp_path)) == []
+
+
+def test_default_runs_dir(tmp_path, monkeypatch, live_proc):
+    # No AGENT_EVAL_RUNS_DIR -> falls back to <cwd>/eval/runs.
+    monkeypatch.delenv("AGENT_EVAL_RUNS_DIR", raising=False)
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    run_dir = _make_run(runs, "run-1", live_proc.pid, ct)
+
+    assert str(run_dir) in guard._live_eval_runs(str(tmp_path))
+
+
+def test_main_blocks_while_live(tmp_path, monkeypatch, capsys, live_proc):
+    monkeypatch.setattr(guard.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    _make_run(runs, "run-1", live_proc.pid, ct)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+    monkeypatch.setattr(
+        sys, "stdin",
+        io.StringIO(json.dumps({"session_id": "s1", "cwd": str(tmp_path)})),
+    )
+
+    rc = guard.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert json.loads(out)["decision"] == "block"
+
+
+def test_main_allows_when_no_run(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(guard.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(tmp_path / "eval" / "runs"))
+    monkeypatch.setattr(
+        sys, "stdin",
+        io.StringIO(json.dumps({"session_id": "s1", "cwd": str(tmp_path)})),
+    )
+
+    rc = guard.main()
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_main_disabled_env(tmp_path, monkeypatch, capsys, live_proc):
+    monkeypatch.setenv("AGENT_EVAL_STOP_GUARD", "0")
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    _make_run(runs, "run-1", live_proc.pid, ct)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+    monkeypatch.setattr(
+        sys, "stdin",
+        io.StringIO(json.dumps({"session_id": "s1", "cwd": str(tmp_path)})),
+    )
+
+    rc = guard.main()
+    assert rc == 0
+    assert capsys.readouterr().out == ""  # allowed despite a live run
+
+
+def test_main_escape_hatch(tmp_path, monkeypatch, capsys, live_proc):
+    monkeypatch.setattr(guard.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.setenv("AGENT_EVAL_STOP_GUARD_MAX_MIN", "60")
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    _make_run(runs, "run-1", live_proc.pid, ct)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+
+    # Pre-seed the first-block timestamp well past the ceiling.
+    state_path = guard._state_path("s1", str(tmp_path))
+    assert state_path is not None
+    Path(state_path).write_text(json.dumps({"first_block": time.time() - 7200}))
+
+    monkeypatch.setattr(
+        sys, "stdin",
+        io.StringIO(json.dumps({"session_id": "s1", "cwd": str(tmp_path)})),
+    )
+    rc = guard.main()
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""  # stop allowed
+    assert "escape hatch" in captured.err
+
+
+def _func_ast(path, name):
+    """AST dump of a function body minus its docstring (format-insensitive)."""
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            body = list(node.body)
+            if (body and isinstance(body[0], ast.Expr)
+                    and isinstance(getattr(body[0], "value", None), ast.Constant)
+                    and isinstance(body[0].value.value, str)):
+                body = body[1:]
+            return "\n".join(ast.dump(n) for n in body)
+    return None
+
+
+def test_process_create_time_matches_execute_py():
+    """The hook and execute.py must derive the create-time marker identically,
+    or the pid-reuse guard silently rejects every live run."""
+    hook_code = _func_ast(HOOK_PATH, "_process_create_time")
+    exec_code = _func_ast(EXECUTE_PATH, "_process_create_time")
+    assert hook_code is not None and exec_code is not None
+    assert hook_code == exec_code

--- a/tests/test_eval_stop_guard.py
+++ b/tests/test_eval_stop_guard.py
@@ -237,12 +237,114 @@ def test_escape_hatch_timer_resets_on_new_run(tmp_path, monkeypatch):
     """A chained eval must not inherit the previous run's first_block."""
     state = tmp_path / "state.json"
     old = time.time() - 7200
-    assert guard._first_block_ts(str(state), old, ["/runs/run-1"]) == old
+    assert guard._load_timer(str(state), old, ["/runs/run-1"]) == (old, False)
     # Same run set -> timer preserved.
-    assert guard._first_block_ts(str(state), time.time(), ["/runs/run-1"]) == old
+    assert guard._load_timer(str(state), time.time(), ["/runs/run-1"]) == (old, False)
     # Different run set -> timer restarts.
     now = time.time()
-    assert guard._first_block_ts(str(state), now, ["/runs/run-2"]) == now
+    assert guard._load_timer(str(state), now, ["/runs/run-2"]) == (now, False)
+
+
+def test_load_timer_fails_open_when_unpersistable(tmp_path):
+    """No session identity / unwritable state dir must yield the sentinel, not a
+    fresh `now` — every later Stop would otherwise see elapsed ~= 0 and block
+    forever."""
+    assert guard._load_timer(None, time.time(), []) is guard._PERSIST_FAILED
+    unwritable = tmp_path / "nonexistent-dir" / "state.json"
+    assert guard._load_timer(str(unwritable), time.time(), []) is guard._PERSIST_FAILED
+
+
+@pytest.mark.parametrize("bad_pid", [0, -1, -12345, True, False, "123", 1.5, None])
+def test_invalid_pids_rejected(tmp_path, monkeypatch, bad_pid):
+    """os.kill() overloads non-positive pids into broadcasts that always
+    'succeed', and bool is an int subclass — either would wedge the session."""
+    runs = tmp_path / "eval" / "runs"
+    _make_run(runs, "run-1", bad_pid, None)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+
+    assert guard._valid_pid(bad_pid) is False
+    assert guard._live_eval_runs(str(tmp_path)) == []
+
+
+def test_kill_broadcast_pids_would_report_alive():
+    """Pins *why* _valid_pid exists: these pids pass a naive liveness probe."""
+    assert guard._pid_alive(0) is False       # 0 = caller's process group
+    assert guard._pid_alive(-1) is False      # -1 = every permitted process
+    assert guard._pid_alive(True) is False    # bool -> pid 1 (init), always up
+
+
+def test_windows_guard_disabled(monkeypatch):
+    """os.kill(pid, 0) on Windows calls TerminateProcess — it would kill the
+    executor it is probing, causing the very failure this hook prevents."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delenv("AGENT_EVAL_STOP_GUARD", raising=False)
+    assert guard._guard_enabled() is False
+    # Not even an explicit opt-in may enable it there.
+    monkeypatch.setenv("AGENT_EVAL_STOP_GUARD", "1")
+    assert guard._guard_enabled() is False
+
+
+def test_glob_metachars_in_path(tmp_path, monkeypatch, live_proc):
+    """A runs root containing glob metacharacters (CI paths like
+    'linux[py311]') must not silently match nothing."""
+    runs = tmp_path / "linux[py311]" / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    run_dir = _make_run(runs, "my-eval/run-1", live_proc.pid, ct)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+
+    assert guard._live_eval_runs(str(tmp_path)) == [str(run_dir)]
+
+
+def test_stale_result_in_reused_dir_still_live(tmp_path, monkeypatch, live_proc):
+    """A run_result.json left by a previous attempt in a reused run dir must
+    not mark the new executor finished."""
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    run_dir = _make_run(runs, "run-1", live_proc.pid, ct)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+
+    result = run_dir / "run_result.json"
+    result.write_text("{}")
+    old = time.time() - 3600           # result predates the pidfile
+    os.utime(result, (old, old))
+    assert guard._live_eval_runs(str(tmp_path)) == [str(run_dir)]
+
+    # A result written *after* the pidfile is this run's own -> finished.
+    now = time.time() + 10
+    os.utime(result, (now, now))
+    assert guard._live_eval_runs(str(tmp_path)) == []
+
+
+def test_escape_hatch_does_not_rearm(tmp_path, monkeypatch, capsys, live_proc):
+    """Once the ceiling is hit, later Stops must allow immediately rather than
+    opening a fresh full-length window on the same wedged run."""
+    monkeypatch.setattr(guard.time, "sleep", lambda *_a, **_k: None)
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.setenv("AGENT_EVAL_STOP_GUARD_MAX_MIN", "60")
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    _make_run(runs, "run-1", live_proc.pid, ct)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+
+    state_path = guard._state_path("s1", str(tmp_path))
+    runs_key = sorted(guard._live_eval_runs(str(tmp_path)))
+    guard._write_timer(state_path, {"first_block": time.time() - 7200,
+                                    "runs": runs_key})
+
+    def _stop():
+        monkeypatch.setattr(sys, "stdin", io.StringIO(
+            json.dumps({"session_id": "s1", "cwd": str(tmp_path)})))
+        rc = guard.main()
+        return rc, capsys.readouterr()
+
+    rc, first = _stop()
+    assert rc == 0 and first.out == "" and "escape hatch" in first.err
+
+    # The wedged run is still live; the next Stop must NOT block again.
+    rc, second = _stop()
+    assert rc == 0
+    assert second.out == "", "guard re-armed a fresh window after escaping"
+    assert "already tripped" in second.err
 
 
 def test_pidfile_write_precedes_heavy_imports():

--- a/tests/test_eval_stop_guard.py
+++ b/tests/test_eval_stop_guard.py
@@ -7,6 +7,7 @@ subprocess as the "live executor" rather than mocking process liveness.
 import ast
 import importlib.util
 import io
+import os
 import json
 import subprocess
 import sys
@@ -166,10 +167,15 @@ def test_main_escape_hatch(tmp_path, monkeypatch, capsys, live_proc):
     _make_run(runs, "run-1", live_proc.pid, ct)
     monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
 
-    # Pre-seed the first-block timestamp well past the ceiling.
+    # Pre-seed the first-block timestamp well past the ceiling, against the
+    # same run set the hook will see (a differing set resets the timer).
     state_path = guard._state_path("s1", str(tmp_path))
     assert state_path is not None
-    Path(state_path).write_text(json.dumps({"first_block": time.time() - 7200}))
+    runs_key = sorted(guard._live_eval_runs(str(tmp_path)))
+    assert runs_key, "fixture must present a live run"
+    Path(state_path).write_text(
+        json.dumps({"first_block": time.time() - 7200, "runs": runs_key})
+    )
 
     monkeypatch.setattr(
         sys, "stdin",
@@ -180,6 +186,115 @@ def test_main_escape_hatch(tmp_path, monkeypatch, capsys, live_proc):
     assert rc == 0
     assert captured.out == ""  # stop allowed
     assert "escape hatch" in captured.err
+
+
+def test_stale_pidfile_ignored(tmp_path, monkeypatch, live_proc):
+    """A pidfile older than the age bound is abandoned even if the pid lives.
+
+    Backstops the platforms where no create_time marker is obtainable and the
+    pid-reuse check is therefore inert.
+    """
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    run_dir = _make_run(runs, "run-1", live_proc.pid, ct)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+    assert guard._live_eval_runs(str(tmp_path))  # fresh -> live
+
+    old = time.time() - (guard.MAX_PIDFILE_AGE_S + 3600)
+    os.utime(run_dir / "execute.pid", (old, old))
+    assert guard._live_eval_runs(str(tmp_path)) == []
+
+
+def test_pidfile_found_at_nested_depths(tmp_path, monkeypatch, live_proc):
+    """Bounded-depth globs must still cover the real layout
+    (<runs>/<eval-name>/<run-id>/execute.pid) and shallower variants."""
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+    expected = set()
+    for name in ("run-1", "my-eval/run-2", "a/b/run-3"):
+        expected.add(str(_make_run(runs, name, live_proc.pid, ct)))
+
+    assert set(guard._live_eval_runs(str(tmp_path))) == expected
+
+
+def test_no_recursive_glob_walk(tmp_path, monkeypatch, live_proc):
+    """The scan must not walk deep artifact trees under a run dir."""
+    runs = tmp_path / "eval" / "runs"
+    ct = guard._process_create_time(live_proc.pid)
+    run_dir = _make_run(runs, "my-eval/run-1", live_proc.pid, ct)
+    # A decoy far below the bounded depth: a recursive walk would surface it.
+    deep = run_dir / "cases" / "case-1" / "subagents" / "x" / "y"
+    deep.mkdir(parents=True)
+    (deep / "execute.pid").write_text(json.dumps({"pid": live_proc.pid,
+                                                  "create_time": ct}))
+    monkeypatch.setenv("AGENT_EVAL_RUNS_DIR", str(runs))
+
+    assert guard._live_eval_runs(str(tmp_path)) == [str(run_dir)]
+
+
+def test_escape_hatch_timer_resets_on_new_run(tmp_path, monkeypatch):
+    """A chained eval must not inherit the previous run's first_block."""
+    state = tmp_path / "state.json"
+    old = time.time() - 7200
+    assert guard._first_block_ts(str(state), old, ["/runs/run-1"]) == old
+    # Same run set -> timer preserved.
+    assert guard._first_block_ts(str(state), time.time(), ["/runs/run-1"]) == old
+    # Different run set -> timer restarts.
+    now = time.time()
+    assert guard._first_block_ts(str(state), now, ["/runs/run-2"]) == now
+
+
+def test_pidfile_write_precedes_heavy_imports():
+    """The early write must stay ahead of the agent_eval imports.
+
+    The window this closes is the race the guard exists for: the orchestrator
+    can end its turn immediately after launching execute.py, and the hook is
+    blind until execute.pid lands. Module import dominates startup, so letting
+    the write drift below those imports would silently reopen the hole.
+    """
+    tree = ast.parse(EXECUTE_PATH.read_text())
+    early_call = min(
+        (n.lineno for n in ast.walk(tree)
+         if isinstance(n, ast.Call)
+         and isinstance(n.func, ast.Name)
+         and n.func.id == "_early_pidfile"),
+        default=None,
+    )
+    heavy_import = min(
+        (n.lineno for n in ast.walk(tree)
+         if isinstance(n, ast.ImportFrom)
+         and (n.module or "").startswith("agent_eval.")
+         and n.module != "agent_eval._bootstrap"),
+        default=None,
+    )
+    assert early_call is not None, "_early_pidfile() call disappeared"
+    assert heavy_import is not None
+    assert early_call < heavy_import, (
+        f"_early_pidfile() at line {early_call} runs after the agent_eval "
+        f"import at line {heavy_import}; the Stop guard is blind for the "
+        f"duration of those imports."
+    )
+
+
+@pytest.mark.parametrize("argv,expected", [
+    (["--output", "RUNDIR", "--config", "x.yaml"], True),
+    (["--config", "x.yaml", "--output=RUNDIR"], True),
+    (["--config", "x.yaml"], False),          # no --output -> no write
+    (["--output"], False),                    # dangling flag -> no crash
+])
+def test_early_pidfile_argv_scrape(tmp_path, monkeypatch, argv, expected):
+    """--output is scraped by hand, so cover both spellings and the misses."""
+    import execute
+
+    monkeypatch.setattr(execute, "_PIDFILE_WRITTEN", False)
+    target = tmp_path / "rundir"
+    argv = [a.replace("RUNDIR", str(target)) for a in argv]
+
+    execute._early_pidfile(argv)
+    assert (target / "execute.pid").exists() is expected
+    if expected:
+        assert json.loads((target / "execute.pid").read_text())["pid"] == os.getpid()
 
 
 def _func_ast(path, name):


### PR DESCRIPTION
## Summary

In headless / print mode (`claude -p`, the Agent SDK) the eval-run orchestrator sometimes launches `execute.py` with `run_in_background` and then ends its turn immediately. The session tears down, the background task is killed ~5s later before it writes `run_result.json`, and the empty result is reported as green. This has recurred on the CI `eval-payload-analysis` job even under 1.40.x, whose bg-kill handling only relabels per-case kills and cannot help when the whole orchestrator dies before any `run_result.json` exists — and it can surface in any headless run, not just CI.

## What this does

Adds a plugin-level `Stop` hook (`scripts/eval_stop_guard.py`) that blocks the agent from ending its turn while the session still has a live background task. It reconstructs the live-task set from the session transcript (`background_tasks_changed` / `task_started` / `task_updated` / `task_notification`), so it is scoped to this session and does not false-positive on other concurrent `execute.py` runs the way a host-wide `pgrep` would.

- **Enabled by default everywhere.** The failure is specific to headless mode, but Claude Code exposes no reliable signal (no env var, no Stop-payload field) to detect headless vs interactive, so the guard cannot gate on mode. In interactive sessions background tasks persist across turns, so a spurious block is only a nuisance (interrupt, or set `AGENT_EVAL_STOP_GUARD=0`).
- **Escape hatch.** The hook records when it first blocked and, once more than `AGENT_EVAL_STOP_GUARD_MAX_MIN` (default 180) minutes have elapsed, allows the Stop and warns loudly on stderr, so a genuinely stuck task can never hang the session indefinitely.
- Progress sniffing is deliberately not used — at high effort a single case can run ~30 min with no console output, so "quiet" is not "stuck"; only a bounded wall-clock ceiling is free of false positives.
- Fails open when the transcript is unreadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a safeguard that prevents stopping while active evaluation runs are still in progress.
  - Added guidance to poll the evaluation output when stopping is blocked.
  - Added configurable opt-out and time-based escape-hatch options.
  - Improved detection of active runs, including stale or reused process identifiers.
  - Added fail-open behavior when run information is invalid or unavailable.

- **Chores**
  - Reverted the plugin version to 1.40.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->