### PR TITLE
fix(config): stop warning that the pairwise judge has no score_range

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -1349,8 +1349,11 @@ class EvalConfig:
             # treats anything that is not "bool" as numeric — so the judge that
             # most needs this warning is the one that declares neither field,
             # and gating on ("int", "float") alone never reached it.
+            # The judge named "pairwise" is exempt: score.py routes it past
+            # the numeric path by that name into the A/B/tie verdict flow, so
+            # no scale — declared or defaulted — is ever applied to it.
             if (jc.feedback_type in ("int", "float", "") and not jc.score_range
-                    and not jc.builtin
+                    and not jc.builtin and jc.name != "pairwise"
                     and (jc.prompt or jc.prompt_file or jc.llm_rubric)):
                 import warnings
                 warnings.warn(

--- a/skills/eval-analyze/references/eval-yaml-template.md
+++ b/skills/eval-analyze/references/eval-yaml-template.md
@@ -376,6 +376,8 @@ judges:
   #     threshold: 0.8
 
   # Pairwise comparison (used with score.py pairwise --baseline <id>)
+  # No score_range here: the judge named "pairwise" returns A/B/tie verdicts,
+  # not a numeric score — score.py routes it by this reserved name.
   # - name: pairwise
   #   description: Compare two runs and pick the better output
   #   prompt_file: eval/prompts/comparison-judge.md

--- a/tests/test_config_score_scale.py
+++ b/tests/test_config_score_scale.py
@@ -146,6 +146,23 @@ def test_inline_check_without_a_range_is_silent(tmp_path):
                           "check: \"return (7, 'r')\"}\n")
 
 
+def test_the_pairwise_judge_without_a_range_is_silent(tmp_path):
+    """score.py routes the judge named "pairwise" into the A/B/tie verdict
+    flow by name — no numeric scale ever applies, so warning about a missing
+    one steered configs into declaring a range that is never read."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _config(tmp_path, "  - {name: pairwise, prompt: 'which is better?'}\n")
+
+
+def test_a_numeric_judge_merely_mentioning_pairwise_still_warns(tmp_path):
+    """The exemption is by the exact reserved name, matching score.py."""
+    with pytest.warns(UserWarning, match="no 'score_range'"):
+        _config(tmp_path, "  - {name: pairwise_quality, prompt: 'p'}\n")
+
+
 class TestBuiltinJudgeKind:
     """Resolution has to work without `discover()`, which execs every Python
     judge module — far too much to do to validate a config."""


### PR DESCRIPTION
## Problem

The numeric-judge load warning (issue #182) fires for any prompt-based judge that declares no `score_range`:

```
UserWarning: Judge 'pairwise': numeric judge has no 'score_range', so it is scored on the unenforced [1, 5] default — declare one to have the returned value checked
```

But the judge named `pairwise` is never scored numerically: `score.py` skips it by that reserved name in the judge-building loop and routes it into the A/B/tie verdict flow (`preferred` verdicts aggregated into wins/ties/win_rate). No scale — declared or defaulted — is ever applied to it, so the warning is a false positive that steers configs into declaring a range that is never read. The `eval-yaml-template.md` pairwise example itself triggers it (opendatahub-io/rfe-creator#164 is a downstream config that just cargo-culted a `score_range: [1, 5]` onto its pairwise judges to silence this; it can drop those lines once this lands).

## Change

- `config.py`: exempt `jc.name == "pairwise"` from the missing-`score_range` warning — the same by-name rule `score.py` uses, with a comment tying the two together.
- `eval-yaml-template.md`: note on the pairwise example explaining why it declares no range.
- Tests: `pairwise` without a range loads silently (fails if the exemption is removed — mutation-checked); a numeric judge merely *named like* pairwise (`pairwise_quality`) still warns, pinning the exemption to the exact reserved name.

`tests/test_config_score_scale.py` + `tests/test_config.py`: 69 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected judge configuration warnings so the pairwise A/B/tie evaluator is not incorrectly treated as a numeric scorer.
  * Numeric judges with similar names continue to receive appropriate score-range warnings.

* **Documentation**
  * Clarified that pairwise evaluation uses A/B/tie results and does not require a numeric score range.

* **Tests**
  * Added coverage for pairwise and similarly named numeric judge configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->