### PR TITLE
materialize in-repo workspace.files symlinks

### DIFF
--- a/skills/eval-run/scripts/workspace_files.py
+++ b/skills/eval-run/scripts/workspace_files.py
@@ -17,13 +17,15 @@ def _copy_input_files(case_dir, workspace, config):
 
     Iterates ``config.dataset.workspace.files`` and copies each listed
     path from *case_dir* into *workspace*, preserving relative structure.
-    Directory entries are copied recursively; nested symlinks are skipped.
+    Directory entries are copied recursively; nested symlinks are skipped
+    with a warning.
 
-    A *listed* file symlink whose resolved target stays inside the project
-    root or a configured ``runner.plugin_dirs`` entry is materialized as a
-    regular file (the live SKILL.md companion-file pattern). Listed
-    directory symlinks, escaping/dangling/looping links, and nested
-    (unlisted) symlinks are skipped with a warning (CWE-59).
+    A *listed* file symlink whose resolved target is in the current case,
+    a configured ``runner.plugin_dirs`` entry, or a project companion path
+    outside the sibling-case dataset directory is materialized as a regular
+    file (the live SKILL.md companion-file pattern). Listed directory
+    symlinks, escaping/dangling/looping links, and nested (unlisted)
+    symlinks are skipped with a warning (CWE-59).
     """
     ds = getattr(config, "dataset", None)
     if ds is None:
@@ -36,7 +38,8 @@ def _copy_input_files(case_dir, workspace, config):
         return
 
     case_root = case_dir.resolve()
-    allowed_roots = _allowed_roots(config, case_root)
+    plugin_roots = _plugin_roots(config)
+    project = Path(getattr(config, "project_root", Path.cwd())).resolve()
     for entry in files:
         rel = Path(entry)
         if rel.is_absolute() or ".." in rel.parts:
@@ -54,28 +57,29 @@ def _copy_input_files(case_dir, workspace, config):
             if target.is_dir():
                 _warn_skip(display, "directory symlink is not copied")
             elif target.is_file():
-                if not _is_contained(target, allowed_roots):
+                if not _is_listed_symlink_target_allowed(
+                    target, case_root, plugin_roots, project
+                ):
                     _warn_skip(
                         display,
-                        f"resolves outside project/plugin: {target}",
+                        f"resolves outside allowed companion paths: {target}",
                     )
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(target, dest)
         elif src.is_dir():
-            _copy_tree(src, dest)
+            _copy_tree(src, dest, display_prefix=display)
         elif src.is_file():
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dest)
 
 
-def _allowed_roots(config, case_root):
-    """Roots a listed file-symlink target may resolve into."""
-    roots = [case_root]
+def _plugin_roots(config):
+    """Validated ``runner.plugin_dirs`` roots for symlink targets."""
     project = Path(getattr(config, "project_root", Path.cwd())).resolve()
-    roots.append(project)
     runner = getattr(config, "runner", None)
     config_dir = getattr(config, "config_dir", None)
+    roots = []
     for configured in getattr(runner, "plugin_dirs", None) or []:
         try:
             roots.append(
@@ -86,8 +90,19 @@ def _allowed_roots(config, case_root):
     return roots
 
 
-def _is_contained(path, roots):
-    return any(path.is_relative_to(root) for root in roots)
+def _is_listed_symlink_target_allowed(target, case_root, plugin_roots, project):
+    """Whether a listed file-symlink target may be copied into the workspace."""
+    if target.is_relative_to(case_root):
+        return True
+    if any(target.is_relative_to(root) for root in plugin_roots):
+        return True
+    if not target.is_relative_to(project):
+        return False
+    # Project companions (e.g. skills/) are allowed, but not sibling cases.
+    cases_dir = case_root.parent
+    if target.is_relative_to(cases_dir) and not target.is_relative_to(case_root):
+        return False
+    return True
 
 
 def _warn_skip(display, reason):
@@ -97,18 +112,25 @@ def _warn_skip(display, reason):
     )
 
 
-def _copy_tree(src_dir, dest_dir):
-    """Recursively copy a directory, skipping nested symlinks."""
+def _copy_tree(src_dir, dest_dir, *, display_prefix=""):
+    """Recursively copy a directory, skipping nested symlinks with a warning."""
     resolved_root = src_dir.resolve()
     for item in src_dir.rglob("*"):
-        if item.is_symlink() or not item.is_file():
+        rel = item.relative_to(src_dir)
+        display = f"{display_prefix}/{rel}" if display_prefix else str(rel)
+        if item.is_symlink():
+            _warn_skip(display, "nested symlink is not copied")
+            continue
+        if not item.is_file():
             continue
         try:
             resolved = item.resolve(strict=True)
         except (OSError, RuntimeError):
+            _warn_skip(display, "could not resolve nested file")
             continue
         if not resolved.is_relative_to(resolved_root):
+            _warn_skip(display, "nested file resolves outside its directory")
             continue
-        dest = dest_dir / item.relative_to(src_dir)
+        dest = dest_dir / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(item, dest)

--- a/skills/eval-run/scripts/workspace_files.py
+++ b/skills/eval-run/scripts/workspace_files.py
@@ -1,10 +1,15 @@
 """Helpers for copying input files into eval workspaces.
 
-Extracted so tests can import without triggering agent_eval._bootstrap
-side effects from workspace.py.
+Extracted so tests can import the copier without pulling in workspace.py.
 """
 
+import agent_eval._bootstrap  # noqa: F401 — auto-activate venv
+
 import shutil
+import sys
+from pathlib import Path
+
+from agent_eval.config import resolve_plugin_path
 
 
 def _copy_input_files(case_dir, workspace, config):
@@ -12,8 +17,13 @@ def _copy_input_files(case_dir, workspace, config):
 
     Iterates ``config.dataset.workspace.files`` and copies each listed
     path from *case_dir* into *workspace*, preserving relative structure.
-    Directory entries are copied recursively.  Symlinks are skipped to
-    prevent escaping the case directory.
+    Directory entries are copied recursively; nested symlinks are skipped.
+
+    A *listed* file symlink whose resolved target stays inside the project
+    root or a configured ``runner.plugin_dirs`` entry is materialized as a
+    regular file (the live SKILL.md companion-file pattern). Listed
+    directory symlinks, escaping/dangling/looping links, and nested
+    (unlisted) symlinks are skipped with a warning (CWE-59).
     """
     ds = getattr(config, "dataset", None)
     if ds is None:
@@ -26,32 +36,79 @@ def _copy_input_files(case_dir, workspace, config):
         return
 
     case_root = case_dir.resolve()
+    allowed_roots = _allowed_roots(config, case_root)
     for entry in files:
-        src = case_dir / entry
-        if src.is_symlink():
+        rel = Path(entry)
+        if rel.is_absolute() or ".." in rel.parts:
+            _warn_skip(str(entry), "escapes the case directory")
             continue
-        if src.is_dir():
-            _copy_tree(src, case_dir, workspace, case_root)
-        elif src.is_file():
-            if not src.resolve().is_relative_to(case_root):
+        src = case_dir / rel
+        dest = workspace / rel
+        display = str(rel)
+        if src.is_symlink():
+            try:
+                target = src.resolve(strict=True)
+            except (OSError, RuntimeError):
+                _warn_skip(display, "dangling or looping symlink")
                 continue
-            rel = src.relative_to(case_dir)
-            dst = workspace / rel
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(src, dst)
+            if target.is_dir():
+                _warn_skip(display, "directory symlink is not copied")
+            elif target.is_file():
+                if not _is_contained(target, allowed_roots):
+                    _warn_skip(
+                        display,
+                        f"resolves outside project/plugin: {target}",
+                    )
+                else:
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(target, dest)
+        elif src.is_dir():
+            _copy_tree(src, dest)
+        elif src.is_file():
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
 
 
-def _copy_tree(src_dir, case_dir, workspace, case_root):
-    """Recursively copy a directory, skipping symlinks."""
+def _allowed_roots(config, case_root):
+    """Roots a listed file-symlink target may resolve into."""
+    roots = [case_root]
+    project = Path(getattr(config, "project_root", Path.cwd())).resolve()
+    roots.append(project)
+    runner = getattr(config, "runner", None)
+    config_dir = getattr(config, "config_dir", None)
+    for configured in getattr(runner, "plugin_dirs", None) or []:
+        try:
+            roots.append(
+                resolve_plugin_path(configured, project, config_dir).resolve()
+            )
+        except (ValueError, OSError, TypeError):
+            continue
+    return roots
+
+
+def _is_contained(path, roots):
+    return any(path.is_relative_to(root) for root in roots)
+
+
+def _warn_skip(display, reason):
+    print(
+        f"WARNING: skipping workspace.files path {display}: {reason}",
+        file=sys.stderr,
+    )
+
+
+def _copy_tree(src_dir, dest_dir):
+    """Recursively copy a directory, skipping nested symlinks."""
     resolved_root = src_dir.resolve()
     for item in src_dir.rglob("*"):
-        if item.is_symlink():
+        if item.is_symlink() or not item.is_file():
             continue
-        if not item.is_file():
+        try:
+            resolved = item.resolve(strict=True)
+        except (OSError, RuntimeError):
             continue
-        if not item.resolve().is_relative_to(resolved_root):
+        if not resolved.is_relative_to(resolved_root):
             continue
-        rel = item.relative_to(case_dir)
-        dst = workspace / rel
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(item, dst)
+        dest = dest_dir / item.relative_to(src_dir)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, dest)

--- a/tests/test_input_files.py
+++ b/tests/test_input_files.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from agent_eval.config import DatasetConfig, EvalConfig, WorkspaceConfig
+from agent_eval.config import DatasetConfig, EvalConfig, RunnerConfig, WorkspaceConfig
 from workspace_files import _copy_input_files
 
 
@@ -202,17 +202,21 @@ def test_copy_workspace_files_noop_when_path_missing(tmp_path):
     assert list(workspace.iterdir()) == []
 
 
-def test_copy_workspace_files_skips_symlinks(tmp_path):
-    """Symlinks in workspace file entries are not followed."""
-    case_dir = tmp_path / "cases" / "case-001"
-    (case_dir / "src").mkdir(parents=True)
-    (case_dir / "src" / "real.py").write_text("real")
-
+def test_copy_workspace_files_skips_nested_symlinks(tmp_path, monkeypatch):
+    """Nested (unlisted) symlinks inside a copied directory are skipped."""
+    project = tmp_path / "project"
     outside = tmp_path / "outside"
+    project.mkdir()
     outside.mkdir()
     (outside / "secret.txt").write_text("secret")
+    monkeypatch.chdir(project)
 
+    case_dir = project / "cases" / "case-001"
+    (case_dir / "src").mkdir(parents=True)
+    (case_dir / "src" / "real.py").write_text("real")
     os.symlink(outside / "secret.txt", case_dir / "src" / "link.txt")
+    (project / "live.md").write_text("live")
+    (case_dir / "src" / "nested.md").symlink_to(project / "live.md")
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -226,17 +230,52 @@ def test_copy_workspace_files_skips_symlinks(tmp_path):
 
     assert (workspace / "src" / "real.py").read_text() == "real"
     assert not os.path.lexists(workspace / "src" / "link.txt")
+    assert not os.path.lexists(workspace / "src" / "nested.md")
 
 
-def test_copy_workspace_files_skips_symlinked_entry(tmp_path):
-    """A top-level symlinked directory entry is skipped entirely."""
-    case_dir = tmp_path / "cases" / "case-001"
+def test_copy_workspace_files_skips_listed_dir_symlink(
+    tmp_path, monkeypatch, capsys,
+):
+    """A listed directory symlink is not walked (would copy the whole repo)."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "secret.env").write_text("noleak")
+    monkeypatch.chdir(project)
+
+    case_dir = project / "cases" / "case-001"
     case_dir.mkdir(parents=True)
+    (case_dir / "peek").symlink_to(project)
 
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(workspace=WorkspaceConfig(files=["peek"])),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert not os.path.lexists(workspace / "peek")
+    assert list(workspace.iterdir()) == []
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "peek" in err
+
+
+def test_copy_workspace_files_skips_external_symlinked_entry(
+    tmp_path, monkeypatch, capsys,
+):
+    """A top-level symlink escaping the project is skipped, with a warning."""
+    project = tmp_path / "project"
     outside = tmp_path / "outside"
+    project.mkdir()
     outside.mkdir()
     (outside / "secret.txt").write_text("secret")
+    monkeypatch.chdir(project)
 
+    case_dir = project / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
     os.symlink(outside, case_dir / "evil")
 
     workspace = tmp_path / "workspace"
@@ -251,3 +290,229 @@ def test_copy_workspace_files_skips_symlinked_entry(tmp_path):
 
     assert not os.path.lexists(workspace / "evil")
     assert list(workspace.iterdir()) == []
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "evil" in err
+
+
+def test_copy_workspace_files_materializes_internal_symlink(tmp_path, monkeypatch):
+    """A case symlink to a live SKILL.md under the project is copied as a file."""
+    project = tmp_path / "project"
+    skill = project / "skills" / "address-ci-failures"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# live skill\n")
+    monkeypatch.chdir(project)
+
+    case_dir = project / "eval" / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    (case_dir / "triage-skill.md").symlink_to(
+        "../../../skills/address-ci-failures/SKILL.md"
+    )
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(
+            workspace=WorkspaceConfig(files=["triage-skill.md"]),
+        ),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    dest = workspace / "triage-skill.md"
+    assert dest.is_file()
+    assert not dest.is_symlink()
+    assert dest.read_text() == "# live skill\n"
+
+
+def test_copy_workspace_files_copies_file_resolved_outside_case(
+    tmp_path, monkeypatch,
+):
+    """A listed file may resolve outside the case if it stays in the project."""
+    project = tmp_path / "project"
+    live = project / "skills" / "foo"
+    live.mkdir(parents=True)
+    (live / "SKILL.md").write_text("live")
+    monkeypatch.chdir(project)
+
+    case_dir = project / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    (case_dir / "docs").symlink_to(live)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(
+            workspace=WorkspaceConfig(files=["docs/SKILL.md"]),
+        ),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    dest = workspace / "docs" / "SKILL.md"
+    assert dest.is_file()
+    assert not dest.is_symlink()
+    assert dest.read_text() == "live"
+
+
+def test_copy_workspace_files_materializes_plugin_symlink(
+    tmp_path, monkeypatch,
+):
+    """A symlink into a configured plugin dir is materialized even off-project."""
+    consumer = tmp_path / "consumer"
+    plugin = tmp_path / "plugin"
+    consumer.mkdir()
+    skill = plugin / "skills" / "address-ci-failures"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# from plugin\n")
+    monkeypatch.chdir(consumer)
+
+    case_dir = consumer / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    (case_dir / "triage-skill.md").symlink_to(skill / "SKILL.md")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        runner=RunnerConfig(plugin_dirs=[str(plugin)]),
+        dataset=DatasetConfig(
+            workspace=WorkspaceConfig(files=["triage-skill.md"]),
+        ),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    dest = workspace / "triage-skill.md"
+    assert dest.is_file()
+    assert not dest.is_symlink()
+    assert dest.read_text() == "# from plugin\n"
+
+
+def test_copy_workspace_files_plugin_symlink_rejected_without_plugin_dirs(
+    tmp_path, monkeypatch, capsys,
+):
+    """The same plugin symlink is skipped when plugin_dirs is not configured."""
+    consumer = tmp_path / "consumer"
+    plugin = tmp_path / "plugin"
+    consumer.mkdir()
+    skill = plugin / "skills" / "address-ci-failures"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# from plugin\n")
+    monkeypatch.chdir(consumer)
+
+    case_dir = consumer / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    (case_dir / "triage-skill.md").symlink_to(skill / "SKILL.md")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(
+            workspace=WorkspaceConfig(files=["triage-skill.md"]),
+        ),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert not os.path.lexists(workspace / "triage-skill.md")
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "triage-skill.md" in err
+
+
+def test_copy_workspace_files_warns_on_dangling_symlink(
+    tmp_path, monkeypatch, capsys,
+):
+    """A dangling symlink is skipped with a warning rather than silently."""
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    case_dir = project / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    (case_dir / "gone.md").symlink_to("missing.md")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(workspace=WorkspaceConfig(files=["gone.md"])),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert list(workspace.iterdir()) == []
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "gone.md" in err
+
+
+def test_copy_workspace_files_skips_listed_dir_symlink_inside_project(
+    tmp_path, monkeypatch, capsys,
+):
+    """A contained directory symlink is skipped; only listed file links copy."""
+    project = tmp_path / "project"
+    real = project / "lib"
+    real.mkdir(parents=True)
+    (real / "util.py").write_text("x")
+    monkeypatch.chdir(project)
+
+    case_dir = project / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    (case_dir / "lib").symlink_to(real)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(workspace=WorkspaceConfig(files=["lib"])),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert not os.path.lexists(workspace / "lib")
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "lib" in err
+
+
+def test_copy_workspace_files_rejects_lexical_escape(
+    tmp_path, monkeypatch, capsys,
+):
+    """A listed path with .. must not write outside the workspace."""
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    leaked = project / "cases" / "leaked.md"
+    leaked.parent.mkdir(parents=True)
+    leaked.write_text("leaked")
+
+    case_dir = project / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(
+            workspace=WorkspaceConfig(files=["../leaked.md"]),
+        ),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert list(workspace.iterdir()) == []
+    assert not (tmp_path / "leaked.md").exists()
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "leaked.md" in err

--- a/tests/test_input_files.py
+++ b/tests/test_input_files.py
@@ -202,7 +202,7 @@ def test_copy_workspace_files_noop_when_path_missing(tmp_path):
     assert list(workspace.iterdir()) == []
 
 
-def test_copy_workspace_files_skips_nested_symlinks(tmp_path, monkeypatch):
+def test_copy_workspace_files_skips_nested_symlinks(tmp_path, monkeypatch, capsys):
     """Nested (unlisted) symlinks inside a copied directory are skipped."""
     project = tmp_path / "project"
     outside = tmp_path / "outside"
@@ -231,6 +231,42 @@ def test_copy_workspace_files_skips_nested_symlinks(tmp_path, monkeypatch):
     assert (workspace / "src" / "real.py").read_text() == "real"
     assert not os.path.lexists(workspace / "src" / "link.txt")
     assert not os.path.lexists(workspace / "src" / "nested.md")
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "link.txt" in err
+    assert "nested.md" in err
+
+
+def test_copy_workspace_files_skips_sibling_case_symlink(
+    tmp_path, monkeypatch, capsys,
+):
+    """A listed symlink to another case's answers.yaml is not copied."""
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    case_002 = project / "cases" / "case-002"
+    case_002.mkdir(parents=True)
+    (case_002 / "answers.yaml").write_text("gold: secret\n")
+
+    case_dir = project / "cases" / "case-001"
+    case_dir.mkdir(parents=True)
+    (case_dir / "peek.yaml").symlink_to("../case-002/answers.yaml")
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    config = EvalConfig(
+        name="t",
+        skill="s",
+        dataset=DatasetConfig(workspace=WorkspaceConfig(files=["peek.yaml"])),
+    )
+    _copy_input_files(case_dir, workspace, config)
+
+    assert not os.path.lexists(workspace / "peek.yaml")
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "peek.yaml" in err
 
 
 def test_copy_workspace_files_skips_listed_dir_symlink(

--- a/website/reference/config/dataset.md
+++ b/website/reference/config/dataset.md
@@ -102,7 +102,7 @@ Behavior (`workspace_files._copy_input_files`):
 | --- | --- |
 | Directory | Copied recursively, preserving relative structure. Nested symlinks are skipped. |
 | File | Copied as a single file at its relative path. |
-| Listed file symlink | Materialized as a regular file if the resolved target is under the project root or a configured `runner.plugin_dirs` entry; otherwise skipped with a warning (CWE-59). |
+| Listed file symlink | Materialized as a regular file when the resolved target is in the current case, a configured `runner.plugin_dirs` entry, or a project companion path outside the sibling-case dataset directory; otherwise skipped with a warning (CWE-59). |
 | Listed directory symlink | Skipped with a warning (not walked). |
 | Path resolving outside the project/plugin root | Skipped with a warning. |
 | Not listed | Left behind (never reaches the workspace). |

--- a/website/reference/config/dataset.md
+++ b/website/reference/config/dataset.md
@@ -100,10 +100,11 @@ Behavior (`workspace_files._copy_input_files`):
 
 | Entry kind | Effect |
 | --- | --- |
-| Directory | Copied recursively, preserving relative structure. |
+| Directory | Copied recursively, preserving relative structure. Nested symlinks are skipped. |
 | File | Copied as a single file at its relative path. |
-| Symlink | **Skipped** (prevents escaping the case directory). |
-| Path outside the case dir | Skipped. |
+| Listed file symlink | Materialized as a regular file if the resolved target is under the project root or a configured `runner.plugin_dirs` entry; otherwise skipped with a warning (CWE-59). |
+| Listed directory symlink | Skipped with a warning (not walked). |
+| Path resolving outside the project/plugin root | Skipped with a warning. |
 | Not listed | Left behind (never reaches the workspace). |
 
 Paths are relative to each case directory; a trailing `/` is stripped, and `..` is


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A listed companion file that was a symlink to a live SKILL.md was skipped with no warning, so the agent never saw it. Copy the target when it stays inside the project or a configured plugin dir; warn when it escapes.

Without this, it is necessary to copy (and persist in git) the skill file into the eval case.

## How Has This Been Tested?
Tested against the https://github.com/openshift-eng/ai-helpers/blob/main/plugins/openshift-developer/evals/eval-address-ci-failures.yaml eval locally. This one includes symlinks to the skill itself (ex: https://github.com/openshift-eng/ai-helpers/tree/main/plugins/openshift-developer/evals/cases/address-ci-failures/case-001), and was a pain to run. With this change it works perfectly.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Listed file symlinks are copied as regular files when their targets remain within approved project, case, or plugin locations.

* **Bug Fixes**
  * Nested symlinks and listed directory symlinks are skipped instead of traversed.
  * Unsafe, external, dangling, looping, or escaping symlinks are safely skipped with a warning.

* **Documentation**
  * Updated dataset configuration guidance to clarify symlink handling and safety restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->