### PR TITLE
docs(judges): rename the canonical example judge and scope it to one criterion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,6 @@ The `brainstorm/` directory contains exploratory ideas and design thinking. Thes
 ## Remaining Work
 
 - CI integration patterns and examples
-- `traces.events` implementation — parse stream-json into structured `outputs["events"]` for judges
 
 ## Execution Paths
 

--- a/website/concepts/pairwise-and-sampling.md
+++ b/website/concepts/pairwise-and-sampling.md
@@ -126,7 +126,7 @@ recording the spread so you can tell signal from noise.
 ```yaml title="eval.yaml"
 judges:
   - name: completeness
-    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\nRequest:\n{{ inputs }}\n\nOutput:\n{{ outputs }}"
     feedback_type: int
     score_range: [1, 5] # declare the scale — omitting it warns at config load
     samples: 5          # run 5×/case, reduce to a stable score

--- a/website/concepts/pairwise-and-sampling.md
+++ b/website/concepts/pairwise-and-sampling.md
@@ -125,8 +125,8 @@ recording the spread so you can tell signal from noise.
 
 ```yaml title="eval.yaml"
 judges:
-  - name: output_quality
-    prompt: "Score the output 1-5 for completeness and accuracy."
+  - name: completeness
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
     feedback_type: int
     score_range: [1, 5] # declare the scale — omitting it warns at config load
     samples: 5          # run 5×/case, reduce to a stable score
@@ -158,7 +158,7 @@ sample agreed *and* none errored**:
 ```yaml
 per_case:
   case-001:
-    output_quality:
+    completeness:
       value: 4
       rationale: "..."
       stability:
@@ -176,12 +176,12 @@ many cases were stable:
 
 ```yaml
 judges:
-  output_quality:
+  completeness:
     mean: 3.9
     stability: { samples: 5, stable_cases: 8, total_cases: 12 }
 ```
 
-The console echoes the same, e.g. `output_quality: mean=3.90  [8/12 stable over 5 samples]`.
+The console echoes the same, e.g. `completeness: mean=3.90  [8/12 stable over 5 samples]`.
 
 ### The `--samples` override
 

--- a/website/concepts/thresholds.md
+++ b/website/concepts/thresholds.md
@@ -8,7 +8,7 @@ landing in a report.
 ```yaml title="eval.yaml"
 thresholds:
   has_content:    { min_pass_rate: 1.0 }   # boolean judge
-  output_quality: { min_mean: 3.5 }        # numeric (1–5) judge
+  completeness: { min_mean: 3.5 }        # numeric (1–5) judge
   pairwise:       { min_win_rate: 0.6 }     # pairwise comparison
 ```
 
@@ -53,7 +53,7 @@ that is *not* silently ignored.
 
     ```text
     REGRESSIONS: 1 detected
-      [output_quality] pass_rate: >= 0.9 -> n/a
+      [completeness] pass_rate: >= 0.9 -> n/a
     ```
 
     The detail names the cause: *"pass_rate unavailable — judge errored on 12 cases; see
@@ -70,7 +70,7 @@ that is *not* silently ignored.
 
     ```yaml
     thresholds:
-      output_quality:
+      completeness:
         min_mean: 3.5
         max_error_rate: 0.2    # ...over at least 80% of the dataset
     ```
@@ -119,7 +119,7 @@ Thresholds are enforced in two places, both of which `exit(1)` on any regression
 
     ```text
       REGRESSIONS: 1 detected
-        [output_quality] mean: >= 3.5 -> 3.1
+        [completeness] mean: >= 3.5 -> 3.1
     ```
 
     A non-zero exit fails the surrounding CI step. See the [CI guide](../guides/ci.md).
@@ -151,7 +151,7 @@ the baseline's. A drop of **more than 0.5** (absolute) is reported as a
 `<metric>_vs_baseline` regression:
 
 ```text
-  [output_quality] mean_vs_baseline: 4.2 -> 3.4   Degraded vs baseline
+  [completeness] mean_vs_baseline: 4.2 -> 3.4   Degraded vs baseline
 ```
 
 !!! note "0.5 is a fixed absolute delta"

--- a/website/cookbook/custom-judges.md
+++ b/website/cookbook/custom-judges.md
@@ -161,17 +161,19 @@ all compile to the same Jinja2 template, then render against the case record:
 
     ```yaml
     judges:
-      - name: output_quality
-        description: Compare the output to the reference.
+      - name: completeness
+        description: How completely the output covers the reference.
         score_range: [1, 5]     # declare the scale — omitting it warns at config load
         prompt: |
-          Compare the generated output against the reference for
-          completeness, clarity, and accuracy.
+          How completely does the generated output cover the reference?
 
           {{ inputs }}
 
           # Output
           {{ outputs }}
+
+          Score 1-5: 1 = most requirements missing, 3 = covers the basics
+          with gaps, 5 = every requirement addressed.
     ```
 
 === "prompt_file"
@@ -351,11 +353,11 @@ judges:
     feedback_type: bool
     prompt: "Did the agent correctly flag the input as a duplicate?"
 
-  - name: output_quality
+  - name: completeness
     if: "not annotations.get('skip_quality', False)"
     feedback_type: int
     score_range: [1, 5]
-    prompt: "Score the output 1-5 for completeness, clarity, and accuracy."
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
 ```
 
 !!! warning "`if` runs in a restricted sandbox"

--- a/website/cookbook/custom-judges.md
+++ b/website/cookbook/custom-judges.md
@@ -162,11 +162,12 @@ all compile to the same Jinja2 template, then render against the case record:
     ```yaml
     judges:
       - name: completeness
-        description: How completely the output covers the reference.
+        description: How completely the output covers the request.
         score_range: [1, 5]     # declare the scale — omitting it warns at config load
         prompt: |
-          How completely does the generated output cover the reference?
+          How completely does the generated output cover the request?
 
+          # Request
           {{ inputs }}
 
           # Output
@@ -357,7 +358,7 @@ judges:
     if: "not annotations.get('skip_quality', False)"
     feedback_type: int
     score_range: [1, 5]
-    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\nRequest:\n{{ inputs }}\n\nOutput:\n{{ outputs }}"
 ```
 
 !!! warning "`if` runs in a restricted sandbox"

--- a/website/cookbook/skill-case.md
+++ b/website/cookbook/skill-case.md
@@ -85,6 +85,10 @@ judges:
       How completely does the generated output cover the reference?
       Grade completeness only — clarity and accuracy belong to other judges.
 
+      ## Reference
+      {{ outputs.annotation_reference_content }}
+
+      ## Output
       {{ outputs }}
 
       Score 1-5 where:
@@ -126,11 +130,12 @@ starter set with [`/eval-dataset`](../guides/eval-dataset.md).
 eval/dataset/cases/
 ├── case-001-simple/
 │   ├── input.yaml
-│   └── reference.md
+│   ├── reference.md
+│   └── annotations.yaml    # points judges at reference.md
 └── case-002-edge/
     ├── input.yaml
     ├── reference.md
-    └── annotations.yaml    # optional metadata judges can read
+    └── annotations.yaml
 ```
 
 === "case-001-simple/input.yaml"
@@ -145,10 +150,19 @@ eval/dataset/cases/
     prompt: "Summarize an empty document and note that it has no content."
     ```
 
+=== "case-001-simple/annotations.yaml"
+
+    ```yaml
+    # A filename value is loaded at scoring time and exposed to judges as
+    # {{ outputs.annotation_reference_content }} (and inside {{ annotations }}).
+    reference: reference.md
+    ```
+
 === "case-002-edge/annotations.yaml"
 
     ```yaml
     category: edge-case
+    reference: reference.md
     ```
 
 !!! note "Schema fields are natural language"

--- a/website/cookbook/skill-case.md
+++ b/website/cookbook/skill-case.md
@@ -77,25 +77,25 @@ judges:
           return False, f"Output too short ({len(content.strip())} chars)"
       return True, f"Output has {len(content.strip())} chars"
 
-  - name: output_quality
-    description: Quality of the output versus the reference.
+  - name: completeness
+    description: How completely the output covers the reference.
     feedback_type: int
     score_range: [1, 5]     # declare the scale — omitting it warns at config load
     prompt: |
-      Compare the generated output against the reference.
+      How completely does the generated output cover the reference?
+      Grade completeness only — clarity and accuracy belong to other judges.
 
       {{ outputs }}
 
-      Consider completeness, clarity, accuracy, and relevance.
       Score 1-5 where:
-      - 1: missing most requirements, major errors
-      - 3: covers the basics but lacks depth or has minor errors
-      - 5: comprehensive, accurate, well-written
+      - 1: most of the reference's requirements are missing
+      - 3: covers the basics but leaves real gaps
+      - 5: every requirement addressed
 
 thresholds:
   has_content:
     min_pass_rate: 1.0    # every case must pass this boolean judge
-  output_quality:
+  completeness:
     min_mean: 3.5         # mean LLM score must stay at or above 3.5
 ```
 
@@ -164,7 +164,7 @@ This recipe uses two of the [five judge types](../reference/config/judges.md):
 | Judge | Type | What it verifies |
 | --- | --- | --- |
 | `has_content` | inline `check` (Python) | An artifact exists and is at least 100 chars — deterministic structure |
-| `output_quality` | LLM `prompt` | Completeness/clarity/accuracy versus the reference — needs understanding |
+| `completeness` | LLM `prompt` | How completely the output covers the reference — needs understanding |
 
 !!! warning "Inside `check`, access data through `outputs`"
     Check judges run in the project root, not the per-case output directory. Read

--- a/website/get-started/first-eval.md
+++ b/website/get-started/first-eval.md
@@ -57,6 +57,10 @@ judges:
     prompt: |
       How completely does the output cover the request?
 
+      Request:
+      {{ inputs }}
+
+      Output:
       {{ outputs }}
 
       Score 1-5: 1 = most requirements missing, 3 = covers the basics with

--- a/website/get-started/first-eval.md
+++ b/website/get-started/first-eval.md
@@ -51,15 +51,20 @@ judges:
           return False, f"Output too short ({len(content.strip())} chars)"
       return True, "OK"
 
-  - name: output_quality
+  - name: completeness
     feedback_type: int
     score_range: [1, 5]     # declare the scale — omitting it warns at config load
     prompt: |
-      Score the output 1-5 for completeness, clarity, and accuracy.
+      How completely does the output cover the request?
+
+      {{ outputs }}
+
+      Score 1-5: 1 = most requirements missing, 3 = covers the basics with
+      gaps, 5 = every requirement addressed.
 
 thresholds:
   has_content: { min_pass_rate: 1.0 }
-  output_quality: { min_mean: 3.5 }
+  completeness: { min_mean: 3.5 }
 ```
 
 !!! tip "Reference"

--- a/website/guides/ci.md
+++ b/website/guides/ci.md
@@ -48,14 +48,14 @@ judges:
       content = outputs.get("main_content", "")
       return (len(content.strip()) >= 100,
               f"{len(content.strip())} chars")
-  - name: output_quality       # numeric judge (1–5) → mean
+  - name: completeness       # numeric judge (1–5) → mean
     feedback_type: int
     score_range: [1, 5]        # declare the scale — omitting it warns at config load
-    prompt: "Score the output 1-5 for completeness, clarity, and accuracy."
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
 
 thresholds:
   has_content:    { min_pass_rate: 1.0 }   # every case must pass
-  output_quality: { min_mean: 3.5 }        # average score must stay >= 3.5
+  completeness: { min_mean: 3.5 }        # average score must stay >= 3.5
 ```
 
 !!! warning "An unavailable metric counts as a regression"

--- a/website/guides/ci.md
+++ b/website/guides/ci.md
@@ -51,7 +51,7 @@ judges:
   - name: completeness       # numeric judge (1–5) → mean
     feedback_type: int
     score_range: [1, 5]        # declare the scale — omitting it warns at config load
-    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\nRequest:\n{{ inputs }}\n\nOutput:\n{{ outputs }}"
 
 thresholds:
   has_content:    { min_pass_rate: 1.0 }   # every case must pass

--- a/website/guides/eval-optimize.md
+++ b/website/guides/eval-optimize.md
@@ -44,7 +44,7 @@ Both consume eval results, but the control loop is different.
 
 ```bash
 # Optimize the auto-discovered eval, up to 5 cycles, focused on one judge
-/eval-optimize --model opus --max-iterations 5 --target-judge output_quality
+/eval-optimize --model opus --max-iterations 5 --target-judge completeness
 ```
 
 ## The loop

--- a/website/guides/harbor.md
+++ b/website/guides/harbor.md
@@ -325,7 +325,7 @@ violated, the command **exits non-zero** (useful in [CI](ci.md)):
 
 ```text
 REGRESSIONS: 1 detected
-  [output_quality] min_mean: 3.5 -> 3.1
+  [completeness] min_mean: 3.5 -> 3.1
 ```
 
 Harbor infra errors (transient pod/exec failures with no reward) and trial errors (pods

--- a/website/guides/skill-vs-prompt.md
+++ b/website/guides/skill-vs-prompt.md
@@ -40,10 +40,10 @@ Both minimal configs below differ in exactly one key.
       schema: "Each case has an input.yaml with a 'prompt' field."
 
     judges:
-      - name: output_quality
+      - name: completeness
         feedback_type: int
         score_range: [1, 5]    # declare the scale — omitting it warns at load
-        prompt: "Score the output 1-5 for completeness and accuracy."
+        prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
     ```
 
 === "Prompt mode"

--- a/website/guides/skill-vs-prompt.md
+++ b/website/guides/skill-vs-prompt.md
@@ -43,7 +43,7 @@ Both minimal configs below differ in exactly one key.
       - name: completeness
         feedback_type: int
         score_range: [1, 5]    # declare the scale — omitting it warns at load
-        prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
+        prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\nRequest:\n{{ inputs }}\n\nOutput:\n{{ outputs }}"
     ```
 
 === "Prompt mode"

--- a/website/reference/config/judges.md
+++ b/website/reference/config/judges.md
@@ -21,7 +21,7 @@ judges:
       return True, "OK"
 
   - name: completeness
-    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\nRequest:\n{{ inputs }}\n\nOutput:\n{{ outputs }}"
     score_range: [1, 5]      # declare the scale — omitting it warns at config load
 ```
 
@@ -330,7 +330,8 @@ judges. The report records the spread and flags unstable cases. See
 
 ```yaml
 - name: completeness
-  prompt: "Score 1-5 how complete the output is.\n\n{{ outputs }}"
+  prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\nRequest:\n{{ inputs }}\n\nOutput:\n{{ outputs }}"
+  score_range: [1, 5]
   samples: 5
 ```
 
@@ -345,7 +346,7 @@ at load.
 
 ```yaml
 - name: completeness
-  prompt: "Score 1-5 how complete the output is.\n\n{{ outputs }}"
+  prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\nRequest:\n{{ inputs }}\n\nOutput:\n{{ outputs }}"
   score_range: [1, 5]
   examples:
     source: reviews     # only source today (default)

--- a/website/reference/config/judges.md
+++ b/website/reference/config/judges.md
@@ -20,8 +20,8 @@ judges:
           return False, f"Output too short ({len(content.strip())} chars)"
       return True, "OK"
 
-  - name: output_quality
-    prompt: "Score 1-5 for completeness, clarity, and accuracy.\n\n{{ outputs }}"
+  - name: completeness
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
     score_range: [1, 5]      # declare the scale — omitting it warns at config load
 ```
 
@@ -111,13 +111,15 @@ Jinja2 with the case record. Priority when more than one is set: **`llm_rubric` 
 === "prompt (full template)"
 
     ```yaml
-    - name: output_quality
-      description: Completeness and accuracy versus the reference.
+    - name: completeness
+      description: How completely the output covers the reference.
       prompt: |
-        Score 1-5 for completeness, clarity, and accuracy.
+        How completely does the output cover the reference?
 
         {{ outputs }}
-        {{ conversation }}
+
+        Score 1-5: 1 = most requirements missing, 3 = covers the basics
+        with gaps, 5 = every requirement addressed.
       score_range: [1, 5]
     ```
 
@@ -327,8 +329,8 @@ judges. The report records the spread and flags unstable cases. See
 [pairwise & sampling](../../concepts/pairwise-and-sampling.md).
 
 ```yaml
-- name: output_quality
-  prompt: "Score 1-5 for accuracy.\n\n{{ outputs }}"
+- name: completeness
+  prompt: "Score 1-5 how complete the output is.\n\n{{ outputs }}"
   samples: 5
 ```
 
@@ -342,8 +344,8 @@ agent judges only; declaring it on a `check`, `builtin`, or `code` judge fails
 at load.
 
 ```yaml
-- name: output_quality
-  prompt: "Score 1-5 for accuracy.\n\n{{ outputs }}"
+- name: completeness
+  prompt: "Score 1-5 how complete the output is.\n\n{{ outputs }}"
   score_range: [1, 5]
   examples:
     source: reviews     # only source today (default)
@@ -421,7 +423,7 @@ warning exempts inline `check:` judges — they compute
 their own value, so there is no model to bound.
 
 ```text
-UserWarning: Judge 'output_quality': numeric judge has no 'score_range', so it is
+UserWarning: Judge 'completeness': numeric judge has no 'score_range', so it is
 scored on the unenforced [1, 5] default — declare one to have the returned value
 checked
 ```

--- a/website/reference/config/models.md
+++ b/website/reference/config/models.md
@@ -94,8 +94,8 @@ models:
   judge: claude-opus-4-6
 
 judges:
-  - name: output_quality
-    prompt: "Score the output 1-5 for completeness and accuracy."
+  - name: completeness
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
     score_range: [1, 5]      # declare the scale — omitting it warns at config load
   - name: strict_rubric
     model: claude-opus-4-6   # per-judge override wins over models.judge

--- a/website/reference/config/models.md
+++ b/website/reference/config/models.md
@@ -95,7 +95,7 @@ models:
 
 judges:
   - name: completeness
-    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\nRequest:\n{{ inputs }}\n\nOutput:\n{{ outputs }}"
     score_range: [1, 5]      # declare the scale — omitting it warns at config load
   - name: strict_rubric
     model: claude-opus-4-6   # per-judge override wins over models.judge

--- a/website/reference/config/reward.md
+++ b/website/reference/config/reward.md
@@ -50,11 +50,11 @@ flowchart TD
 
     ```yaml
     judges:
-      - name: output_quality
+      - name: completeness
         score_range: [1, 5]     # the scale the value is mapped from
 
     reward:
-      judge: output_quality
+      judge: completeness
       normalize: true
     ```
 

--- a/website/reference/config/thresholds.md
+++ b/website/reference/config/thresholds.md
@@ -6,7 +6,7 @@ them, scoring exits non-zero — the hook you want for CI.
 
 ```yaml
 thresholds:
-  output_quality:
+  completeness:
     min_mean: 3.5            # numeric judge — average score across cases
   has_content:
     min_pass_rate: 1.0       # boolean judge — fraction of cases passing (0.0–1.0)
@@ -96,7 +96,7 @@ flowchart TD
 
     ```text
     REGRESSIONS: 2 detected
-      [output_quality] mean: >= 3.5 -> 3.1
+      [completeness] mean: >= 3.5 -> 3.1
       [has_content] pass_rate: >= 1.0 -> 0.8
     ```
 
@@ -126,7 +126,7 @@ python3 ${CLAUDE_SKILL_DIR}/scripts/score.py regression \
 
 ```text
 REGRESSIONS: 1 detected
-  [output_quality] mean_vs_baseline: 4.2 -> 3.5
+  [completeness] mean_vs_baseline: 4.2 -> 3.5
 ```
 
 Baseline degradation is only checked for metrics present in both runs; the

--- a/website/reference/eval-yaml.md
+++ b/website/reference/eval-yaml.md
@@ -249,8 +249,8 @@ See [the execution model](../concepts/execution-model.md) for the difference.
       schema: "Each case has an input.yaml with a 'prompt' field."
 
     judges:
-      - name: output_quality
-        prompt: "Score the output 1-5 for completeness and accuracy."
+      - name: completeness
+        prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
         score_range: [1, 5]   # declare the scale — omitting it warns at config load
     ```
 
@@ -330,13 +330,13 @@ judges:
           return False, f"Output too short ({len(content.strip())} chars)"
       return True, f"Output has {len(content.strip())} chars"
 
-  - name: output_quality
-    prompt: "Score 1-5 vs the reference for completeness, clarity, accuracy."
+  - name: completeness
+    prompt: "Score 1-5 how completely the output covers the reference (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
     score_range: [1, 5]     # declare the scale — omitting it warns at config load
 
 thresholds:
   has_content: { min_pass_rate: 1.0 }
-  output_quality: { min_mean: 3.5 }
+  completeness: { min_mean: 3.5 }
 ```
 
 ## Conventions

--- a/website/reference/eval-yaml.md
+++ b/website/reference/eval-yaml.md
@@ -250,7 +250,7 @@ See [the execution model](../concepts/execution-model.md) for the difference.
 
     judges:
       - name: completeness
-        prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
+        prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\nRequest:\n{{ inputs }}\n\nOutput:\n{{ outputs }}"
         score_range: [1, 5]   # declare the scale — omitting it warns at config load
     ```
 
@@ -331,7 +331,7 @@ judges:
       return True, f"Output has {len(content.strip())} chars"
 
   - name: completeness
-    prompt: "Score 1-5 how completely the output covers the reference (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\n{{ outputs }}"
+    prompt: "Score 1-5 how completely the output covers the request (1 = most requirements missing, 3 = basics with gaps, 5 = complete).\n\nRequest:\n{{ inputs }}\n\nOutput:\n{{ outputs }}"
     score_range: [1, 5]     # declare the scale — omitting it warns at config load
 
 thresholds:


### PR DESCRIPTION
## What

The site's boilerplate example judge — `output_quality`, *"Score the output 1-5 for completeness, clarity, and accuracy"* — taught the exact holistic-judge anti-pattern the judge-authoring guidance (#207) now warns against: three criteria in one judge, no observable level anchors, and most one-line variants never rendered `{{ outputs }}`, so a judge copied from the docs graded blind.

This sweep makes the cross-page example one coherent story:

- **Rename** `output_quality` → `completeness` across all 14 pages that use it, including name-only mentions in thresholds, reward, regression-output, and CLI snippets, so a reader following the docs never sees mismatched judge names.
- **Scope every example prompt to the single criterion**, with observable level anchors (1 = most requirements missing, 3 = basics with gaps, 5 = every requirement addressed).
- **Feed each judge the artifact it grades** (`{{ outputs }}`) — the compact one-liners previously graded blind.
- The full-template example in the judges reference also drops its `{{ outputs }}` + `{{ conversation }}` pairing, per the minimal-context rule.
- The two remaining "completeness, clarity, accuracy" mentions are the guidance passages that *state* the decomposition rule.

Also drops the stale `traces.events` bullet from CLAUDE.md's Remaining Work — spec 002 shipped `agent_eval/events.py`, per-case `events.json`, and the `{{ conversation }}`/`{{ tool_trace }}` template variables long ago.

## How tested

- `mkdocs build --strict`: clean.
- Full unit suite: 1488 passed, 7 skipped.
- `grep -rE 'completeness, clarity|completeness and accuracy|Score the output 1-5'` over website/: only the two rule-stating guidance passages remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the example judge from `output_quality` to `completeness` throughout guides, references, recipes, and configuration examples.
  * Updated sample prompts with clearer completeness-focused scoring rubrics and 1–5 score guidance.
  * Updated related threshold, regression output, optimization, and reporting examples to use the new judge name.
  * Removed an outdated remaining-work item related to structured event output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->