### PR TITLE
fix(staging): copy plugin-root .mcp.json into isolated eval workspaces

### DIFF
--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -26,8 +26,8 @@ _print_lock = threading.Lock()
 # ${CLAUDE_PLUGIN_ROOT}/scripts/... or ${CLAUDE_SKILL_DIR}/../../scripts/...
 # at runtime; a staged copy without it would break those plugins.
 _PLUGIN_OPTIONAL_DIRS = ("commands", "agents", "hooks", "scripts")
-# Plugin-root MCP config (Claude Code loads this from the plugin directory).
-# Staging omitted it, so isolated evals never saw plugin MCP servers.
+# Optional plugin-root files Claude Code loads besides the manifest and
+# conventional directories. Copied only when present.
 _PLUGIN_OPTIONAL_FILES = (".mcp.json",)
 
 # Bulk plugin discovery never reads — keeps the staged copy small.

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -79,6 +79,10 @@ def stage_plugin_dir(plugin_dir: Path, workspace: Path) -> Path:
     manifest (via ``resolve_plugin_skill_roots``, which validates
     containment), the conventional ``_PLUGIN_OPTIONAL_DIRS`` when they
     exist at the plugin root, and ``_PLUGIN_OPTIONAL_FILES`` (``.mcp.json``).
+    Isolated MCP coverage is that conventional config file plus servers
+    already reachable without extra trees (HTTP/npx/uvx, or code under
+    ``scripts/``). Local stdio trees (``servers/``, …) and a custom
+    ``mcpServers`` path in the manifest are not staged.
     Symlinks are not reproduced — in-plugin targets are copied as content,
     dangling ones are skipped, and links escaping the plugin are refused —
     so the staged tree cannot point back outside the workspace. Idempotent

--- a/agent_eval/agent/claude_code.py
+++ b/agent_eval/agent/claude_code.py
@@ -26,6 +26,9 @@ _print_lock = threading.Lock()
 # ${CLAUDE_PLUGIN_ROOT}/scripts/... or ${CLAUDE_SKILL_DIR}/../../scripts/...
 # at runtime; a staged copy without it would break those plugins.
 _PLUGIN_OPTIONAL_DIRS = ("commands", "agents", "hooks", "scripts")
+# Plugin-root MCP config (Claude Code loads this from the plugin directory).
+# Staging omitted it, so isolated evals never saw plugin MCP servers.
+_PLUGIN_OPTIONAL_FILES = (".mcp.json",)
 
 # Bulk plugin discovery never reads — keeps the staged copy small.
 _PLUGIN_IGNORE = shutil.ignore_patterns(".git", "node_modules", "__pycache__")
@@ -74,13 +77,13 @@ def stage_plugin_dir(plugin_dir: Path, workspace: Path) -> Path:
     Copies only what plugin discovery and execution need: the
     ``.claude-plugin/`` manifest, every skill root declared by the
     manifest (via ``resolve_plugin_skill_roots``, which validates
-    containment), and the conventional ``_PLUGIN_OPTIONAL_DIRS`` when they
-    exist at the plugin root. Symlinks are not reproduced — in-plugin
-    targets are copied as content, dangling ones are skipped, and links
-    escaping the plugin are refused — so the staged tree cannot point back
-    outside the workspace. Idempotent per workspace: an existing
-    destination is reused; a partial copy never becomes the destination
-    (copy into a temp sibling, then rename).
+    containment), the conventional ``_PLUGIN_OPTIONAL_DIRS`` when they
+    exist at the plugin root, and ``_PLUGIN_OPTIONAL_FILES`` (``.mcp.json``).
+    Symlinks are not reproduced — in-plugin targets are copied as content,
+    dangling ones are skipped, and links escaping the plugin are refused —
+    so the staged tree cannot point back outside the workspace. Idempotent
+    per workspace: an existing destination is reused; a partial copy never
+    becomes the destination (copy into a temp sibling, then rename).
     """
     plugin = Path(plugin_dir).resolve()
     dest = workspace / ".staged-plugins" / plugin.name
@@ -137,6 +140,17 @@ def stage_plugin_dir(plugin_dir: Path, workspace: Path) -> Path:
                 resolved, staging / source.relative_to(plugin),
                 symlinks=False, ignore=_plugin_ignore(plugin),
                 ignore_dangling_symlinks=True, dirs_exist_ok=True)
+        for name in _PLUGIN_OPTIONAL_FILES:
+            source = plugin / name
+            if not source.is_file():
+                continue
+            try:
+                resolved = source.resolve(strict=True)
+            except (OSError, RuntimeError):
+                continue
+            if not resolved.is_file() or not resolved.is_relative_to(plugin):
+                continue
+            shutil.copy2(resolved, staging / name)
         try:
             staging.replace(dest)
         except OSError:

--- a/tests/test_stage_plugins.py
+++ b/tests/test_stage_plugins.py
@@ -64,6 +64,25 @@ class TestStagePluginDir:
         assert (staged / "agents" / "helper.md").is_file()
         assert (staged / "hooks" / "hooks.json").is_file()
 
+    def test_copies_plugin_mcp_json(self, tmp_path):
+        plugin = make_plugin(tmp_path / "plugins")
+        (plugin / ".mcp.json").write_text('{"mcpServers": {"ship-status": {}}}')
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        staged = stage_plugin_dir(plugin, ws)
+        assert (staged / ".mcp.json").is_file()
+        assert "ship-status" in (staged / ".mcp.json").read_text()
+
+    def test_escaping_mcp_json_symlink_is_refused(self, tmp_path):
+        plugin = make_plugin(tmp_path / "plugins")
+        secret = tmp_path / "outside-mcp.json"
+        secret.write_text('{"secret": true}')
+        (plugin / ".mcp.json").symlink_to(secret)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        staged = stage_plugin_dir(plugin, ws)
+        assert not (staged / ".mcp.json").exists()
+
     def test_skips_git_node_modules_and_unlisted_files(self, tmp_path):
         plugin = make_plugin(tmp_path / "plugins")
         # Bulk inside a copied tree is pruned by ignore patterns...
@@ -332,6 +351,23 @@ class TestClaudeCodeRunnerStaging:
         assert result.exit_code == 0, result.stderr
         [staged] = self._plugin_dir_args(self._argv(ws))
         assert (Path(staged) / "scripts" / "helper.py").is_file()
+
+    def test_plugin_mcp_json_is_staged(self, tmp_path, monkeypatch):
+        """Claude Code loads plugin MCP servers from .mcp.json at the plugin
+        root. Isolated evals must stage that file or the skill never sees
+        those tools."""
+        self._stub_claude(tmp_path, monkeypatch)
+        plugin = make_plugin(tmp_path / "plugins")
+        (plugin / ".mcp.json").write_text('{"mcpServers": {"ship-status": {}}}')
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        runner = ClaudeCodeRunner(plugin_dirs=[str(plugin)])
+        result = runner.execute(
+            target="epic-decompose", args="", workspace=ws,
+            model="m", timeout_s=60)
+        assert result.exit_code == 0, result.stderr
+        [staged] = self._plugin_dir_args(self._argv(ws))
+        assert (Path(staged) / ".mcp.json").is_file()
 
     def test_duplicate_plugin_basenames_fail_loud(self, tmp_path, monkeypatch):
         self._stub_claude(tmp_path, monkeypatch)


### PR DESCRIPTION
## Summary
- Isolated evals stage a plugin into `.staged-plugins/` and pass that path to Claude. Staging copied the manifest, skill roots, and `commands`/`agents`/`hooks`/`scripts`, but not plugin-root `.mcp.json`.
- Claude Code loads plugin MCP servers from that file, so skills that depend on them (for example SHIP Status in `plugins/ci`) ran without those tools in the catalog.
- `stage_plugin_dir` now copies `.mcp.json` with the same symlink-escape rules as the optional dirs.

## Test plan
- [x] `python -m pytest tests/test_stage_plugins.py` (22 passed)
- [ ] Confirm a payload-analysis eval init event includes `mcp__ship-status__*` / `mcp__plugin_ci_ship-status__*` after this lands


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin staging now includes a valid root-level `.mcp.json` configuration file.
  * Staged plugin MCP configuration is available during runner execution.

* **Bug Fixes**
  * Invalid, dangling, escaping, or non-file `.mcp.json` links are safely excluded from staging.
  * Existing symlink containment, atomic-copy, and repeatable staging behavior remain supported.

* **Documentation**
  * Updated staging documentation to describe `.mcp.json` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->