### PR TITLE
fix(config): skip hidden files and dirs in eval-config discovery

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -1622,12 +1622,17 @@ def discover_configs(project_root: Path) -> list[DiscoveryResult]:
     eval_dir = project_root / "eval"
     if eval_dir.is_dir():
         for subdir in sorted(eval_dir.iterdir()):
-            if subdir.is_dir():
+            if subdir.is_dir() and not subdir.name.startswith("."):
                 candidate = subdir / "eval.yaml"
                 if candidate.is_file():
                     _try_add(candidate, is_root=False)
+        # pathlib's glob matches dotfiles (unlike the glob module), so hidden
+        # working files — .entity-map.yaml, editor droppings — would surface
+        # as eval configs, and one extra "config" turns auto-selection into a
+        # which-config prompt on every run.
         for candidate in sorted(eval_dir.glob("*.yaml")):
-            if candidate.is_file() and candidate.name != "eval.yaml":
+            if (candidate.is_file() and candidate.name != "eval.yaml"
+                    and not candidate.name.startswith(".")):
                 _try_add(candidate, is_root=False)
 
     root_config = project_root / "eval.yaml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -619,3 +619,20 @@ name: t
 execution: {skill: s}
 runner: {type: codex, workspace_mode: repo}
 """))
+
+
+def test_discovery_skips_hidden_files_and_dirs(tmp_path):
+    """Hidden entries under eval/ are working files, never configs — a
+    git-ignored .entity-map.yaml surfacing as an eval config turns
+    single-config auto-selection into a which-config prompt."""
+    from agent_eval.config import discover_configs
+    eval_dir = tmp_path / "eval"
+    eval_dir.mkdir()
+    (eval_dir / "my-skill.yaml").write_text("name: t\nexecution:\n  skill: s\n")
+    (eval_dir / ".entity-map.yaml").write_text("SomeCorp: OtherCorp\n")
+    hidden_dir = eval_dir / ".raw"
+    hidden_dir.mkdir()
+    (hidden_dir / "eval.yaml").write_text("name: h\nexecution:\n  skill: x\n")
+
+    found = discover_configs(tmp_path)
+    assert [c.path.name for c in found] == ["my-skill.yaml"]


### PR DESCRIPTION
pathlib's `glob("*.yaml")` matches dotfiles — unlike the `glob` module — so a hidden working file under `eval/` surfaces as an eval config. Observed concretely: a project keeping a git-ignored `eval/.entity-map.yaml` (an anonymization map, deliberately hidden and never a config) gets it discovered as an eval named `.entity-map`, and since discovery then reports two configs, `/eval-run`'s single-config auto-selection turns into a which-config prompt on every invocation.

Hidden files and directories are never configs under any documented layout (root / `eval/<name>.yaml` flat / `eval/<name>/eval.yaml` nested), so both scans now skip dotfile entries. Regression test covers a hidden flat file and a hidden nested dir alongside a real flat config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden files and directories in the evaluation configuration folder are no longer detected as evaluation configurations.
  * Prevents temporary or working files from appearing in configuration discovery results.

* **Tests**
  * Added coverage verifying that hidden configuration files and directories are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->