### PR TITLE
fix(eval-analyze): derive eval.md name from config so flat layouts don't collide

### DIFF
--- a/agent_eval/config.py
+++ b/agent_eval/config.py
@@ -1834,6 +1834,21 @@ def discover_configs(project_root: Path) -> list[DiscoveryResult]:
     return sorted(results, key=lambda r: r.path)
 
 
+def analysis_cache_path(config_path) -> Path:
+    """Return the eval-analyze cache (``eval.md``) path for a config.
+
+    The cache lives next to the config, named by swapping the config's
+    extension to ``.md``: ``eval.yaml`` -> ``eval.md`` (root and nested
+    ``eval/<name>/eval.yaml`` layouts, unchanged), and flat
+    ``eval/<name>.yaml`` -> ``eval/<name>.md``. Deriving the name from the
+    config filename keeps flat-layout configs from silently colliding on a
+    single ``eval/eval.md``: flat configs are uniquely named (and warned on
+    name collision in ``discover_configs``), so their analysis caches must be
+    uniquely named too.
+    """
+    return Path(config_path).with_suffix(".md")
+
+
 def infer_layout(configs: list[DiscoveryResult]) -> str:
     """Infer the project's eval layout from discovery results.
 

--- a/skills/eval-analyze/SKILL.md
+++ b/skills/eval-analyze/SKILL.md
@@ -38,9 +38,8 @@ If `--config` provided, use that path. Otherwise run `python3 ${CLAUDE_SKILL_DIR
 - **No configs**: Create `eval.yaml` at project root
 - **One root config** and `--skill` targets a different eval than the existing one: offer to reorganize into `eval/` layout. If the user accepts, run `python3 ${CLAUDE_SKILL_DIR}/scripts/reorganize.py --eval-name <name>` (add `--project-root <path>` if not the cwd). If declined, ask where to put the new config.
 - **Nested/flat layout already exists**: place the new config at `eval/<skill-name>/eval.yaml` (nested) or alongside existing flat configs
-- **`--config` provided**: use the explicit path, bypass layout logic
 
-Set the resolved config path as `<config>` for all subsequent steps. Set `<eval_md_path>` to the same directory as `<config>`, with filename `eval.md`.
+Set the resolved config path as `<config>` for all subsequent steps. Set `<eval_md_path>` to `<config>` with `.yaml`→`.md` (so flat `eval/<name>.yaml` → `eval/<name>.md`, not a shared `eval/eval.md`).
 
 ## Batch Assessment
 
@@ -185,20 +184,20 @@ This checks dataset path exists (resolved relative to the config file's director
 
 ## Step 7: Generate eval.md
 
-The eval.md caches the skill analysis so it doesn't need to be repeated. Write it to `<eval_md_path>` (same directory as the config file). The hash tracks only the top-level SKILL.md — if sub-skills change, the user should run `/eval-analyze --update` to refresh. Compute the skill hash:
+The eval.md caches the skill analysis so it doesn't need to be repeated. Write it to `<eval_md_path>` (defined in Config Location Discovery). The hash tracks only the top-level SKILL.md — if sub-skills change, the user should run `/eval-analyze --update` to refresh. Compute the skill hash:
 
 ```bash
 python3 -c "import hashlib; from pathlib import Path; print(hashlib.sha256(Path('<skill-path>/SKILL.md').read_bytes()).hexdigest()[:12])"
 ```
 
-Read the template at `${CLAUDE_SKILL_DIR}/prompts/generate-eval-md.md`. Write eval.md with YAML frontmatter (skill, analyzed_at, skill_hash) and a markdown narrative of the analysis.
+Read the template at `${CLAUDE_SKILL_DIR}/prompts/generate-eval-md.md`. Write `<eval_md_path>` with YAML frontmatter (skill, analyzed_at, skill_hash) and a markdown narrative of the analysis.
 
 ## Step 8: Report
 
 Tell the user what was generated:
 
 - **eval.yaml**: created/updated — N judges configured, dataset at `<path>` (M cases found)
-- **eval.md**: skill analysis cached (hash: `<hash>`)
+- **`<eval_md_path>`**: skill analysis cached (hash: `<hash>`)
 - **Next steps**:
   - If no test cases found: `/eval-dataset` to generate test cases (required before eval-run)
   - If test cases exist: `/eval-run --model <model>` to execute the evaluation

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -7,7 +7,11 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from agent_eval.config import DiscoveryResult, discover_configs
+from agent_eval.config import (
+    DiscoveryResult,
+    analysis_cache_path,
+    discover_configs,
+)
 
 
 def _write_eval(path: Path, skill: str = "test-skill"):
@@ -131,3 +135,19 @@ def test_dot_eval_name_rejected(tmp_path):
     cfg.write_text("skill: .\n")
     results = discover_configs(tmp_path)
     assert results == []
+
+
+def test_analysis_cache_path_root_and_nested_use_eval_md(tmp_path):
+    # eval.yaml (root and nested eval/<name>/eval.yaml) -> eval.md (unchanged).
+    assert analysis_cache_path(tmp_path / "eval.yaml") == tmp_path / "eval.md"
+    nested = tmp_path / "eval" / "alpha" / "eval.yaml"
+    assert analysis_cache_path(nested) == tmp_path / "eval" / "alpha" / "eval.md"
+
+
+def test_analysis_cache_path_flat_is_stem_derived_and_distinct(tmp_path):
+    # Flat configs must get distinct caches, not a shared eval/eval.md.
+    a = analysis_cache_path(tmp_path / "eval" / "alpha.yaml")
+    b = analysis_cache_path(tmp_path / "eval" / "beta.yaml")
+    assert a == tmp_path / "eval" / "alpha.md"
+    assert b == tmp_path / "eval" / "beta.md"
+    assert a != b


### PR DESCRIPTION
## Problem

Flat multi-eval (`eval/<name>.yaml`) is a first-class, tested layout — `discover_configs` derives a unique `eval_name` per config and even warns on name collisions (`test_flat_name_collision_warns`). But the `eval-analyze` cache was always written to `<config-dir>/eval.md` (fixed filename), so **multiple flat configs silently overwrite each other's `eval/eval.md`** — with no warning, unlike the config-name case.

Example: `eval/epic-decompose.yaml` and `eval/user-guides.yaml` both map their analysis cache to `eval/eval.md`.

## Fix

Derive the cache path from the config filename: **config path with `.yaml` → `.md`**.

- Root `eval.yaml` → `eval.md` (unchanged)
- Nested `eval/<name>/eval.yaml` → `eval/<name>/eval.md` (unchanged)
- Flat `eval/<name>.yaml` → `eval/<name>.md` (**fixed** — distinct per config)

Changes:
- **`agent_eval/config.py`**: add `analysis_cache_path(config_path)` returning the config path with a `.md` suffix, documenting the flat-collision rationale.
- **`skills/eval-analyze/SKILL.md`**: set `<eval_md_path>` to the config path with `.yaml` → `.md` (was: fixed filename `eval.md`), in both Config Location Discovery and Step 7.
- **`tests/test_discovery.py`**: cover root/nested (`eval.md`) and flat (distinct `<name>.md`, `a != b`).

## Impact

`eval.md` is a regenerable analysis cache read only by `/eval-analyze --update` (freshness) and `validate_eval.py` — **not** by `/eval-run`. So this doesn't affect running evals; it stops the analysis cache from clobbering across flat-layout evals.

## Test

```
$ .venv/bin/python3 -m pytest tests/test_discovery.py tests/test_layout.py tests/test_reorganization.py -q
32 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Eval analysis results now use uniquely named `.md` cache files derived from each configuration file.
  - This applies consistently to both discovered configurations and explicitly specified configurations.
- **Documentation**
  - Updated eval analysis guidance to reflect the revised output-path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->